### PR TITLE
optional disable of sync

### DIFF
--- a/internal/cli/ctl/install.go
+++ b/internal/cli/ctl/install.go
@@ -191,7 +191,7 @@ func defaultConfig() *InstallConfig {
 		TURNPort:                 "3478",
 		TURNTTL:                  86400,
 		MaxMessageSize:           "32M",
-		SkipSync:                false,
+		SkipSync:                 false,
 	}
 }
 

--- a/internal/cli/ctl/install.go
+++ b/internal/cli/ctl/install.go
@@ -142,6 +142,7 @@ type InstallConfig struct {
 	NoLog          bool
 	Debug          bool
 	MaxMessageSize string
+	SkipSync       bool
 	// Internal state
 	SkipPrompts bool
 }
@@ -190,6 +191,7 @@ func defaultConfig() *InstallConfig {
 		TURNPort:                 "3478",
 		TURNTTL:                  86400,
 		MaxMessageSize:           "32M",
+		SkipSync:                false,
 	}
 }
 
@@ -343,6 +345,10 @@ Examples:
 					Usage: "Maximum message size (e.g. 32M, 100M)",
 					Value: "32M",
 				},
+				&cli.BoolFlag{
+					Name:  "skip-sync",
+					Usage: "Disable SQLite synchronous mode (unsafe, may corrupt data on crash)",
+				},
 			},
 		})
 }
@@ -382,6 +388,9 @@ func installCommand(ctx *cli.Context) error {
 		if !ctx.IsSet("hostname") {
 			config.Hostname = ctx.String("domain")
 		}
+	}
+	if ctx.Bool("skip-sync") {
+		config.SkipSync = true
 	}
 	if ctx.IsSet("hostname") {
 		config.Hostname = ctx.String("hostname")
@@ -1748,6 +1757,10 @@ Restart=on-failure
 # ... Unless it is a configuration problem.
 RestartPreventExitStatus=2
 
+{{if .SkipSync}}
+Environment=MADDY_SQLITE_UNSAFE_SYNC_OFF=1
+{{end}}
+
 ExecStart={{.BinaryPath}} --config {{.ConfigDir}}/maddy.conf {{if .Debug}}--debug {{end}}run --libexec {{.LibexecDir}}
 
 ExecReload=/bin/kill -USR1 $MAINPID
@@ -1827,6 +1840,10 @@ LimitNPROC=512
 Restart=on-failure
 # ... Unless it is a configuration problem.
 RestartPreventExitStatus=2
+
+{{if .SkipSync}}
+Environment=MADDY_SQLITE_UNSAFE_SYNC_OFF=1
+{{end}}
 
 ExecStart={{.BinaryPath}} --config {{.ConfigDir}}/%i.conf run --libexec {{.LibexecDir}}
 ExecReload=/bin/kill -USR1 $MAINPID

--- a/internal/storage/imapsql/imapsql.go
+++ b/internal/storage/imapsql/imapsql.go
@@ -31,6 +31,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime/debug"
 	"strconv"
@@ -264,6 +265,14 @@ func (store *Storage) Init(cfg *config.Map) error {
 	var err error
 
 	dsnStr := strings.Join(dsn, " ")
+	if driver == "sqlite3" && os.Getenv("MADDY_SQLITE_UNSAFE_SYNC_OFF") == "1" {
+		// WARNING: this reduces durability and can corrupt data on crash.
+		sep := "?"
+		if strings.Contains(dsnStr, "?") {
+			sep = "&"
+		}
+		dsnStr = dsnStr + sep + "_journal_mode=WAL&_synchronous=OFF"
+	}
 
 	if len(compression) != 0 {
 		switch compression[0] {


### PR DESCRIPTION
#### pr overview:
- addresses #9 
- this patch takes pragma approach to disable sync which introduces overhead in transaction time
- to test this you need to do the following
- clone the repo, `make build`, `maddy install --simple --ip 1.2.4.5 --skip-sync`
- `systemctl restart maddy.service`


note to reviewers:
- i patched the `internal/cli/ctl/install.go` to make better use of this.  it's ready to manual test
