### PR TITLE
feat: uids are not read anymore when storing messages

### DIFF
--- a/internal/go-imap-sql/user.go
+++ b/internal/go-imap-sql/user.go
@@ -117,23 +117,10 @@ func (u *User) GetMailbox(name string, readOnly bool, conn backend.Conn) (*imap.
 	mbox.readOnly = readOnly
 
 	if conn == nil {
-		// For non-interactive sessions (conn == nil) uids are not used so it's not necessary to retrieve them
-		// from db for every single message that is stored.
-		//
+		// For non-interactive sessions (conn == nil) we do not provide Uids (expensive DB query). 
+		// The SMTP internal/go-imap-sql/delivery.go pipeline does not need a list of Uids. 
 		// All the methods that use uidMap (Sync, ResolveSeq, UidAsSeq, MsgsCount) have conn == nil guards or are
-		// only called from IMAP command handlers that require an active connection. Specifically:
-		//  - Sync: returns immediately if conn == nil (go-imap-mess/mailbox.go:171)
-		//  - FlagsChanged: returns immediately if conn == nil (go-imap-mess/mailbox.go:310)
-		//  - Removed/RemovedSet: return immediately if conn == nil
-		//    (go-imap-mess/mailbox.go:354, go-imap-mess/mailbox.go:378)
-		//  - Close: returns nil if conn == nil (go-imap-mess/mailbox.go:398)
-		//  - ResolveSeq: only called from FETCH (fetch.go:50), STORE (flags.go:48),
-		//    MOVE (go-imap-sql/mailbox.go:499), COPY (go-imap-sql/mailbox.go:609),
-		//    EXPUNGE (go-imap-sql/mailbox.go:650)
-		//  - UidAsSeq: only called from FETCH (fetch.go:168), SEARCH (search.go:97,268),
-		//    SORT/THREAD (sortthread.go:66,282)
-		//  - ResolveCriteria — only called from SEARCH (search.go:23)
-		//  - MsgsCount: only called from SEARCH (search.go:187)
+		// only called from IMAP command handlers that require an active connection. 
 		mbox.handle = u.parent.mngr.ManagementHandle(mbox.id, nil, nil)
 		return nil, mbox, nil
 	}


### PR DESCRIPTION
## Description
Every time a message is received via SMTP, all UIDs of the recipient's mailbox are retrieved from the database, which is unnecessary and has quite an impact on performance. With this PR, UIDs are not read anymore, and the related struct fields are set to nil. 

## Type of Change
- [  ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [  ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [  ] Documentation update

## AI Responsibility
- [x] I have read and followed the [AI Disclosure & Security Model](docs/ai-disclosure.md).

## Testing
- [ ] I have added a new test scenario in `tests/deltachat-test/scenarios/`.
- [ ] I have run `make test` and all tests passed.
- [ ] I have run `make test-unit` and all unit tests passed.

Tests don't run locally at all due to some lxc network problems.
