### PR TITLE
fix: get rid of msgscount in go-imap-sql.

### DIFF
--- a/internal/go-imap-sql/backend.go
+++ b/internal/go-imap-sql/backend.go
@@ -156,6 +156,7 @@ type Backend struct {
 	setSubbed          *sql.Stmt
 	uidNextLocked      *sql.Stmt
 	uidNext            *sql.Stmt
+	uidNextIncrease    *sql.Stmt
 	hasChildren        *sql.Stmt
 	uidValidity        *sql.Stmt
 	msgsCount          *sql.Stmt
@@ -232,9 +233,7 @@ type Backend struct {
 	// Used by Delivery.SpecialMailbox.
 	specialUseMbox *sql.Stmt
 
-	setSeenFlagUid   *sql.Stmt
-	increaseMsgCount *sql.Stmt
-	decreaseMsgCount *sql.Stmt
+	setSeenFlagUid *sql.Stmt
 
 	setInboxId *sql.Stmt
 

--- a/internal/go-imap-sql/mailbox.go
+++ b/internal/go-imap-sql/mailbox.go
@@ -234,7 +234,7 @@ func (m *Mailbox) incrementMsgCounters(tx *sql.Tx) (uint32, error) {
 	// Increment both uidNext and msgsCount and return previous uidNext.
 	if m.parent.db.driver == "postgres" {
 		var nextId uint32
-		err := tx.Stmt(m.parent.increaseMsgCount).QueryRow(1, 1, m.id).Scan(&nextId)
+		err := tx.Stmt(m.parent.uidNextIncrease).QueryRow(1, m.id).Scan(&nextId)
 		return nextId, err
 	}
 
@@ -245,7 +245,7 @@ func (m *Mailbox) incrementMsgCounters(tx *sql.Tx) (uint32, error) {
 		return 0, err
 	}
 
-	if _, err := tx.Stmt(m.parent.increaseMsgCount).Exec(1, 1, m.id); err != nil {
+	if _, err := tx.Stmt(m.parent.uidNextIncrease).Exec(1, m.id); err != nil {
 		return 0, err
 	}
 
@@ -566,21 +566,14 @@ func (m *Mailbox) MoveMessages(uid bool, seqset *imap.SeqSet, dest string) error
 		return wrapErr(err, "MoveMessages (decrease counters)")
 	}
 
-	// Decrease MESSAGES for the source mailbox.
-	_, err = tx.Stmt(m.parent.decreaseMsgCount).Exec(copiedCount, m.id)
-	if err != nil {
-		m.parent.logMboxErr(m, err, "MoveMessages (decrease counters)", uid, seqset, dest)
-		return wrapErr(err, "MoveMessages (decrease counters)")
-	}
-
 	var oldUidNext uint32
 	if err := tx.Stmt(m.parent.uidNext).QueryRow(destID).Scan(&oldUidNext); err != nil {
 		m.parent.logMboxErr(m, err, "MoveMessages (old uidNext)", uid, seqset, dest)
 		return wrapErr(err, "MoveMessages (old uidNext)")
 	}
 
-	// Increase UIDNEXT and MESSAGES for the target mailbox.
-	if _, err := tx.Stmt(m.parent.increaseMsgCount).Exec(copiedCount, copiedCount, destID); err != nil {
+	// Increase UIDNEXT for the target mailbox.
+	if _, err := tx.Stmt(m.parent.uidNextIncrease).Exec(copiedCount, destID); err != nil {
 		m.parent.logMboxErr(m, err, "MoveMessages (increase counters)", uid, seqset, dest)
 		return wrapErr(err, "MoveMessages (increase counters)")
 	}
@@ -716,7 +709,6 @@ func (m *Mailbox) delMessages(tx *sql.Tx, seqset *imap.SeqSet) (imap.SeqSet, err
 	}
 
 	m.parent.Opts.Log.Println("delMessages: deleted", deletedCount, "messages")
-	_, err = tx.Stmt(m.parent.decreaseMsgCount).Exec(deletedCount, m.id)
 	return deletedUids, err
 }
 
@@ -758,7 +750,7 @@ func (m *Mailbox) copyMessages(tx *sql.Tx, seqset *imap.SeqSet, dest string) (fi
 		return 0, 0, 0, err
 	}
 
-	if _, err := tx.Stmt(m.parent.increaseMsgCount).Exec(totalCopied, totalCopied, destID); err != nil {
+	if _, err := tx.Stmt(m.parent.uidNextIncrease).Exec(totalCopied, destID); err != nil {
 		return 0, 0, 0, err
 	}
 
@@ -812,12 +804,6 @@ func (m *Mailbox) Expunge() error {
 	if err != nil {
 		m.parent.logMboxErr(m, err, "Expunge (expunge)")
 		return wrapErr(err, "Expunge")
-	}
-
-	_, err = tx.Stmt(m.parent.decreaseMsgCount).Exec(expungedCount, m.id)
-	if err != nil {
-		m.parent.logMboxErr(m, err, "Expunge (decrease counters)", m.id, expungedCount)
-		return wrapErr(err, "Expunge (decrease counters)")
 	}
 
 	if _, err := tx.Stmt(m.parent.deleteZeroRef).Exec(m.user.id); err != nil {

--- a/internal/go-imap-sql/sql.go
+++ b/internal/go-imap-sql/sql.go
@@ -125,8 +125,6 @@ func (b *Backend) initSchema() error {
 			uidvalidity BIGINT NOT NULL,
             specialuse VARCHAR(255) DEFAULT NULL,
 
-            msgsCount INTEGER NOT NULL DEFAULT 0,
-
 			UNIQUE(uid, name)
 		)`)
 	if err != nil {
@@ -312,28 +310,19 @@ func (b *Backend) prepareStmts() error {
 		return wrapErr(err, "uidNext prep")
 	}
 	if b.db.driver == "postgres" {
-		b.increaseMsgCount, err = b.db.Prepare(`
+		b.uidNextIncrease, err = b.db.Prepare(`
 		    UPDATE mboxes
-		    SET uidnext = uidnext + ?,
-                msgsCount = msgsCount + ?
+		    SET uidnext = uidnext + ?
 		    WHERE id = ?
 		    RETURNING uidnext - 1`)
 	} else {
-		b.increaseMsgCount, err = b.db.Prepare(`
+		b.uidNextIncrease, err = b.db.Prepare(`
 		    UPDATE mboxes
-		    SET uidnext = uidnext + ?,
-                msgsCount = msgsCount + ?
+		    SET uidnext = uidnext + ?
 		    WHERE id = ?`)
 	}
 	if err != nil {
-		return wrapErr(err, "increaseMsgCount prep")
-	}
-	b.decreaseMsgCount, err = b.db.Prepare(`
-		UPDATE mboxes
-		SET msgsCount = msgsCount - ?
-		WHERE id = ?`)
-	if err != nil {
-		return wrapErr(err, "decreaseMsgCount prep")
+		return wrapErr(err, "uidNextIncrease prep")
 	}
 	b.uidValidity, err = b.db.Prepare(`
 		SELECT uidvalidity
@@ -343,9 +332,9 @@ func (b *Backend) prepareStmts() error {
 		return wrapErr(err, "uidvalidity prep")
 	}
 	b.msgsCount, err = b.db.Prepare(`
-		SELECT msgsCount
-		FROM mboxes
-		WHERE id = ?`)
+		SELECT count(*)
+		FROM msgs
+		WHERE mboxId = ?`)
 	if err != nil {
 		return wrapErr(err, "msgsCount prep")
 	}


### PR DESCRIPTION
## Description
The go-imap-sql module is incomplete and riddled with concurrency bugs and performance issues, which isn't surprising considering it's in beta and doesn't seem to get much attention or maintenance. I administrate a Deltachat relay of ~40 people, and the postgresql database is already having issues locking up when the traffic is high, often completely hanging all message delivery every 10 minutes or so for several minutes at a time.

I've identified some of the causes of this, and also some other serious issues with the SQL code (external message bodies not being reference counted properly, staying around even after they're not referenced anymore and clogging up the database and disk space) but for this patch I'm focusing on the completely unused `msgsCount` column. Not only is this column never read, and its high frequency updating has been one of the main sources of deadlocks, but due to concurrency bugs the value stored in it isn't even correct in the first place.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## AI Responsibility
- [x] I have read and followed the [AI Disclosure & Security Model](docs/ai-disclosure.md).

## Testing
- [ ] I have added a new test scenario in `tests/deltachat-test/scenarios/`.
- [ ] I have run `make test` and all tests passed.
- [x] I have run `make test-unit` and all unit tests passed.
