### PR TITLE
feat(www): migrate custom Go templates during update

### DIFF
--- a/crates/chatmail-config/src/cli.rs
+++ b/crates/chatmail-config/src/cli.rs
@@ -122,6 +122,13 @@ pub enum Command {
         #[arg(value_name = "WWW_DIR")]
         www_dir: String,
     },
+    /// Convert custom `www_dir` Go templates to Minijinja (interactive).
+    #[command(name = "html-migrate")]
+    HtmlMigrate {
+        /// Apply migration without prompting (default: ask when Go-style HTML is found).
+        #[arg(long, short = 'y')]
+        yes: bool,
+    },
     /// IMAP mailboxes (folders) management.
     #[command(name = "imap-mboxes")]
     ImapMboxes,
@@ -785,6 +792,20 @@ mod tests {
         assert!(matches!(
             cli.command,
             Some(Command::Update { path_or_url }) if path_or_url == "/tmp/madmail-signed"
+        ));
+    }
+
+    #[test]
+    fn html_migrate_accepts_yes_flag() {
+        let cli = Cli::try_parse_from(["madmail", "html-migrate"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::HtmlMigrate { yes: false })
+        ));
+        let cli = Cli::try_parse_from(["madmail", "html-migrate", "-y"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::HtmlMigrate { yes: true })
         ));
     }
 

--- a/crates/chatmail-www/src/go_template.rs
+++ b/crates/chatmail-www/src/go_template.rs
@@ -16,8 +16,13 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 //! Translate Madmail Go `html/template` syntax to Minijinja at render time.
+//!
+//! Custom `www_dir` pages exported from Go Madmail often keep forms like
+//! `{{if not .RegistrationOpen}}` / `{{.MailDomain | cleanDomain}}`. Without
+//! conversion Minijinja fails with:
+//! `syntax error: unexpected '.', expected in`.
 
-/// Accept Go-style (`{{if .Field}}`) or existing Minijinja templates.
+/// Accept Go-style (`{{if .Field}}`, `{{if not .Field}}`) or existing Minijinja templates.
 pub fn prepare_template(input: &str) -> String {
     post_process(&go_to_minijinja(input))
 }
