### PR TITLE
Fix: Only Advertise IMAP METADATA When TURN is Enabled

### DIFF
--- a/internal/endpoint/imap/imap.go
+++ b/internal/endpoint/imap/imap.go
@@ -526,6 +526,9 @@ type metadataExtension struct {
 func (ext *metadataExtension) Capabilities(c imapserver.Conn) []string {
 	turnEnabled := ext.endp.enableTURN && ext.endp.saslAuth.IsTurnEnabled()
 	ext.endp.Log.Debugf("IMAP: Capabilities check (state=%v, turnEnabled=%v)", c.Context().State, turnEnabled)
+	if !turnEnabled {
+		return nil
+	}
 	return []string{"METADATA"}
 }
 


### PR DESCRIPTION
## Summary

This PR fixes the IMAP server to only advertise the METADATA capability when TURN server functionality is enabled.

## Problem

The IMAP server was advertising METADATA capability even when TURN was disabled, which could confuse clients expecting TURN-related metadata functionality.

## Solution

Only advertise METADATA capability when TURN is enabled, ensuring clients only see this capability when the feature is actually available.

## Changes

- Updated IMAP endpoint to check TURN status before advertising METADATA
- Ensures capability advertisement matches actual functionality

## Testing

- Verified METADATA is only advertised when TURN is enabled
- Verified METADATA is not advertised when TURN is disabled