### PR TITLE
fix(webimap): unblock multi-mailbox image publish (search + create_mailbox)

### DIFF
--- a/crates/chatmail-delivery/src/federation_smtp.rs
+++ b/crates/chatmail-delivery/src/federation_smtp.rs
@@ -169,9 +169,7 @@ async fn deliver_plain_starttls(
     let mut transport = SmtpTransport::Plain(stream);
     read_smtp_reply(&mut transport, 220).await?;
 
-    transport
-        .write_all(format!("EHLO {helo_name}\r\n"))
-        .await?;
+    transport.write_all(format!("EHLO {helo_name}\r\n")).await?;
     let ehlo_plain = read_smtp_reply(&mut transport, 250).await?;
 
     if ehlo_advertises_starttls(&ehlo_plain) {
@@ -192,9 +190,7 @@ async fn deliver_plain_starttls(
         .map_err(|e| format!("smtp starttls: {e}"))?;
 
         transport = SmtpTransport::Tls(Box::new(tls_stream));
-        transport
-            .write_all(format!("EHLO {helo_name}\r\n"))
-            .await?;
+        transport.write_all(format!("EHLO {helo_name}\r\n")).await?;
         read_smtp_reply(&mut transport, 250).await?;
     }
 
@@ -227,9 +223,7 @@ async fn deliver_implicit_tls(
 
     let mut transport = SmtpTransport::Tls(Box::new(tls_stream));
     read_smtp_reply(&mut transport, 220).await?;
-    transport
-        .write_all(format!("EHLO {helo_name}\r\n"))
-        .await?;
+    transport.write_all(format!("EHLO {helo_name}\r\n")).await?;
     read_smtp_reply(&mut transport, 250).await?;
 
     run_smtp_transaction(&mut transport, job).await?;

--- a/crates/chatmail-www/src/webimap.rs
+++ b/crates/chatmail-www/src/webimap.rs
@@ -189,16 +189,6 @@ fn chrono_lite_now() -> String {
     format!("{secs}")
 }
 
-pub(crate) async fn load_entries(
-    st: &WwwState,
-    user: &str,
-    cors: &CorsSnap,
-) -> Result<Vec<InboxEntry>, Response> {
-    load_mailbox_entries(st, user, "INBOX")
-        .await
-        .map_err(|e| json_err(StatusCode::BAD_REQUEST, &e, cors))
-}
-
 pub(crate) async fn load_mailbox_entries(
     st: &WwwState,
     user: &str,
@@ -232,7 +222,10 @@ pub(crate) async fn user_mailbox_exists(st: &WwwState, user: &str, mailbox: &str
     mailbox_exists(&st.app.mailbox_store, user, mailbox).await
 }
 
-pub(crate) async fn list_user_mailboxes(st: &WwwState, user: &str) -> Result<Vec<MailboxInfo>, String> {
+pub(crate) async fn list_user_mailboxes(
+    st: &WwwState,
+    user: &str,
+) -> Result<Vec<MailboxInfo>, String> {
     let mut names = vec!["INBOX".to_string()];
     let folders = st
         .app
@@ -590,7 +583,11 @@ pub(crate) async fn search_messages(
     Ok(out)
 }
 
-pub(crate) async fn create_user_mailbox(st: &WwwState, user: &str, name: &str) -> Result<(), String> {
+pub(crate) async fn create_user_mailbox(
+    st: &WwwState,
+    user: &str,
+    name: &str,
+) -> Result<(), String> {
     let name = name.trim();
     if name.is_empty() {
         return Err("missing mailbox name".into());
@@ -606,7 +603,11 @@ pub(crate) async fn create_user_mailbox(st: &WwwState, user: &str, name: &str) -
     Ok(())
 }
 
-pub(crate) async fn delete_user_mailbox(st: &WwwState, user: &str, name: &str) -> Result<(), String> {
+pub(crate) async fn delete_user_mailbox(
+    st: &WwwState,
+    user: &str,
+    name: &str,
+) -> Result<(), String> {
     if name.eq_ignore_ascii_case("INBOX") {
         return Err("cannot delete INBOX".into());
     }
@@ -827,7 +828,10 @@ mod tests {
 
         let uid = summaries[0].uid;
         delete_uid(&st, USER, "INBOX", uid).await.unwrap();
-        assert!(summaries_since(&st, USER, "INBOX", 0).await.unwrap().is_empty());
+        assert!(summaries_since(&st, USER, "INBOX", 0)
+            .await
+            .unwrap()
+            .is_empty());
     }
 
     #[tokio::test]

--- a/crates/chatmail-www/src/webimap_ws.rs
+++ b/crates/chatmail-www/src/webimap_ws.rs
@@ -690,6 +690,18 @@ mod tests {
         assert_eq!(created.action, "result");
         assert_eq!(created.data["status"], "created");
 
+        let listed = handle_ws_request(&st, USER, &ws_req("list_mailboxes", json!({}))).await;
+        assert_eq!(listed.action, "result");
+        let names: Vec<&str> = listed
+            .data
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|m| m["name"].as_str())
+            .collect();
+        assert!(names.contains(&"INBOX"));
+        assert!(names.contains(&"Archive"));
+
         let renamed = handle_ws_request(
             &st,
             USER,
@@ -710,6 +722,26 @@ mod tests {
         .await;
         assert_eq!(deleted.action, "result");
         assert_eq!(deleted.data["status"], "deleted");
+    }
+
+    #[tokio::test]
+    async fn search_matches_subject_and_body() {
+        let (st, _dir) = test_www_state().await;
+        seed_inbox(&st).await;
+        let hit =
+            handle_ws_request(&st, USER, &ws_req("search", json!({ "query": "WS test" }))).await;
+        assert_eq!(hit.action, "result");
+        assert_eq!(hit.data.as_array().unwrap().len(), 1);
+        assert_eq!(hit.data[0]["envelope"]["subject"], "WS test");
+
+        let miss = handle_ws_request(
+            &st,
+            USER,
+            &ws_req("search", json!({ "query": "no-such-token-xyz" })),
+        )
+        .await;
+        assert_eq!(miss.action, "result");
+        assert!(miss.data.as_array().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/docs/TDD/10-webimap.md
+++ b/docs/TDD/10-webimap.md
@@ -76,13 +76,15 @@ Server reply:
 
 | Action | Gate | Status |
 |--------|------|--------|
-| `list_mailboxes` | WebIMAP | Implemented (INBOX) |
+| `list_mailboxes` | WebIMAP | Implemented (INBOX + user folders under `folders/`) |
 | `list_messages` | WebIMAP | Implemented |
 | `fetch` | WebIMAP | Implemented |
 | `delete` | WebIMAP | Implemented |
 | `flags` | WebIMAP | Ack only (maildir) |
 | `send` | WebSMTP | Implemented |
-| `move`, `copy`, `search`, mailbox CRUD | WebIMAP | Error: INBOX-only storage |
+| `search` | WebIMAP | Implemented (INBOX full-text over subject/from/body/Message-ID) |
+| `create_mailbox` / `rename_mailbox` / `delete_mailbox` | WebIMAP | Implemented (maildir subfolders; cannot touch INBOX) |
+| `copy` / `move` | WebIMAP | Implemented between INBOX and user folders |
 
 Push (no `req_id`):
 
@@ -94,8 +96,9 @@ Poll interval: 2s; also wakes on `AppState` mailbox events.
 
 ## Deviations from full IMAP backend (Madmail Go)
 
-- Single mailbox **INBOX** backed by maildir index (`chatmail-storage`)
-- No EXPUNGE/move/copy/search across folders until multi-mailbox storage lands
+- Default delivery is still **INBOX** maildir; user folders live under per-user `folders/`
+- SEARCH is a simple substring scan (not full IMAP SEARCH criteria)
+- Flags are acknowledged without durable flag persistence (maildir v1)
 - REST long-poll uses sleep loop (not IMAP IDLE)
 
 ## Testing


### PR DESCRIPTION
## Summary

Madcore E2E against `ghcr.io/themadorg/madmail:latest` still fails with:

- `WS/search — not supported on this server (INBOX-only storage)`
- `WS/create_mailbox — not supported on this server (INBOX-only storage)`

Those handlers were **already implemented** on `main` (`bc58b0c`), but that push’s **Lint** job failed `cargo fmt`, so **Build + Docker push never ran**. GHCR `:latest` is still the pre-multi-mailbox binary.

This PR:

1. **rustfmt** the multi-mailbox webimap code (and a pre-existing `federation_smtp` fmt drift)
2. Removes unused `load_entries` so **clippy -D warnings** stays green
3. Adds WS unit coverage for **search** + create→list_mailboxes
4. Updates `docs/TDD/10-webimap.md` so SEARCH / mailbox CRUD are documented as implemented

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p chatmail-www --all-targets -- -D warnings`
- [x] `cargo test -p chatmail-www --lib`
- [ ] After merge: confirm CI **Build and Push Docker Images** updates `ghcr.io/themadorg/madmail:latest`
- [ ] Re-run madcore E2E against published image; `WS/search` and `WS/create_mailbox` should pass (no soft-skip)