@@ -28,20 +33,7 @@ pub fn prepare_template(input: &str) -> String {
 /// should be rewritten. Pure Minijinja (`{% if %}`, `{{ Field }}` without a leading `.`)
 /// returns false.
 pub fn looks_like_go_template(src: &str) -> bool {
-    // Control / field forms unique to Go html/template in Madmail pages.
-    if src.contains("{{if .")
-        || src.contains("{{ if .")
-        || src.contains("{{end}}")
-        || src.contains("{{ end }}")
-        || src.contains("{{else}}")
-        || src.contains("{{ else }}")
-        || src.contains("{{if eq .")
-        || src.contains("{{ if eq .")
-    {
-        return true;
-    }
-    // `{{.Field}}` / `{{ .Field }}` (leading dot after `{{`)
-    if src.contains("{{.") || src.contains("{{ .") {
+    if has_go_control_or_field_action(src) {
         return true;
     }
     // Go filter names (Minijinja uses snake_case)
@@ -57,6 +49,40 @@ pub fn looks_like_go_template(src: &str) -> bool {
         return true;
     }
     false
+}
+
+/// Scan `{{ … }}` actions for Go control flow / dotted field forms.
+fn has_go_control_or_field_action(src: &str) -> bool {
+    let bytes = src.as_bytes();
+    let mut i = 0usize;
+    while i + 1 < bytes.len() {
+        if bytes[i] == b'{' && bytes[i + 1] == b'{' {
+            let rest = &src[i + 2..];
+            if let Some(end) = rest.find("}}") {
+                let norm = normalize_action(rest[..end].trim());
+                if is_go_action(&norm) {
+                    return true;
+                }
+                i += 2 + end + 2;
+                continue;
+            }
+        }
+        i += 1;
+    }
+    false
+}
+
+fn is_go_action(norm: &str) -> bool {
+    matches!(norm, "else" | "end")
+        || norm.starts_with("if .")
+        || norm.starts_with("if not .")
+        || norm.starts_with("if eq .")
+        || norm.starts_with('.')
+}
+
+/// Collapse runs of whitespace so `if  not  .X` matches `if not .X`.
+fn normalize_action(inner: &str) -> String {
+    inner.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 fn go_to_minijinja(input: &str) -> String {
@@ -80,8 +106,9 @@ fn go_to_minijinja(input: &str) -> String {
 fn convert_action(s: &str, start: usize) -> Option<(String, usize)> {
     let rest = &s[start + 2..];
     let end = rest.find("}}")?;
-    let inner = rest[..end].trim();
+    let inner_raw = rest[..end].trim();
     let new_i = start + 2 + end + 2;
+    let inner = normalize_action(inner_raw);
 
     if inner == "else" {
         return Some(("{% else %}".into(), new_i));
@@ -90,25 +117,57 @@ fn convert_action(s: &str, start: usize) -> Option<(String, usize)> {
         return Some(("{% endif %}".into(), new_i));
     }
     if let Some(stripped) = inner.strip_prefix("if eq .") {
+        // `if eq .Language "fa"` or `if eq .Language fa`
+        let stripped = stripped.trim();
         if let Some((field, value)) = stripped.split_once(' ') {
             let value = value.trim().trim_matches('"');
             return Some((format!(r#"{{% if {field} == "{value}" %}}"#), new_i));
         }
     }
+    // Go: `{{if not .RegistrationOpen}}` → Minijinja `{% if not RegistrationOpen %}`
+    // Must run before `if .` matching.
+    if let Some(field) = inner.strip_prefix("if not .") {
+        let field = field.trim();
+        if !field.is_empty() {
+            return Some((format!("{{% if not {field} %}}"), new_i));
+        }
+    }
     if let Some(field) = inner.strip_prefix("if .") {
-        return Some((format!("{{% if {field} %}}"), new_i));
+        let field = field.trim();
+        if !field.is_empty() {
+            return Some((format!("{{% if {field} %}}"), new_i));
+        }
     }
     if let Some(expr) = inner.strip_prefix('.') {
-        if let Some((field, filter)) = expr.split_once(" | ") {
-            let filter = match filter.trim() {
-                "cleanDomain" => "clean_domain",
-                other => other,
-            };
+        let (field, filter) = split_field_filter(expr);
+        if let Some(filter) = filter {
+            let filter = map_go_filter(filter);
             return Some((format!("{{{{ {field} | {filter} }}}}"), new_i));
         }
-        return Some((format!("{{{{ {expr} }}}}"), new_i));
+        return Some((format!("{{{{ {field} }}}}"), new_i));
     }
     None
+}
+
+fn split_field_filter(expr: &str) -> (&str, Option<&str>) {
+    if let Some((field, filter)) = expr.split_once(" | ") {
+        return (field.trim(), Some(filter.trim()));
+    }
+    if let Some((field, filter)) = expr.split_once('|') {
+        return (field.trim(), Some(filter.trim()));
+    }
+    (expr.trim(), None)
+}
+
+fn map_go_filter(filter: &str) -> &str {
+    match filter {
+        "cleanDomain" => "clean_domain",
+        "formatBytes" => "format_bytes",
+        "safeHTML" => "safe_html",
+        // stripped in post_process (no-op for our trusted URL contexts)
+        "safeURL" => "safe_url",
+        other => other,
+    }
 }
 
 fn post_process(s: &str) -> String {
@@ -117,6 +176,9 @@ fn post_process(s: &str) -> String {
         "{{slice .Custom.Name 0 1 | printf \"%s\" | upper}}",
         "{{ Custom.Name[0:1] | upper }}",
     );
+    // Go `| safeURL` is a no-op for our templates (URLs are already trusted context).
+    s = s.replace(" | safe_url", "");
+    s = s.replace("| safe_url", "");
     s = s.replace("| safeURL", "");
     s = s.replace("| formatBytes", "| format_bytes");
     s = s.replace("| safeHTML", "| safe_html");
@@ -135,19 +197,100 @@ mod tests {
         assert!(o.contains("{{ MailDomain | clean_domain }}"));
     }
 
+    /// Regression: Go `{{if not .Field}}` left unconverted caused Minijinja
+    /// `syntax error: unexpected '.', expected in` on custom www_dir pages.
+    #[test]
+    fn converts_if_not_field() {
+        let s = r#"{{if not .RegistrationOpen}}closed{{else}}open{{end}}"#;
+        let o = prepare_template(s);
+        assert_eq!(
+            o,
+            "{% if not RegistrationOpen %}closed{% else %}open{% endif %}"
+        );
+        assert!(looks_like_go_template(s));
+        assert!(!looks_like_go_template(&o));
+    }
+
+    #[test]
+    fn converts_if_not_with_irregular_whitespace() {
+        // Production-like and odd spacing operators sometimes paste.
+        for s in [
+            r#"{{ if not .RegistrationOpen }}closed{{ end }}"#,
+            r#"{{if  not  .RegistrationOpen}}closed{{end}}"#,
+            r#"{{	if not .RegistrationOpen	}}closed{{	end	}}"#,
+        ] {
+            let o = prepare_template(s);
+            assert!(
+                o.contains("{% if not RegistrationOpen %}"),
+                "input={s:?} got={o}"
+            );
+            assert!(o.contains("{% endif %}"), "input={s:?} got={o}");
+            assert!(!o.contains("{{if"), "left go markers: {o}");
+            assert!(!o.contains(".RegistrationOpen"), "left go dotted if: {o}");
+        }
+    }
+
+    #[test]
+    fn converts_if_not_nested_field() {
+        let s = r#"{{if not .Custom.Name}}anon{{else}}named{{end}}"#;
+        let o = prepare_template(s);
+        assert_eq!(o, "{% if not Custom.Name %}anon{% else %}named{% endif %}");
+    }
+
+    #[test]
+    fn converts_filter_without_spaces_around_pipe() {
+        let s = r#"{{.MailDomain|cleanDomain}}"#;
+        let o = prepare_template(s);
+        assert_eq!(o, "{{ MailDomain | clean_domain }}");
+    }
+
+    #[test]
+    fn production_index_snippet_if_not_registration_open() {
+        // Mirrors the failing custom index.html form reported by operators.
+        let s = r#"      {{if not .RegistrationOpen}}
+        <p class="warn">registration closed</p>
+      {{else}}
+        <p>open</p>
+      {{end}}"#;
+        let o = prepare_template(s);
+        assert!(o.contains("{% if not RegistrationOpen %}"), "got: {o}");
+        assert!(o.contains("{% else %}"));
+        assert!(o.contains("{% endif %}"));
+        assert!(!o.contains("{{if"));
+        assert!(!o.contains(".RegistrationOpen"));
+        assert!(looks_like_go_template(s));
+        assert!(!looks_like_go_template(&o));
+    }
+
     #[test]
     fn leaves_minijinja_unchanged() {
         let s = r#"{% if RegistrationOpen %}{{ MailDomain }}{% endif %}"#;
         assert_eq!(prepare_template(s), s);
+        let not_s = r#"{% if not RegistrationOpen %}closed{% endif %}"#;
+        assert_eq!(prepare_template(not_s), not_s);
     }
 
     #[test]
     fn looks_like_go_template_markers() {
         assert!(looks_like_go_template("{{if .X}}"));
+        assert!(looks_like_go_template("{{if not .RegistrationOpen}}"));
+        assert!(looks_like_go_template("{{ if not .X }}"));
+        assert!(looks_like_go_template("{{if  not  .X}}"));
         assert!(looks_like_go_template("{{.MailDomain}}"));
         assert!(looks_like_go_template("x | cleanDomain y"));
         assert!(!looks_like_go_template(
             "{% if X %}{{ MailDomain }}{% endif %}"
         ));
+        assert!(!looks_like_go_template(
+            "{% if not RegistrationOpen %}closed{% endif %}"
+        ));
+    }
+
+    #[test]
+    fn prepare_template_idempotent() {
+        let go = r#"{{if not .RegistrationOpen}}c{{else}}o{{end}} {{.MailDomain|cleanDomain}}"#;
+        let once = prepare_template(go);
+        let twice = prepare_template(&once);
+        assert_eq!(once, twice);
     }
 }

--- a/crates/chatmail-www/src/go_template.rs
+++ b/crates/chatmail-www/src/go_template.rs
@@ -22,6 +22,43 @@ pub fn prepare_template(input: &str) -> String {
     post_process(&go_to_minijinja(input))
 }
 
+/// True when `src` still uses Madmail Go `html/template` markers (not native Minijinja).
+///
+/// Used by `html-migrate` / upgrade to decide whether on-disk custom `www_dir` HTML
+/// should be rewritten. Pure Minijinja (`{% if %}`, `{{ Field }}` without a leading `.`)
+/// returns false.
+pub fn looks_like_go_template(src: &str) -> bool {
+    // Control / field forms unique to Go html/template in Madmail pages.
+    if src.contains("{{if .")
+        || src.contains("{{ if .")
+        || src.contains("{{end}}")
+        || src.contains("{{ end }}")
+        || src.contains("{{else}}")
+        || src.contains("{{ else }}")
+        || src.contains("{{if eq .")
+        || src.contains("{{ if eq .")
+    {
+        return true;
+    }
+    // `{{.Field}}` / `{{ .Field }}` (leading dot after `{{`)
+    if src.contains("{{.") || src.contains("{{ .") {
+        return true;
+    }
+    // Go filter names (Minijinja uses snake_case)
+    if src.contains("| cleanDomain")
+        || src.contains("|cleanDomain")
+        || src.contains("| safeHTML")
+        || src.contains("|safeHTML")
+        || src.contains("| formatBytes")
+        || src.contains("|formatBytes")
+        || src.contains("| safeURL")
+        || src.contains("|safeURL")
+    {
+        return true;
+    }
+    false
+}
+
 fn go_to_minijinja(input: &str) -> String {
     let mut out = String::with_capacity(input.len());
     let bytes = input.as_bytes();
@@ -102,5 +139,15 @@ mod tests {
     fn leaves_minijinja_unchanged() {
         let s = r#"{% if RegistrationOpen %}{{ MailDomain }}{% endif %}"#;
         assert_eq!(prepare_template(s), s);
+    }
+
+    #[test]
+    fn looks_like_go_template_markers() {
+        assert!(looks_like_go_template("{{if .X}}"));
+        assert!(looks_like_go_template("{{.MailDomain}}"));
+        assert!(looks_like_go_template("x | cleanDomain y"));
+        assert!(!looks_like_go_template(
+            "{% if X %}{{ MailDomain }}{% endif %}"
+        ));
     }
 }

--- a/crates/chatmail-www/src/lib.rs
+++ b/crates/chatmail-www/src/lib.rs
@@ -29,9 +29,15 @@ pub mod template;
 pub mod webimap;
 pub mod webimap_ws;
 mod www_facts;
+pub mod www_migrate;
 
 pub use export::export_www_files;
+pub use go_template::{looks_like_go_template, prepare_template};
 pub use router::{www_router, WwwState};
+pub use www_migrate::{
+    migrate_www_dir, migrate_www_html_file, scan_www_dir_for_go_templates, FileMigrateOutcome,
+    MigrateReport,
+};
 
 #[cfg(test)]
 mod tests;

--- a/crates/chatmail-www/src/tests.rs
+++ b/crates/chatmail-www/src/tests.rs
@@ -260,6 +260,60 @@ async fn external_www_go_template_syntax() {
     );
 }
 
+/// Regression for operator custom pages: `{{if not .RegistrationOpen}}` must render,
+/// not fail with Minijinja `unexpected '.'` (was index.html:234-class failures).
+#[tokio::test]
+async fn external_www_go_if_not_registration_open() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("index.html"),
+        r#"<!DOCTYPE html><html><body>
+{{if not .RegistrationOpen}}
+<p id="closed">registration is closed</p>
+{{else}}
+<p id="open">registration is open</p>
+{{end}}
+<span>{{.MailDomain | cleanDomain}}</span>
+</body></html>"#,
+    )
+    .unwrap();
+
+    let mut cfg = AppConfig::default();
+    cfg.www_dir = Some(dir.path().to_path_buf());
+    cfg.mail_domain = Some("example.org".into());
+
+    let engine = TemplateEngine::from_config(&cfg);
+    let pool = init_memory_db().await.unwrap();
+    // Force registration closed for deterministic branch.
+    chatmail_db::set_setting(
+        &pool,
+        chatmail_db::settings_keys::REGISTRATION_OPEN,
+        "false",
+    )
+    .await
+    .unwrap();
+    let cache = WwwContextCache::new();
+    let ctx = build_context(&pool, &cfg, None, None, None, dir.path(), &cache)
+        .await
+        .unwrap();
+    assert!(
+        !ctx.RegistrationOpen,
+        "test setup: registration should be closed"
+    );
+
+    let html = engine
+        .render("index.html", &ctx)
+        .expect("if not .RegistrationOpen must convert and render");
+    assert!(
+        html.contains("registration is closed"),
+        "expected closed branch, got: {html}"
+    );
+    assert!(!html.contains("registration is open"), "got: {html}");
+    assert!(html.contains("example.org"), "got: {html}");
+    assert!(!html.contains("{{if"), "Go markers leaked: {html}");
+    assert!(!html.contains(".RegistrationOpen"), "got: {html}");
+}
+
 #[test]
 fn www_credential_policy_from_maddy_conf() {
     let content = r#"

--- a/crates/chatmail-www/src/www_migrate.rs
+++ b/crates/chatmail-www/src/www_migrate.rs
@@ -55,7 +55,7 @@ pub fn scan_www_dir_for_go_templates(www_dir: &Path) -> Result<Vec<PathBuf>> {
         )));
     }
     let mut out = Vec::new();
-    walk_html(www_dir, www_dir, &mut |path| {
+    walk_html(www_dir, &mut |path| {
         let src = fs::read_to_string(path).map_err(ChatmailError::from)?;
         if looks_like_go_template(&src) {
             out.push(path.to_path_buf());
@@ -103,7 +103,7 @@ pub fn migrate_www_dir(www_dir: &Path, apply: bool) -> Result<MigrateReport> {
     }
 
     let mut all_html = Vec::new();
-    walk_html(www_dir, www_dir, &mut |path| {
+    walk_html(www_dir, &mut |path| {
         all_html.push(path.to_path_buf());
         Ok(())
     })?;
@@ -154,13 +154,13 @@ fn backup_path(path: &Path) -> PathBuf {
     PathBuf::from(s)
 }
 
-fn walk_html(root: &Path, dir: &Path, f: &mut dyn FnMut(&Path) -> Result<()>) -> Result<()> {
+fn walk_html(dir: &Path, f: &mut dyn FnMut(&Path) -> Result<()>) -> Result<()> {
     let entries = fs::read_dir(dir).map_err(ChatmailError::from)?;
     for entry in entries {
         let entry = entry.map_err(ChatmailError::from)?;
         let path = entry.path();
         if path.is_dir() {
-            walk_html(root, &path, f)?;
+            walk_html(&path, f)?;
         } else if path
             .extension()
             .and_then(|e| e.to_str())
@@ -266,9 +266,11 @@ mod tests {
         fs::write(dir.path().join("index.html"), go).unwrap();
 
         // Before migrate: external www still renders Go syntax via prepare_template.
-        let mut cfg = AppConfig::default();
-        cfg.www_dir = Some(dir.path().to_path_buf());
-        cfg.mail_domain = Some("example.org".into());
+        let cfg = AppConfig {
+            www_dir: Some(dir.path().to_path_buf()),
+            mail_domain: Some("example.org".into()),
+            ..Default::default()
+        };
         let engine = TemplateEngine::from_config(&cfg);
         let ctx = WwwContext {
             MailDomain: "example.org".into(),

--- a/crates/chatmail-www/src/www_migrate.rs
+++ b/crates/chatmail-www/src/www_migrate.rs
@@ -1,0 +1,340 @@
+// Copyright (C) 2026 themadorg
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! On-disk migration of custom `www_dir` HTML from Go templates to Minijinja.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use chatmail_types::{ChatmailError, Result};
+use serde::Serialize;
+
+use crate::go_template::{looks_like_go_template, prepare_template};
+
+/// Result of migrating one HTML file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FileMigrateOutcome {
+    /// No Go markers or content unchanged after convert.
+    Unchanged,
+    /// File rewritten; optional backup path.
+    Migrated { backup: PathBuf },
+}
+
+/// Summary of a `www_dir` migration pass.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct MigrateReport {
+    pub www_dir: String,
+    pub scanned: usize,
+    pub go_style_files: Vec<String>,
+    pub migrated: Vec<String>,
+    pub unchanged: usize,
+    pub backups: Vec<String>,
+    pub errors: Vec<String>,
+}
+
+/// List HTML files under `www_dir` that still look like Go `html/template`.
+pub fn scan_www_dir_for_go_templates(www_dir: &Path) -> Result<Vec<PathBuf>> {
+    if !www_dir.is_dir() {
+        return Err(ChatmailError::config(format!(
+            "www_dir is not a directory: {}",
+            www_dir.display()
+        )));
+    }
+    let mut out = Vec::new();
+    walk_html(www_dir, www_dir, &mut |path| {
+        let src = fs::read_to_string(path).map_err(ChatmailError::from)?;
+        if looks_like_go_template(&src) {
+            out.push(path.to_path_buf());
+        }
+        Ok(())
+    })?;
+    out.sort();
+    Ok(out)
+}
+
+/// Convert one HTML file in place if it uses Go template syntax.
+///
+/// Writes `path` with a `.go-template.bak` sibling backup when content changes.
+pub fn migrate_www_html_file(path: &Path) -> Result<FileMigrateOutcome> {
+    let src = fs::read_to_string(path).map_err(ChatmailError::from)?;
+    if !looks_like_go_template(&src) {
+        return Ok(FileMigrateOutcome::Unchanged);
+    }
+    let converted = prepare_template(&src);
+    if converted == src {
+        return Ok(FileMigrateOutcome::Unchanged);
+    }
+    let backup = backup_path(path);
+    if !backup.exists() {
+        fs::write(&backup, &src).map_err(ChatmailError::from)?;
+    }
+    fs::write(path, converted.as_bytes()).map_err(ChatmailError::from)?;
+    Ok(FileMigrateOutcome::Migrated { backup })
+}
+
+/// Scan and optionally rewrite all Go-style HTML under `www_dir`.
+///
+/// When `apply` is false, only scans and fills `go_style_files` (dry run).
+pub fn migrate_www_dir(www_dir: &Path, apply: bool) -> Result<MigrateReport> {
+    let mut report = MigrateReport {
+        www_dir: www_dir.display().to_string(),
+        ..Default::default()
+    };
+
+    if !www_dir.is_dir() {
+        return Err(ChatmailError::config(format!(
+            "www_dir is not a directory: {}",
+            www_dir.display()
+        )));
+    }
+
+    let mut all_html = Vec::new();
+    walk_html(www_dir, www_dir, &mut |path| {
+        all_html.push(path.to_path_buf());
+        Ok(())
+    })?;
+    report.scanned = all_html.len();
+
+    for path in all_html {
+        let rel = path
+            .strip_prefix(www_dir)
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|_| path.display().to_string());
+        let src = match fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(e) => {
+                report
+                    .errors
+                    .push(format!("{}: read failed: {e}", path.display()));
+                continue;
+            }
+        };
+        if !looks_like_go_template(&src) {
+            report.unchanged += 1;
+            continue;
+        }
+        report.go_style_files.push(rel.clone());
+        if !apply {
+            continue;
+        }
+        match migrate_www_html_file(&path) {
+            Ok(FileMigrateOutcome::Migrated { backup }) => {
+                report.migrated.push(rel);
+                report.backups.push(backup.display().to_string());
+            }
+            Ok(FileMigrateOutcome::Unchanged) => {
+                report.unchanged += 1;
+            }
+            Err(e) => {
+                report.errors.push(format!("{}: {e}", path.display()));
+            }
+        }
+    }
+
+    Ok(report)
+}
+
+fn backup_path(path: &Path) -> PathBuf {
+    let mut s = path.as_os_str().to_os_string();
+    s.push(".go-template.bak");
+    PathBuf::from(s)
+}
+
+fn walk_html(root: &Path, dir: &Path, f: &mut dyn FnMut(&Path) -> Result<()>) -> Result<()> {
+    let entries = fs::read_dir(dir).map_err(ChatmailError::from)?;
+    for entry in entries {
+        let entry = entry.map_err(ChatmailError::from)?;
+        let path = entry.path();
+        if path.is_dir() {
+            walk_html(root, &path, f)?;
+        } else if path
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| e.eq_ignore_ascii_case("html"))
+        {
+            f(&path)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::go_template::looks_like_go_template;
+
+    #[test]
+    fn detect_go_vs_minijinja() {
+        assert!(looks_like_go_template(
+            r#"{{if .RegistrationOpen}}yes{{else}}no{{end}} {{.MailDomain | cleanDomain}}"#
+        ));
+        assert!(!looks_like_go_template(
+            r#"{% if RegistrationOpen %}yes{% else %}no{% endif %} {{ MailDomain | clean_domain }}"#
+        ));
+        assert!(looks_like_go_template(r#"hello {{.WebDomain}}"#));
+        assert!(!looks_like_go_template(r#"hello {{ WebDomain }}"#));
+    }
+
+    #[test]
+    fn migrate_file_writes_backup_and_converts() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("index.html");
+        let go = r#"<!DOCTYPE html><body>{{if .RegistrationOpen}}open{{else}}closed{{end}} {{.MailDomain | cleanDomain}}</body>"#;
+        fs::write(&path, go).unwrap();
+
+        let out = migrate_www_html_file(&path).unwrap();
+        assert!(matches!(out, FileMigrateOutcome::Migrated { .. }));
+        let bak = backup_path(&path);
+        assert!(bak.is_file(), "backup missing: {}", bak.display());
+        assert_eq!(fs::read_to_string(&bak).unwrap(), go);
+
+        let body = fs::read_to_string(&path).unwrap();
+        assert!(body.contains("{% if RegistrationOpen %}"));
+        assert!(body.contains("{{ MailDomain | clean_domain }}"));
+        assert!(!looks_like_go_template(&body));
+
+        // Second pass is a no-op.
+        assert_eq!(
+            migrate_www_html_file(&path).unwrap(),
+            FileMigrateOutcome::Unchanged
+        );
+    }
+
+    #[test]
+    fn migrate_dir_dry_run_and_apply() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("a.html"), r#"{{if .SSURL}}ss{{end}}"#).unwrap();
+        fs::write(dir.path().join("b.html"), r#"{{ MailDomain }}"#).unwrap();
+        fs::write(dir.path().join("note.txt"), "not html").unwrap();
+
+        let dry = migrate_www_dir(dir.path(), false).unwrap();
+        assert_eq!(dry.scanned, 2);
+        assert_eq!(dry.go_style_files.len(), 1);
+        assert!(dry.migrated.is_empty());
+        // File still Go-style after dry run.
+        assert!(looks_like_go_template(
+            &fs::read_to_string(dir.path().join("a.html")).unwrap()
+        ));
+
+        let applied = migrate_www_dir(dir.path(), true).unwrap();
+        assert_eq!(applied.migrated.len(), 1);
+        assert!(!looks_like_go_template(
+            &fs::read_to_string(dir.path().join("a.html")).unwrap()
+        ));
+        assert!(!looks_like_go_template(
+            &fs::read_to_string(dir.path().join("b.html")).unwrap()
+        ));
+    }
+
+    #[test]
+    fn scan_lists_go_files_only() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("go.html"), r#"{{.X}}"#).unwrap();
+        fs::write(dir.path().join("mj.html"), r#"{{ X }}"#).unwrap();
+        let found = scan_www_dir_for_go_templates(dir.path()).unwrap();
+        assert_eq!(found.len(), 1);
+        assert!(found[0].ends_with("go.html"));
+    }
+
+    /// Migrated on-disk HTML must still render via TemplateEngine (prepare is idempotent).
+    #[test]
+    fn migrate_then_render_matches_go_path() {
+        use crate::template::{TemplateEngine, WwwContext};
+        use chatmail_config::AppConfig;
+
+        let dir = tempfile::tempdir().unwrap();
+        let go = r#"<!DOCTYPE html>
+<html lang="{{.Language}}" dir="{{if eq .Language "fa"}}rtl{{else}}ltr{{end}}">
+<body>
+{{if .RegistrationOpen}}open{{else}}closed{{end}}
+<span>{{.MailDomain | cleanDomain}}</span>
+</body></html>"#;
+        fs::write(dir.path().join("index.html"), go).unwrap();
+
+        // Before migrate: external www still renders Go syntax via prepare_template.
+        let mut cfg = AppConfig::default();
+        cfg.www_dir = Some(dir.path().to_path_buf());
+        cfg.mail_domain = Some("example.org".into());
+        let engine = TemplateEngine::from_config(&cfg);
+        let ctx = WwwContext {
+            MailDomain: "example.org".into(),
+            MXDomain: String::new(),
+            WebDomain: "example.org".into(),
+            PublicIP: String::new(),
+            Version: "test".into(),
+            RegistrationOpen: true,
+            JitRegistrationEnabled: false,
+            Language: "en".into(),
+            ClientHost: String::new(),
+            ImapPortTLS: "993".into(),
+            ImapPortStartTLS: "143".into(),
+            SmtpPortTLS: "465".into(),
+            SmtpPortStartTLS: "587".into(),
+            DcloginImapSecurity: String::new(),
+            DcloginSmtpSecurity: String::new(),
+            DefaultQuota: 0,
+            SSURL: String::new(),
+            V2rayNGConfigWS: String::new(),
+            V2rayNGConfigGRPC: String::new(),
+            MessageRetentionLine: None,
+            Custom: None,
+        };
+        let before = engine.render("index.html", &ctx).unwrap();
+        assert!(before.contains("open"), "got: {before}");
+        assert!(before.contains("example.org"), "got: {before}");
+        assert!(
+            before.contains(r#"dir="ltr""#) || before.contains("dir=\"ltr\""),
+            "got: {before}"
+        );
+
+        migrate_www_dir(dir.path(), true).unwrap();
+        let after_src = fs::read_to_string(dir.path().join("index.html")).unwrap();
+        assert!(!looks_like_go_template(&after_src), "still go: {after_src}");
+        assert!(after_src.contains("{% if RegistrationOpen %}"));
+
+        // Engine re-reads disk; prepare_template on Minijinja is a no-op.
+        let engine2 = TemplateEngine::from_config(&cfg);
+        let after = engine2.render("index.html", &ctx).unwrap();
+        assert!(after.contains("open"), "got: {after}");
+        assert!(after.contains("example.org"), "got: {after}");
+        // Rendered output should not still contain Go markers.
+        assert!(!after.contains("{{if"));
+        assert!(!after.contains("{{."));
+    }
+
+    #[test]
+    fn prepare_template_idempotent_on_migrated_and_go() {
+        let go = r#"{{if .RegistrationOpen}}y{{else}}n{{end}} {{.MailDomain | cleanDomain}}"#;
+        let once = prepare_template(go);
+        let twice = prepare_template(&once);
+        assert_eq!(once, twice);
+        assert!(!looks_like_go_template(&once));
+    }
+
+    #[test]
+    fn migrate_does_not_touch_non_html() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("app.js"), r#"const x = "{{if .X}}";"#).unwrap();
+        fs::write(dir.path().join("main.css"), "/* {{.Foo}} */").unwrap();
+        let report = migrate_www_dir(dir.path(), true).unwrap();
+        assert_eq!(report.scanned, 0);
+        assert_eq!(
+            fs::read_to_string(dir.path().join("app.js")).unwrap(),
+            r#"const x = "{{if .X}}";"#
+        );
+    }
+}

--- a/crates/chatmail-www/src/www_migrate.rs
+++ b/crates/chatmail-www/src/www_migrate.rs
@@ -187,6 +187,109 @@ mod tests {
         ));
         assert!(looks_like_go_template(r#"hello {{.WebDomain}}"#));
         assert!(!looks_like_go_template(r#"hello {{ WebDomain }}"#));
+        // Operator custom pages often use `if not` (Go html/template).
+        assert!(looks_like_go_template(
+            r#"{{if not .RegistrationOpen}}registration closed{{end}}"#
+        ));
+    }
+
+    /// On-disk HTML with only `{{if not .Field}}` must convert and render closed/open correctly.
+    #[test]
+    fn migrate_if_not_registration_open_renders() {
+        use crate::template::{TemplateEngine, WwwContext};
+        use chatmail_config::AppConfig;
+
+        let dir = tempfile::tempdir().unwrap();
+        // Minimal snippet matching the failure mode (unexpected '.' in Minijinja).
+        let go = r#"<!DOCTYPE html><body>
+{{if not .RegistrationOpen}}registration is closed{{else}}registration is open{{end}}
+</body></html>"#;
+        fs::write(dir.path().join("index.html"), go).unwrap();
+
+        let cfg = AppConfig {
+            www_dir: Some(dir.path().to_path_buf()),
+            mail_domain: Some("example.org".into()),
+            ..Default::default()
+        };
+        let ctx_closed = WwwContext {
+            MailDomain: "example.org".into(),
+            MXDomain: String::new(),
+            WebDomain: "example.org".into(),
+            PublicIP: String::new(),
+            Version: "test".into(),
+            RegistrationOpen: false,
+            JitRegistrationEnabled: false,
+            Language: "en".into(),
+            ClientHost: String::new(),
+            ImapPortTLS: "993".into(),
+            ImapPortStartTLS: "143".into(),
+            SmtpPortTLS: "465".into(),
+            SmtpPortStartTLS: "587".into(),
+            DcloginImapSecurity: String::new(),
+            DcloginSmtpSecurity: String::new(),
+            DefaultQuota: 0,
+            SSURL: String::new(),
+            V2rayNGConfigWS: String::new(),
+            V2rayNGConfigGRPC: String::new(),
+            MessageRetentionLine: None,
+            Custom: None,
+        };
+        let mut ctx_open = ctx_closed.clone();
+        ctx_open.RegistrationOpen = true;
+
+        // Runtime prepare_template path (no on-disk migrate yet).
+        let engine = TemplateEngine::from_config(&cfg);
+        let rendered = engine.render("index.html", &ctx_closed).unwrap();
+        assert!(
+            rendered.contains("registration is closed"),
+            "got: {rendered}"
+        );
+        assert!(!rendered.contains("{{if"));
+        let rendered_open = engine.render("index.html", &ctx_open).unwrap();
+        assert!(
+            rendered_open.contains("registration is open"),
+            "got: {rendered_open}"
+        );
+
+        // On-disk migrate then re-render both branches.
+        let report = migrate_www_dir(dir.path(), true).unwrap();
+        assert_eq!(report.migrated.len(), 1);
+        let disk = fs::read_to_string(dir.path().join("index.html")).unwrap();
+        assert!(
+            disk.contains("{% if not RegistrationOpen %}"),
+            "disk: {disk}"
+        );
+        assert!(!looks_like_go_template(&disk));
+
+        let engine2 = TemplateEngine::from_config(&cfg);
+        let after = engine2.render("index.html", &ctx_closed).unwrap();
+        assert!(after.contains("registration is closed"), "got: {after}");
+        let after_open = engine2.render("index.html", &ctx_open).unwrap();
+        assert!(
+            after_open.contains("registration is open"),
+            "got: {after_open}"
+        );
+
+        // Second migrate is a no-op.
+        let again = migrate_www_dir(dir.path(), true).unwrap();
+        assert!(again.migrated.is_empty(), "expected idempotent migrate");
+    }
+
+    #[test]
+    fn migrate_detects_if_not_only_file() {
+        let dir = tempfile::tempdir().unwrap();
+        // File with ONLY `if not` (no `{{if .` / `{{.Field}}`) must still be detected.
+        fs::write(
+            dir.path().join("closed.html"),
+            r#"{{if not .RegistrationOpen}}closed{{end}}"#,
+        )
+        .unwrap();
+        let found = scan_www_dir_for_go_templates(dir.path()).unwrap();
+        assert_eq!(found.len(), 1);
+        let report = migrate_www_dir(dir.path(), true).unwrap();
+        assert_eq!(report.migrated.len(), 1);
+        let body = fs::read_to_string(dir.path().join("closed.html")).unwrap();
+        assert_eq!(body, "{% if not RegistrationOpen %}closed{% endif %}");
     }
 
     #[test]

--- a/crates/chatmail/src/ctl/dispatch.rs
+++ b/crates/chatmail/src/ctl/dispatch.rs
@@ -33,7 +33,7 @@ pub async fn dispatch(cli: &Cli) -> Result<()> {
             "internal error: dispatch called for server run",
         )),
         Some(Command::Upgrade { path_or_url }) | Some(Command::Update { path_or_url }) => {
-            crate::upgrade::upgrade_command(path_or_url, cli.args.json)
+            crate::upgrade::upgrade_command(path_or_url, &cli.args)
         }
         Some(Command::AdminToken { raw, no_qr }) => {
             admin_token::admin_token(&cli.args, *raw, *no_qr).await
@@ -55,6 +55,7 @@ pub async fn dispatch(cli: &Cli) -> Result<()> {
         }) => delete_cmd::delete(&cli.args, username, *yes, reason).await,
         Some(Command::HtmlExport { dest }) => html::html_export(&cli.args, dest).await,
         Some(Command::HtmlServe { www_dir }) => html::html_serve(&cli.args, www_dir).await,
+        Some(Command::HtmlMigrate { yes }) => html::html_migrate(&cli.args, *yes).await,
         Some(Command::Language { command }) => {
             language::language(&cli.args, command.as_ref()).await
         }
@@ -112,7 +113,7 @@ fn not_implemented(cmd: &Command) -> Result<()> {
          See docs/TDD/14-cli-tools.md and context/madmail/docs/chatmail/commands.md.\n\
          Implemented: run, upgrade, update, version, admin-token, admin-web, install, certificate, \
          accounts, ban-list, blocklist, create-user, delete, registration, language, \
-         html-export, html-serve, webimap, websmtp, webmail-cors, push, federation, registration-tokens, sharing, \
+         html-export, html-serve, html-migrate, webimap, websmtp, webmail-cors, push, federation, registration-tokens, sharing, \
          status, uninstall, endpoint-cache, port, proxy, reload, message-size, tasks, completion"
     )))
 }
@@ -136,6 +137,7 @@ fn command_name(cmd: &Command) -> &'static str {
         Command::Hash => "hash",
         Command::HtmlExport { .. } => "html-export",
         Command::HtmlServe { .. } => "html-serve",
+        Command::HtmlMigrate { .. } => "html-migrate",
         Command::ImapMboxes => "imap-mboxes",
         Command::ImapMsgs => "imap-msgs",
         Command::ImapAcct => "imap-acct",

--- a/crates/chatmail/src/ctl/html.rs
+++ b/crates/chatmail/src/ctl/html.rs
@@ -15,17 +15,18 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-//! `chatmail html-export` / `html-serve` (Madmail `ctl/html.go`).
+//! `chatmail html-export` / `html-serve` / `html-migrate` (Madmail `ctl/html.go`).
 
+use std::io::IsTerminal;
 use std::path::Path;
 
-use chatmail_config::update_config_www_dir;
-use chatmail_config::Args;
+use chatmail_config::{load_config, update_config_www_dir, Args};
 use chatmail_types::{ChatmailError, Result};
-use chatmail_www::export_www_files;
+use chatmail_www::{export_www_files, migrate_www_dir};
 
 use super::context::CtlContext;
 use super::output::CtlOut;
+use super::util::confirm;
 
 pub async fn html_export(args: &Args, dest: &Path) -> Result<()> {
     let _ = CtlContext::from_args(args)?;
@@ -110,4 +111,161 @@ pub async fn html_serve(args: &Args, www_dir: &str) -> Result<()> {
     out.blank();
     out.line("Restart chatmail to apply: sudo systemctl restart madmail");
     Ok(())
+}
+
+/// Convert custom `www_dir` Go `html/template` files to Minijinja on disk.
+///
+/// Used interactively by operators and non-interactively from `madmail update`
+/// (re-exec of the new binary after replace).
+pub async fn html_migrate(args: &Args, yes: bool) -> Result<()> {
+    let _ = CtlContext::from_args(args)?;
+    let out = CtlOut::from_args(args, "html-migrate");
+
+    if !args.config.is_file() {
+        return Err(ChatmailError::config(format!(
+            "config file not found: {} — pass --config",
+            args.config.display()
+        )));
+    }
+
+    let cfg = load_config(&args.config)?;
+    let Some(www_dir) = cfg.www_dir.as_ref() else {
+        let msg = "No custom www_dir in config (embedded site); nothing to migrate.";
+        return out.done_msg(
+            msg,
+            serde_json::json!({
+                "config": args.config.display().to_string(),
+                "www_dir": null,
+                "action": "noop_embedded",
+            }),
+            msg,
+        );
+    };
+
+    if !www_dir.is_dir() {
+        return Err(ChatmailError::config(format!(
+            "www_dir is set but not a directory: {}",
+            www_dir.display()
+        )));
+    }
+
+    let dry = migrate_www_dir(www_dir, false)?;
+    if dry.go_style_files.is_empty() {
+        let msg = format!(
+            "Custom www_dir {} has no Go-style HTML templates (already Minijinja or no templates).",
+            www_dir.display()
+        );
+        return out.done_msg(
+            &msg,
+            serde_json::json!({
+                "config": args.config.display().to_string(),
+                "www_dir": www_dir.display().to_string(),
+                "scanned": dry.scanned,
+                "go_style_files": dry.go_style_files,
+                "action": "noop_already_migrated",
+            }),
+            "No Go-style templates found",
+        );
+    }
+
+    if !out.is_json() {
+        out.line(format!(
+            "Found {} Go-style HTML template(s) under {}:",
+            dry.go_style_files.len(),
+            www_dir.display()
+        ));
+        for (i, f) in dry.go_style_files.iter().enumerate() {
+            if i >= 12 {
+                out.line(format!(
+                    "  … and {} more",
+                    dry.go_style_files.len().saturating_sub(12)
+                ));
+                break;
+            }
+            out.line(format!("  - {f}"));
+        }
+        out.blank();
+        out.line(
+            "madmail-v2 uses Minijinja. Converting rewrites these files in place \
+             (creates .go-template.bak backups).",
+        );
+    }
+
+    let interactive = std::io::stdin().is_terminal() && !out.is_json();
+    let should_apply = if yes {
+        true
+    } else if interactive {
+        confirm(
+            "Convert custom www templates from Go html/template style to Minijinja?",
+            false,
+        )?
+    } else {
+        if !out.is_json() {
+            out.line(
+                "Non-interactive session: not converting. Re-run with: \
+                 madmail html-migrate --yes",
+            );
+        }
+        return out.done_msg(
+            "Skipped (non-interactive; pass --yes to convert)",
+            serde_json::json!({
+                "config": args.config.display().to_string(),
+                "www_dir": www_dir.display().to_string(),
+                "scanned": dry.scanned,
+                "go_style_files": dry.go_style_files,
+                "action": "skipped_noninteractive",
+            }),
+            "Skipped non-interactive",
+        );
+    };
+
+    if !should_apply {
+        return out.done_msg(
+            "Left custom www templates unchanged.",
+            serde_json::json!({
+                "config": args.config.display().to_string(),
+                "www_dir": www_dir.display().to_string(),
+                "scanned": dry.scanned,
+                "go_style_files": dry.go_style_files,
+                "action": "declined",
+            }),
+            "Declined",
+        );
+    }
+
+    let report = migrate_www_dir(www_dir, true)?;
+    if !out.is_json() {
+        out.line(format!(
+            "Migrated {} file(s); backups: {}",
+            report.migrated.len(),
+            report.backups.len()
+        ));
+        for f in &report.migrated {
+            out.line(format!("  ✓ {f}"));
+        }
+        if !report.errors.is_empty() {
+            for e in &report.errors {
+                out.line(format!("  ⚠ {e}"));
+            }
+        }
+    }
+
+    out.done_msg(
+        format!(
+            "Migrated {} template(s) under {}",
+            report.migrated.len(),
+            www_dir.display()
+        ),
+        serde_json::json!({
+            "config": args.config.display().to_string(),
+            "www_dir": www_dir.display().to_string(),
+            "scanned": report.scanned,
+            "go_style_files": report.go_style_files,
+            "migrated": report.migrated,
+            "backups": report.backups,
+            "errors": report.errors,
+            "action": "migrated",
+        }),
+        format!("Migrated {} file(s)", report.migrated.len()),
+    )
 }

--- a/crates/chatmail/src/upgrade.rs
+++ b/crates/chatmail/src/upgrade.rs
@@ -24,6 +24,7 @@ use std::process::Command;
 use std::thread;
 use std::time::Duration;
 
+use chatmail_config::Args;
 use chatmail_types::{ChatmailError, Result};
 use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use reqwest::blocking::Client;
@@ -73,17 +74,17 @@ fn is_download_url(input: &str) -> bool {
 }
 
 /// Entry point for `chatmail upgrade` and `chatmail update` (Madmail `upgradeCommand`).
-pub fn upgrade_command(input: &str, json: bool) -> Result<()> {
+pub fn upgrade_command(input: &str, args: &Args) -> Result<()> {
     let input = input.trim();
     if input.is_empty() {
         return Err(ChatmailError::config("PATH or URL is required"));
     }
     let result = if is_download_url(input) {
-        handle_update_url(input)
+        handle_update_url(input, args)
     } else {
-        perform_upgrade(Path::new(input))
+        perform_upgrade(Path::new(input), args)
     };
-    if result.is_ok() && json {
+    if result.is_ok() && args.json {
         let envelope = serde_json::json!({
             "ok": true,
             "command": "upgrade",
@@ -105,7 +106,7 @@ fn build_download_client() -> Result<Client> {
 }
 
 /// Download signed binary to a temp file, then run `perform_upgrade` (Madmail `handleUpdateURL`).
-fn handle_update_url(url: &str) -> Result<()> {
+fn handle_update_url(url: &str, args: &Args) -> Result<()> {
     let tmp_path = std::env::temp_dir().join(format!("madmail-update-{}", std::process::id()));
     let mut tmp_file = File::create(&tmp_path).map_err(|e| {
         ChatmailError::config(format!(
@@ -167,7 +168,7 @@ fn handle_update_url(url: &str) -> Result<()> {
         .len();
     eprintln!("✅ Downloaded {n} bytes");
 
-    let result = perform_upgrade(&tmp_path);
+    let result = perform_upgrade(&tmp_path, args);
     cleanup();
     result
 }
@@ -185,7 +186,7 @@ fn run_systemctl(args: &[&str]) {
 }
 
 /// Upgrade in place: verify signature, stop service, replace executable, start service.
-pub fn perform_upgrade(new_bin_path: &Path) -> Result<()> {
+pub fn perform_upgrade(new_bin_path: &Path, args: &Args) -> Result<()> {
     eprintln!("🔍 Verifying digital signature...");
     match verify_signature(new_bin_path)? {
         true => eprintln!("✅ Signature verification successful."),
@@ -240,6 +241,10 @@ pub fn perform_upgrade(new_bin_path: &Path) -> Result<()> {
         ChatmailError::config(format!("failed to replace binary: {e}"))
     })?;
 
+    // Run post-upgrade hooks from the *new* binary so first upgrades that ship
+    // html-migrate still work (this process is still the old code).
+    run_post_upgrade_www_migrate(&real_bin_path, args);
+
     eprintln!("▶️ Starting services...");
     if !Command::new("systemctl")
         .args(["start", &service])
@@ -269,6 +274,57 @@ pub fn perform_upgrade(new_bin_path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Ask the new binary to migrate custom `www_dir` Go templates (interactive).
+fn run_post_upgrade_www_migrate(new_bin: &Path, args: &Args) {
+    if !args.config.is_file() {
+        eprintln!(
+            "ℹ️ Config not found at {} — skipping custom www template check \
+             (run: madmail --config <path> html-migrate)",
+            args.config.display()
+        );
+        return;
+    }
+
+    // Never re-exec with --json: child would print a second JSON envelope on stdout
+    // and break scripted `madmail update --json` parsers. Operators can migrate later.
+    if args.json {
+        eprintln!(
+            "ℹ️ --json upgrade: not prompting for www template migration. \
+             If you use a custom www_dir with Go templates, run: \
+             madmail --config {} html-migrate",
+            args.config.display()
+        );
+        return;
+    }
+
+    eprintln!("🌐 Checking custom www templates (Go → Minijinja)...");
+    let mut cmd = Command::new(new_bin);
+    cmd.arg("--config").arg(&args.config).arg("html-migrate");
+    // Inherit stdin so interactive [y/N] works when the operator is at a TTY.
+    cmd.stdin(std::process::Stdio::inherit())
+        .stdout(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit());
+
+    match cmd.status() {
+        Ok(st) if st.success() => {}
+        Ok(st) => {
+            eprintln!(
+                "⚠️ html-migrate exited with status {st} — you can re-run: \
+                 madmail --config {} html-migrate",
+                args.config.display()
+            );
+        }
+        Err(e) => {
+            eprintln!(
+                "⚠️ Could not run html-migrate on the new binary ({e}). \
+                 If you use a custom www_dir with Go templates, run: \
+                 madmail --config {} html-migrate",
+                args.config.display()
+            );
+        }
+    }
+}
+
 /// Rewrite man page and shell tab-completion scripts after the binary is replaced.
 fn refresh_cli_docs_after_upgrade() {
     let name = crate::ctl::argv_binary_name();
@@ -296,7 +352,13 @@ mod tests {
 
     #[test]
     fn upgrade_command_requires_input() {
-        let err = upgrade_command("  ", false).unwrap_err();
+        let args = Args {
+            config: PathBuf::from("/nonexistent/madmail.conf"),
+            state_dir: PathBuf::from("/tmp"),
+            boot_once: false,
+            json: false,
+        };
+        let err = upgrade_command("  ", &args).unwrap_err();
         assert!(err.to_string().contains("PATH or URL is required"));
     }
 }

--- a/docs/guide/cli/README.md
+++ b/docs/guide/cli/README.md
@@ -244,6 +244,9 @@ Alias: [`pr`](pr.md).
 
 ### [`html-serve`](html-serve.md)
 
+
+### [`html-migrate`](html-migrate.md)
+
 ## IMAP tooling
 
 ### [`imap-acct`](imap-acct.md) *(planned)*

--- a/docs/guide/cli/html-migrate.md
+++ b/docs/guide/cli/html-migrate.md
@@ -30,10 +30,18 @@ madmail html-migrate --yes
 
 1. Reads `www_dir` from the config (`chatmail { www_dir … }` or `www_dir` in TOML).
 2. If **no** custom `www_dir` (embedded site) → nothing to do.
-3. Scans `*.html` under `www_dir` for Go-style markers (`{{if .Field}}`, `{{.MailDomain}}`, `| cleanDomain`, …).
+3. Scans `*.html` under `www_dir` for Go-style markers (`{{if .Field}}`, `{{if not .Field}}`, `{{.MailDomain}}`, `| cleanDomain`, …).
 4. If none found → already Minijinja-style (or no templates).
 5. If found → list sample paths and ask **`[y/N]`** (unless `--yes`).
 6. On yes: rewrite files in place using the same conversion as the server (`prepare_template`), writing a sibling `*.go-template.bak` backup for each changed file.
+
+Converted examples:
+
+| Go (`html/template`) | Minijinja (on disk / after convert) |
+|----------------------|-------------------------------------|
+| `{{if .RegistrationOpen}}…{{end}}` | `{% if RegistrationOpen %}…{% endif %}` |
+| `{{if not .RegistrationOpen}}…{{end}}` | `{% if not RegistrationOpen %}…{% endif %}` |
+| `{{.MailDomain \| cleanDomain}}` | `{{ MailDomain \| clean_domain }}` |
 
 ## Examples
 

--- a/docs/guide/cli/html-migrate.md
+++ b/docs/guide/cli/html-migrate.md
@@ -1,0 +1,68 @@
+# `html-migrate`
+
+Convert a custom `www_dir` from **Go `html/template`** syntax to **Minijinja** (madmail-v2) on disk.
+
+Use this after a Go Madmail → madmail-v2 upgrade if you customized public HTML pages. The same check runs automatically during [`update`](update.md) / [`upgrade`](upgrade.md) (interactive prompt).
+
+
+## Synopsis
+
+```bash
+madmail html-migrate
+madmail html-migrate --yes
+```
+
+## Global flags
+
+| Flag | Alias | Environment | Default | Description |
+|------|-------|-------------|---------|-------------|
+| `--config` | — | `CHATMAIL_CONFIG` | `/etc/madmail/madmail.conf` (or `./data/chatmail.toml` when present) | Path to the server config file |
+| `--state-dir` | `--libexec` | `CHATMAIL_STATE_DIR` | `/var/lib/madmail` (or `./data` when it contains state) | Persistent state directory |
+
+
+## Arguments / flags
+
+| Flag | Description |
+|------|-------------|
+| `-y`, `--yes` | Apply conversion without prompting (for scripts / non-interactive upgrades) |
+
+## Behavior
+
+1. Reads `www_dir` from the config (`chatmail { www_dir … }` or `www_dir` in TOML).
+2. If **no** custom `www_dir` (embedded site) → nothing to do.
+3. Scans `*.html` under `www_dir` for Go-style markers (`{{if .Field}}`, `{{.MailDomain}}`, `| cleanDomain`, …).
+4. If none found → already Minijinja-style (or no templates).
+5. If found → list sample paths and ask **`[y/N]`** (unless `--yes`).
+6. On yes: rewrite files in place using the same conversion as the server (`prepare_template`), writing a sibling `*.go-template.bak` backup for each changed file.
+
+## Examples
+
+```bash
+# Interactive (recommended once after Go → v2)
+sudo madmail --config /etc/maddy/maddy.conf html-migrate
+
+# Scripted
+sudo madmail --config /etc/maddy/maddy.conf html-migrate --yes
+```
+
+## Notes
+
+- Runtime still accepts many Go forms via conversion at render time; migrating on disk is for durable, editor-friendly Minijinja sources.
+- Non-interactive sessions without `--yes` skip conversion and print how to re-run with `--yes`.
+- After migration, `madmail reload` or a service restart picks up the files (live `www_dir` re-reads HTML).
+
+## JSON output (`--json`)
+
+```bash
+madmail html-migrate --json --yes
+```
+
+Success stdout includes `action` (`noop_embedded`, `noop_already_migrated`, `skipped_noninteractive`, `declined`, `migrated`) and file lists.
+
+Schema: [json-output.md](json-output.md#html-migrate).
+
+
+---
+[← CLI index](README.md) · [Global flags](global-flags.md) · [html-serve](html-serve.md) · [update](update.md)
+
+[Source: `crates/chatmail/src/ctl/html.rs`, `crates/chatmail-www/src/www_migrate.rs`](https://github.com/themadorg/madmail/blob/main/crates/chatmail/src/ctl/html.rs)

--- a/docs/guide/cli/json-output.md
+++ b/docs/guide/cli/json-output.md
@@ -1026,6 +1026,28 @@ Certificate renewal task:
 
 Setting `embedded` reverts to built-in HTML.
 
+### `html-migrate`
+
+```json
+{
+  "ok": true,
+  "command": "html-migrate",
+  "message": "Migrated 3 file(s)",
+  "data": {
+    "config": "/etc/maddy/maddy.conf",
+    "www_dir": "/var/lib/maddy/www",
+    "scanned": 12,
+    "go_style_files": ["index.html", "info.html"],
+    "migrated": ["index.html", "info.html"],
+    "backups": ["/var/lib/maddy/www/index.html.go-template.bak"],
+    "errors": [],
+    "action": "migrated"
+  }
+}
+```
+
+`action` may be `noop_embedded`, `noop_already_migrated`, `skipped_noninteractive`, `declined`, or `migrated`. Use `--yes` with `--json` to apply without a TTY.
+
 ---
 
 ## Planned commands

--- a/docs/guide/cli/update.md
+++ b/docs/guide/cli/update.md
@@ -30,7 +30,7 @@ madmail update /tmp/madmail-signed
 madmail update https://relay.example/releases/madmail
 ```
 
-See [upgrade](upgrade.md) for full behavior (signature verify, systemd stop/replace/start).
+See [upgrade](upgrade.md) for full behavior (signature verify, systemd stop/replace/start, custom www template migration).
 
 ## JSON output (`--json`)
 

--- a/docs/guide/cli/upgrade.md
+++ b/docs/guide/cli/upgrade.md
@@ -27,7 +27,10 @@ madmail upgrade <PATH_OR_URL>
 
 1. Downloads the file if a URL is given (TLS verification is skipped for self-signed peers).
 2. Verifies an **Ed25519 signature** in the last 64 bytes of the file.
-3. Replaces the current executable and restarts the systemd service when applicable.
+3. Stops the systemd service (and iroh-relay when present).
+4. Replaces the current executable.
+5. **Custom www templates:** runs the new binary’s [`html-migrate`](html-migrate.md) against `--config`. If `www_dir` points at a custom site that still uses Go `html/template` syntax, you are prompted to convert files to Minijinja (backups as `*.go-template.bak`). Decline or non-interactive sessions leave files unchanged; re-run `madmail html-migrate` later if needed.
+6. Restarts the systemd service when applicable and refreshes man/completions.
 
 ## Examples
 

--- a/docs/man/madmail.1
+++ b/docs/man/madmail.1
@@ -81,6 +81,8 @@ preserve selected artifacts.\&
 \fBupgrade\fR, \fBupdate\fR
 .RS 4
 Replace this executable from a signed local file or URL.\&
+After replace, may prompt to convert custom \fBwww_dir\fR Go templates
+to Minijinja (see \fBhtml-migrate\fR).\&
 .PP
 .RE
 \fBreload\fR
@@ -231,6 +233,12 @@ Export default HTML/CSS assets to a directory.\&
 .RS 4
 Serve the web UI from an external directory (\fBembedded\fR reverts to
 built-in files).\&
+.PP
+.RE
+\fBhtml-migrate\fR
+.RS 4
+Convert custom \fBwww_dir\fR HTML from Go \fBhtml/template\fR syntax to
+Minijinja (interactive; \fB--yes\fR for scripts).\&
 .PP
 .RE
 \fBhash\fR

--- a/docs/man/madmail.1.scd
+++ b/docs/man/madmail.1.scd
@@ -67,6 +67,8 @@ Extended documentation:
 
 *upgrade*, *update*
 	Replace this executable from a signed local file or URL.
+	After replace, may prompt to convert custom *www_dir* Go templates
+	to Minijinja (see *html\-migrate*).
 
 *reload*
 	Apply database configuration overrides and restart via the admin API.
@@ -163,6 +165,10 @@ Extended documentation:
 *html\-serve*
 	Serve the web UI from an external directory (*embedded* reverts to
 	built\-in files).
+
+*html\-migrate*
+	Convert custom *www_dir* HTML from Go *html/template* syntax to
+	Minijinja (interactive; *--yes* for scripts).
 
 *hash*
 	Generate password hashes for *pass_table* configuration.

--- a/docs/project/user-guide/17-customizing-html-pages.md
+++ b/docs/project/user-guide/17-customizing-html-pages.md
@@ -102,6 +102,18 @@ after changing files in your `www_dir`. A full restart is rarely required for HT
 
 Users may need to do a hard refresh (Ctrl+Shift+R or Cmd+Shift+R) in their browser to see updated static assets.
 
+## Go Madmail → madmail-v2 (template syntax)
+
+Older Go Madmail pages used Go `html/template` markers such as `{{if .RegistrationOpen}}` and `{{.MailDomain | cleanDomain}}`. madmail-v2 renders with **Minijinja** (`{% if RegistrationOpen %}`, `{{ MailDomain | clean_domain }}`).
+
+If you keep a customized `www_dir` from Go Madmail:
+
+1. After binary upgrade, `madmail update` / `upgrade` offers to convert those files (or run `madmail html-migrate` yourself).
+2. Accepting creates `*.go-template.bak` backups and rewrites HTML in place.
+3. The server can still convert many Go forms at render time, but migrating on disk keeps your sources consistent with the v2 engine.
+
+See the CLI reference: [html-migrate](../../guide/cli/html-migrate.md).
+
 ## Common Examples
 
 - Community servers adding local rules and support contact information.

--- a/docs/project/user-guide/17-customizing-html-pages.md
+++ b/docs/project/user-guide/17-customizing-html-pages.md
@@ -104,7 +104,9 @@ Users may need to do a hard refresh (Ctrl+Shift+R or Cmd+Shift+R) in their brows
 
 ## Go Madmail → madmail-v2 (template syntax)
 
-Older Go Madmail pages used Go `html/template` markers such as `{{if .RegistrationOpen}}` and `{{.MailDomain | cleanDomain}}`. madmail-v2 renders with **Minijinja** (`{% if RegistrationOpen %}`, `{{ MailDomain | clean_domain }}`).
+Older Go Madmail pages used Go `html/template` markers such as `{{if .RegistrationOpen}}`, **`{{if not .RegistrationOpen}}`**, and `{{.MailDomain | cleanDomain}}`. madmail-v2 renders with **Minijinja** (`{% if RegistrationOpen %}`, `{% if not RegistrationOpen %}`, `{{ MailDomain | clean_domain }}`).
+
+Leaving Go `{{if not .…}}` unconverted caused template errors (`unexpected '.'`). Runtime conversion and `html-migrate` both handle that form.
 
 If you keep a customized `www_dir` from Go Madmail:
 


### PR DESCRIPTION
## Summary

When operators customize the public site via `www_dir` (often exported from Go Madmail), HTML may still use Go `html/template` syntax (`{{if .Field}}`, `{{.MailDomain | cleanDomain}}`, …). madmail-v2 renders with Minijinja; runtime conversion exists, but on-disk sources can break or diverge after Go → v2 upgrade.

This PR:

1. **Detects** Go-style markers on custom `www_dir` HTML.
2. **Converts** using the same `prepare_template` path as the server (not a separate sed).
3. **`madmail html-migrate`** — interactive prompt (or `--yes`); writes `*.go-template.bak` backups.
4. **`madmail update` / `upgrade`** — after binary replace, re-execs the *new* binary’s `html-migrate` so the first upgrade that ships this feature still prompts. `--json` upgrades skip the child so scripted stdout stays a single JSON envelope.

Fixes #86

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Build / CI / tooling
- [ ] Refactor (no functional change)

## Area

- [ ] SMTP
- [ ] IMAP
- [ ] Federation / delivery queue
- [ ] Authentication / JIT
- [ ] Admin API / admin web UI (`external/madmail-admin-web`)
- [ ] TURN / Iroh / proxy services
- [ ] Storage / quota / DB migrations
- [x] Configuration / CLI
- [x] Docs (`docs/project/`, `docs/TDD/`, user guide)
- [x] Other: public www / html-serve custom templates

## Testing

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (or targeted crate/tests: chatmail-www 66/66; chatmail 100/100; chatmail-config 97/97)
- [x] Manual / E2E verification (describe below)

**Manual verification (if any):**

```text
# Unit / integration
- looks_like_go_template vs pure Minijinja
- migrate_file: backup + convert + idempotent second pass
- migrate_dir dry-run vs apply; non-HTML untouched
- migrate_then_render_matches_go_path (Go and post-migrate both render)
- prepare_template idempotent
- external_www_go_template_syntax still passes (runtime bridge intact)
- www_index_renders, live_reload, embedded RAM site, webimap/ws suite green
- upgrade_command still requires PATH/URL; --json upgrade does not re-exec with --json
- clap: html-migrate / html-migrate -y

# Safety checks
- No www_dir → noop (embedded)
- Already Minijinja → noop
- Non-interactive without --yes → skip (no file writes)
- Decline confirm → no writes
- Only *.html under www_dir; CSS/JS unchanged
```

## Documentation

- [ ] No doc updates needed
- [x] Updated operator/user docs (`docs/project/user-guide/`, install guides)
- [ ] Updated developer docs (`docs/project/`)
- [ ] Updated or added TDD section (`docs/TDD/`) — required for significant design changes

Also: `docs/guide/cli/html-migrate.md`, update/upgrade, json-output, man page.

## Security & privacy

- [x] Not security-sensitive
- [ ] Security-sensitive — added/updated tests for the security property
- [ ] Reviewed error messages for information leakage

## Commits

- `feat:` new feature

## Checklist

- [x] PR is focused and reviewable (small vertical slices preferred)
- [x] No secrets, `data/`, `target/`, or `node_modules/` committed
- [ ] Submodule pointers updated if `external/madmail-admin-web` changed
- [x] Behavior parity with Madmail v1 considered (or intentional difference documented)