### PR TITLE
fix(www): post contact share form as urlencoded

### DIFF
--- a/crates/chatmail-www/src/tests.rs
+++ b/crates/chatmail-www/src/tests.rs
@@ -671,6 +671,104 @@ async fn contact_sharing_post_and_slug_view() {
     assert!(page.contains("openpgp4fpr:"));
 }
 
+/// Regression for #94: share page must POST urlencoded fields, not bare FormData/multipart.
+#[tokio::test]
+async fn contact_share_page_posts_urlencoded() {
+    use axum::body::to_bytes;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    use chatmail_state::AppState;
+
+    let pool = init_memory_db().await.unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let mut cfg = AppConfig::default();
+    cfg.enable_contact_sharing = true;
+    cfg.mail_domain = Some("share.test".into());
+
+    let app_state = Arc::new(AppState::new(dir.path(), pool.clone()));
+    let app = crate::www_router(crate::WwwState::new(pool, app_state, cfg, dir.path()));
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/share")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let html = String::from_utf8_lossy(&body);
+    assert!(
+        html.contains("application/x-www-form-urlencoded"),
+        "share form JS must set Content-Type for axum::Form"
+    );
+    assert!(
+        html.contains("URLSearchParams"),
+        "share form must encode fields as urlencoded, not multipart FormData"
+    );
+    assert!(
+        !html.contains("body: formData"),
+        "must not POST raw FormData (multipart) — that triggers HTTP 415 from axum::Form"
+    );
+}
+
+/// Server contract: multipart bodies are rejected (axum::Form). Matches browser FormData without conversion.
+#[tokio::test]
+async fn contact_sharing_rejects_multipart_form() {
+    use axum::body::to_bytes;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    use chatmail_state::AppState;
+
+    let pool = init_memory_db().await.unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let mut cfg = AppConfig::default();
+    cfg.enable_contact_sharing = true;
+    cfg.mail_domain = Some("share.test".into());
+
+    let app_state = Arc::new(AppState::new(dir.path(), pool.clone()));
+    let app = crate::www_router(crate::WwwState::new(pool, app_state, cfg, dir.path()));
+
+    let boundary = "----madmailShareBoundary";
+    let body = format!(
+        "--{boundary}\r\n\
+         Content-Disposition: form-data; name=\"name\"\r\n\r\n\
+         Alice\r\n\
+         --{boundary}\r\n\
+         Content-Disposition: form-data; name=\"slug\"\r\n\r\n\
+         multipage\r\n\
+         --{boundary}\r\n\
+         Content-Disposition: form-data; name=\"url\"\r\n\r\n\
+         https://i.delta.chat/#ABCDEF0123456789\r\n\
+         --{boundary}--\r\n"
+    );
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/share")
+                .header(
+                    "content-type",
+                    format!("multipart/form-data; boundary={boundary}"),
+                )
+                .body(axum::body::Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let text = String::from_utf8_lossy(&bytes);
+    assert!(
+        text.contains("application/x-www-form-urlencoded"),
+        "unexpected rejection body: {text}"
+    );
+}
+
 /// Dev browser access (WebIMAP + WebSMTP) also applies CORS to `POST /new` / OPTIONS.
 #[tokio::test]
 async fn new_account_cors_reflects_origin_when_browser_access_enabled() {

--- a/crates/chatmail-www/www-src/contact_share.html
+++ b/crates/chatmail-www/www-src/contact_share.html
@@ -118,11 +118,15 @@
 
         document.getElementById('shareForm').addEventListener('submit', function (e) {
             e.preventDefault();
-            var formData = new FormData(this);
+            // axum::Form only accepts application/x-www-form-urlencoded (not multipart FormData).
+            var body = new URLSearchParams(new FormData(this));
 
             fetch('/share', {
                 method: 'POST',
-                body: formData
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded'
+                },
+                body: body
             }).then(function(response) {
                 if (response.ok) {
                     return response.text().then(function(html) {


### PR DESCRIPTION
## Summary

Fixes #94: the public Share page (“Create Link”) posted with `fetch` + `FormData` (`multipart/form-data`), while `POST /share` uses Axum’s `Form` extractor and only accepts `application/x-www-form-urlencoded`, which produced HTTP 415.

- Encode form fields with `URLSearchParams` and set the correct `Content-Type` in `contact_share.html`
- Add regression tests: page JS contract + multipart rejection

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Build / CI / tooling
- [ ] Refactor (no functional change)

## Area

- [ ] SMTP
- [ ] IMAP
- [ ] Federation / delivery queue
- [ ] Authentication / JIT
- [ ] Admin API / admin web UI (`external/madmail-admin-web`)
- [ ] TURN / Iroh / proxy services
- [ ] Storage / quota / DB migrations
- [ ] Configuration / CLI
- [ ] Docs (`docs/project/`, `docs/TDD/`, user guide)
- [x] Other: Public www / contact sharing (`/share`)

## Testing

- [x] `cargo fmt --all -- --check` (via `make lint`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (via `make lint`)
- [x] `cargo test --workspace` (or targeted crate/tests: `cargo test -p chatmail-www contact_shar`)
- [x] Manual / E2E verification (describe below)

**Manual verification (if any):**

```text
make fmt && make lint  # exit 0
cargo test -p chatmail-www contact_shar  # 3 passed
# Reproduced #94: multipart POST → 415; urlencoded POST → 200
```

## Documentation

- [x] No doc updates needed
- [ ] Updated operator/user docs (`docs/project/user-guide/`, install guides)
- [ ] Updated developer docs (`docs/project/`)
- [ ] Updated or added TDD section (`docs/TDD/`) — required for significant design changes

## Security & privacy

- [x] Not security-sensitive
- [ ] Security-sensitive — added/updated tests for the security property
- [ ] Reviewed error messages for information leakage

## Commits

- `fix:` bug fix

## Checklist

- [x] PR is focused and reviewable (small vertical slices preferred)
- [x] No secrets, `data/`, `target/`, or `node_modules/` committed
- [ ] Submodule pointers updated if `external/madmail-admin-web` changed
- [x] Behavior parity with Madmail v1 considered (or intentional difference documented)