### PR TITLE
dist/apparmor: extend rules to fit madmail

### DIFF
--- a/dist/apparmor/dev.foxcpp.maddy
+++ b/dist/apparmor/dev.foxcpp.maddy
@@ -9,7 +9,7 @@ profile dev.foxcpp.maddy /usr{/local,}/bin/maddy {
   #include <abstractions/ssl_keys>
   /etc/ca-certificates/** r,
 
-  /etc/resolv.conf r,
+  /proc/[0-9]*/cpuset r,
   /proc/sys/net/core/somaxconn r,
   /sys/kernel/mm/transparent_hugepage/hpage_pmd_size r,
   deny ptrace,
@@ -24,6 +24,10 @@ profile dev.foxcpp.maddy /usr{/local,}/bin/maddy {
   /run/systemd/notify w,
 
   /etc/maddy/** r,
+  /etc/resolv.conf r,
+  /etc/machine-id r,
+  /etc/hosts r,
+  /etc/nsswitch.conf r,
   owner /run/maddy/ rw,
   owner /run/maddy/** rwkl,
   owner /var/lib/maddy/ rw,


### PR DESCRIPTION
I tried out using apparmor and it seems the rules file is missing a few entries for it to work with madmail, this PR adds these. Excerpt from syslog, I think the first two happen during `maddy install` and the latter three during startup.
```
# journalctl -b|grep apparmor|grep DENIED |cut -d' ' -f7-
type=1400 audit(1769693389.177:44220): apparmor="DENIED" operation="open" class="file" profile="dev.foxcpp.maddy" name="/etc/machine-id" pid=157111 comm="maddy" requested_mask="r" denied_mask="r" fsuid=987 ouid=0
type=1400 audit(1769693389.177:44221): apparmor="DENIED" operation="open" class="file" profile="dev.foxcpp.maddy" name="/proc/157111/cpuset" pid=157111 comm="maddy" requested_mask="r" denied_mask="r" fsuid=987 ouid=987
type=1400 audit(1769694415.554:44222): apparmor="DENIED" operation="open" class="file" profile="dev.foxcpp.maddy" name="/etc/nsswitch.conf" pid=157111 comm="maddy" requested_mask="r" denied_mask="r" fsuid=987 ouid=0
type=1400 audit(1769694415.554:44223): apparmor="DENIED" operation="open" class="file" profile="dev.foxcpp.maddy" name="/etc/host.conf" pid=157111 comm="maddy" requested_mask="r" denied_mask="r" fsuid=987 ouid=0
```