### PR TITLE
Fix: Disable Shadowsocks When ss_addr is Commented Out

### DIFF
--- a/internal/endpoint/chatmail/chatmail.go
+++ b/internal/endpoint/chatmail/chatmail.go
@@ -138,7 +138,7 @@ func (e *Endpoint) Init(cfg *config.Map) error {
 	cfg.String("alpn_imap", false, false, "", &e.alpnIMAP)
 	cfg.Bool("enable_contact_sharing", false, false, &e.enableContactSharing)
 	cfg.String("www_dir", false, false, "", &e.wwwDir)
-	cfg.String("ss_addr", false, false, "0.0.0.0:8388", &e.ssAddr)
+	cfg.String("ss_addr", false, false, "", &e.ssAddr)
 	cfg.String("ss_password", false, false, "", &e.ssPassword)
 	cfg.String("ss_cipher", false, false, "aes-128-gcm", &e.ssCipher)
 	cfg.String("sharing_driver", false, false, "sqlite3", &e.sharingDriver)


### PR DESCRIPTION
## Summary

This PR fixes the Shadowsocks server to properly disable when `ss_addr` is commented out or not configured.

## Problem

Shadowsocks server was not properly handling the case when `ss_addr` configuration was commented out, potentially causing issues or unexpected behavior.

## Solution

Properly detect when `ss_addr` is commented out and disable Shadowsocks server accordingly.

## Changes

- Updated Shadowsocks initialization to check if `ss_addr` is configured
- Disable Shadowsocks when `ss_addr` is commented out or empty

## Testing

- Verified Shadowsocks is disabled when `ss_addr` is commented out
- Verified Shadowsocks works normally when `ss_addr` is configured