### PR TITLE
chore: add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,95 @@
+name: Bug report
+description: Something is broken or behaves incorrectly
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. For questions or setup help, use [GitHub Discussions](https://github.com/themadorg/madmail/discussions) instead.
+
+        **Security issues** (auth bypass, PGP enforcement failure, data leakage, etc.) should be reported privately — do not post details here.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of Madmail is affected?
+      options:
+        - SMTP
+        - IMAP
+        - Federation (HTTP /mxdeliv or outbound delivery)
+        - Authentication / JIT registration
+        - Admin API / admin web UI
+        - TURN / STUN / Iroh relay
+        - TLS / ACME / certificates
+        - Storage / quota / Maildir
+        - Configuration / CLI
+        - Installation / deployment
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Madmail version
+      description: Output of `madmail version` or the release tag you are running
+      placeholder: e.g. 2.11.1
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Clear description of the bug and what you expected instead
+      placeholder: When I …, Madmail … instead of …
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps, commands, or client actions that trigger the issue
+      placeholder: |
+        1. Configure …
+        2. Run `…`
+        3. Connect with Delta Chat / curl / …
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, architecture, deployment mode, and relevant config
+      placeholder: |
+        - OS: Debian 13 / amd64
+        - Deploy: systemd, domain mail.example.org (or IP + ACME)
+        - Delta Chat version (if applicable):
+        - Relevant config (hostname, tls_mode, federation settings, etc.):
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / error output
+      description: Relevant log lines, SMTP/IMAP session traces, or stack traces (redact tokens, passwords, and PII)
+      render: shell
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Reporter checklist
+      options:
+        - label: I searched existing issues and discussions for duplicates
+          required: true
+        - label: I redacted secrets, admin tokens, and personal data from logs
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & general discussion
+    url: https://github.com/themadorg/madmail/discussions
+    about: Ask questions, share ideas, or discuss deployment — not everything needs an issue.
+  - name: Report a vulnerability (private)
+    url: https://github.com/themadorg/madmail/security/advisories/new
+    about: Do not post security vulnerabilities publicly — use GitHub Security Advisories.
+  - name: Documentation index
+    url: https://github.com/themadorg/madmail/tree/main/docs/project
+    about: Developer and operator guides live in docs/project/ and docs/project/user-guide/.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,91 @@
+name: Documentation
+description: Report missing, unclear, or incorrect documentation
+title: "[Docs]: "
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Help us improve Madmail's docs. For code bugs or feature requests, use the other issue templates.
+
+        Doc locations:
+        - [User & operator guide](https://github.com/themadorg/madmail/tree/main/docs/project/user-guide) — practical setup and usage
+        - [Developer tour](https://github.com/themadorg/madmail/tree/main/docs/project) — architecture and codebase (01–17 series)
+        - [TDD](https://github.com/themadorg/madmail/tree/main/docs/TDD) — design decisions
+        - [Local dev](https://github.com/themadorg/madmail/blob/main/docs/local-dev.md) / [install guides](https://github.com/themadorg/madmail/tree/main/docs)
+
+  - type: dropdown
+    id: doc_set
+    attributes:
+      label: Documentation set
+      options:
+        - User & operator guide (`docs/project/user-guide/`)
+        - Developer tour (`docs/project/`)
+        - TDD (`docs/TDD/`)
+        - Install / deployment guide
+        - Local development guide
+        - README or landing site
+        - In-server docs (`/docs/` HTML)
+        - Other / not sure
+    validations:
+      required: true
+
+  - type: input
+    id: page
+    attributes:
+      label: Page or file (if known)
+      description: Path or URL to the doc in question
+      placeholder: e.g. docs/project/user-guide/02-quick-start.md
+    validations:
+      required: false
+
+  - type: dropdown
+    id: audience
+    attributes:
+      label: Primary audience
+      options:
+        - Server operator
+        - End user (Delta Chat)
+        - Developer / contributor
+        - All of the above
+    validations:
+      required: true
+
+  - type: dropdown
+    id: issue_type
+    attributes:
+      label: Issue type
+      options:
+        - Missing documentation
+        - Unclear or confusing explanation
+        - Incorrect or outdated information
+        - Broken link or reference
+        - Typo / formatting
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is wrong or missing?
+      description: What did you expect to find, and what did you find instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested improvement
+      description: How should the doc read? Include draft wording if helpful.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Reporter checklist
+      options:
+        - label: I searched existing issues for duplicates
+          required: true
+        - label: I am willing to open a PR with a doc fix (optional — not required)
+          required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,77 @@
+name: Feature request
+description: Propose a new capability or improvement
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the problem you want solved. For large changes, check whether a [TDD document](https://github.com/themadorg/madmail/tree/main/docs/TDD) or design note already exists.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - SMTP
+        - IMAP
+        - Federation
+        - Authentication / registration
+        - Admin API / admin web UI
+        - TURN / STUN / Iroh relay
+        - TLS / ACME
+        - Storage / quota
+        - Configuration / CLI
+        - Operator / deployment experience
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What pain point or gap does this address?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How should Madmail behave? Include operator or Delta Chat user impact if relevant.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about, or workarounds in use today
+    validations:
+      required: false
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Estimated scope
+      options:
+        - Small (localized change, one crate or doc)
+        - Medium (cross-crate, new API surface, new tests)
+        - Large (new subsystem — likely needs TDD / plan doc first)
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: constraints
+    attributes:
+      label: Design constraints
+      description: Madmail aims for a single binary and simple ops — note anything that affects these
+      options:
+        - label: Should preserve behavior parity with Madmail v1 (Go) where applicable
+          required: false
+        - label: Affects PGP enforcement, auth, admin tokens, or logging (No-Log)
+          required: false
+        - label: Requires a new external process or mandatory sidecar
+          required: false

--- a/.github/ISSUE_TEMPLATE/security_report.yml
+++ b/.github/ISSUE_TEMPLATE/security_report.yml
@@ -1,0 +1,82 @@
+name: Security
+description: Report a vulnerability privately or propose a security improvement
+title: "[Security]: "
+labels: ["security"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Do not post exploit details, credentials, or live attack steps in a public issue.**
+
+        If you believe you have found a **vulnerability** (auth bypass, PGP enforcement failure, data leakage, privilege escalation, etc.), report it privately:
+
+        → **[Report a vulnerability](https://github.com/themadorg/madmail/security/advisories/new)** (GitHub Security Advisories)
+
+        Use this template only for **non-sensitive** security topics: hardening ideas, threat-model questions, or documentation gaps. For general questions, use [Discussions](https://github.com/themadorg/madmail/discussions).
+
+  - type: dropdown
+    id: report_type
+    attributes:
+      label: Report type
+      options:
+        - Security hardening / improvement (not an active vulnerability)
+        - Security documentation gap
+        - Threat model / design question
+        - I have a vulnerability — I will report it privately instead
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Authentication / JIT registration
+        - PGP enforcement gate
+        - Admin API / admin token handling
+        - Federation /mxdeliv
+        - SMTP / IMAP session handling
+        - TLS / ACME / certificates
+        - Logging / No-Log policy
+        - Storage / quota / data retention
+        - TURN / Iroh / relay credentials
+        - Configuration / secrets handling
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe the concern or improvement. Do not include working exploits, live credentials, or customer data.
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact (if known)
+      description: Who or what could be affected? What is the worst reasonable outcome?
+      placeholder: e.g. Unauthenticated access to admin API, message content exposure, account takeover
+    validations:
+      required: false
+
+  - type: textarea
+    id: mitigation
+    attributes:
+      label: Suggested mitigation or references
+      description: Ideas, relevant TDD sections, or links to standards/RFCs
+      placeholder: e.g. docs/TDD/12-security.md, rate-limit on …, stricter validation in …
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Reporter checklist
+      options:
+        - label: I did not include exploit code, secrets, or personal data in this issue
+          required: true
+        - label: If this is an active vulnerability, I will (or have) reported it via GitHub Security Advisories instead
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,75 @@
+## Summary
+
+<!-- What does this PR change and why? Link related issues: Fixes #123 -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing behavior to change)
+- [ ] Documentation only
+- [ ] Build / CI / tooling
+- [ ] Refactor (no functional change)
+
+## Area
+
+<!-- Check all that apply -->
+
+- [ ] SMTP
+- [ ] IMAP
+- [ ] Federation / delivery queue
+- [ ] Authentication / JIT
+- [ ] Admin API / admin web UI (`external/madmail-admin-web`)
+- [ ] TURN / Iroh / proxy services
+- [ ] Storage / quota / DB migrations
+- [ ] Configuration / CLI
+- [ ] Docs (`docs/project/`, `docs/TDD/`, user guide)
+- [ ] Other: <!-- describe -->
+
+## Testing
+
+<!-- How did you verify this? Be specific — CI alone is not enough for security-sensitive paths. -->
+
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] `cargo test --workspace` (or targeted crate/tests: <!-- list if subset -->)
+- [ ] Manual / E2E verification (describe below)
+
+**Manual verification (if any):**
+
+```text
+<!-- commands run, Delta Chat scenario, federation test, etc. -->
+```
+
+## Documentation
+
+- [ ] No doc updates needed
+- [ ] Updated operator/user docs (`docs/project/user-guide/`, install guides)
+- [ ] Updated developer docs (`docs/project/`)
+- [ ] Updated or added TDD section (`docs/TDD/`) — required for significant design changes
+
+## Security & privacy
+
+<!-- Required for changes to PGP gate, auth, admin tokens, federation policy, or logging -->
+
+- [ ] Not security-sensitive
+- [ ] Security-sensitive — added/updated tests for the security property
+- [ ] Reviewed error messages for information leakage
+
+## Commits
+
+<!-- Main uses semantic-release with conventional commits. Squash or rebase so merge commits follow: -->
+
+- `feat:` new feature
+- `fix:` bug fix
+- `docs:` documentation
+- `refactor:` code change without feature/fix
+- `test:` tests only
+- `chore:` tooling, deps, release
+
+## Checklist
+
+- [ ] PR is focused and reviewable (small vertical slices preferred)
+- [ ] No secrets, `data/`, `target/`, or `node_modules/` committed
+- [ ] Submodule pointers updated if `external/madmail-admin-web` changed
+- [ ] Behavior parity with Madmail v1 considered (or intentional difference documented)


### PR DESCRIPTION
## Summary

Adds GitHub issue and pull request templates for the repo.

## Type of change

- [x] Build / CI / tooling
- [x] Documentation only

## Changes

- Bug report, feature request, security, and documentation issue templates
- Issue template config with links to Discussions and private vulnerability reporting
- Pull request template aligned with contribution guide and CI checks

## Testing

- [x] Documentation / tooling only — no code changes

## Documentation

- [x] No doc updates needed (templates are self-contained under `.github/`)