### PR TITLE
fix(db): decode blocked_at safely on Postgres

### DIFF
--- a/crates/chatmail-db/src/blocklist.rs
+++ b/crates/chatmail-db/src/blocklist.rs
@@ -28,9 +28,10 @@ pub const CLI_DELETE_REASON: &str = "account deleted via CLI";
 pub const CLI_BAN_REASON: &str = "banned via CLI";
 
 pub async fn block_user(pool: &DbPool, username: &str, reason: &str) -> Result<()> {
+    // Set blocked_at explicitly so legacy Postgres tables without a DEFAULT still get a value.
     db_execute!(
         pool,
-        "INSERT INTO blocked_users (username, reason) VALUES (?, ?)
+        "INSERT INTO blocked_users (username, reason, blocked_at) VALUES (?, ?, CURRENT_TIMESTAMP)
          ON CONFLICT(username) DO UPDATE SET reason = excluded.reason",
         username,
         reason
@@ -48,10 +49,13 @@ pub async fn unblock_user(pool: &DbPool, username: &str) -> Result<()> {
 }
 
 pub async fn list_blocked_users(pool: &DbPool) -> Result<Vec<(String, String, String)>> {
+    // CAST to TEXT: Postgres stores blocked_at as TIMESTAMP; SQLx cannot decode that as String.
+    // COALESCE: legacy/null rows must not abort AuthCache hydrate (boot-fatal on Postgres).
     let rows: Vec<(String, String, String)> = db_fetch_all!(
         pool,
         (String, String, String),
-        "SELECT username, reason, blocked_at FROM blocked_users ORDER BY blocked_at DESC"
+        "SELECT username, reason, COALESCE(CAST(blocked_at AS TEXT), '')
+         FROM blocked_users ORDER BY blocked_at DESC"
     )?;
     Ok(rows)
 }
@@ -71,6 +75,7 @@ mod tests {
     use super::*;
     use crate::init_memory_db;
     use crate::passwords;
+    use crate::DbPool;
 
     #[tokio::test]
     async fn block_prevents_reregistration_check() {
@@ -103,5 +108,115 @@ mod tests {
             .await
             .unwrap()
             .is_none());
+    }
+
+    /// list_blocked_users must return a string timestamp (admin API / ban-list CLI).
+    #[tokio::test]
+    async fn list_blocked_users_returns_blocked_at() {
+        let pool = init_memory_db().await.unwrap();
+        block_user(&pool, "u@x.org", "test").await.unwrap();
+        let rows = list_blocked_users(&pool).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].0, "u@x.org");
+        assert_eq!(rows[0].1, "test");
+        assert!(
+            !rows[0].2.is_empty(),
+            "blocked_at should be non-empty, got {:?}",
+            rows[0].2
+        );
+    }
+
+    /// NULL blocked_at must not fail decode (legacy Postgres / issue #97).
+    #[tokio::test]
+    async fn list_blocked_users_tolerates_null_blocked_at() {
+        let pool = init_memory_db().await.unwrap();
+        let DbPool::Sqlite(p) = &pool else {
+            panic!("memory db is sqlite");
+        };
+        sqlx::query("INSERT INTO blocked_users (username, reason, blocked_at) VALUES (?, ?, NULL)")
+            .bind("null@x.org")
+            .bind("legacy")
+            .execute(p)
+            .await
+            .unwrap();
+
+        let rows = list_blocked_users(&pool).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].0, "null@x.org");
+        assert_eq!(rows[0].1, "legacy");
+        assert_eq!(rows[0].2, "");
+    }
+
+    /// Postgres e2e for issue #97. Opt-in via MADMAIL_TEST_PG_DSN.
+    #[tokio::test]
+    async fn postgres_list_blocked_users_after_block() {
+        let Some(dsn) = std::env::var("MADMAIL_TEST_PG_DSN")
+            .ok()
+            .filter(|s| !s.is_empty())
+        else {
+            eprintln!("skip: set MADMAIL_TEST_PG_DSN for Postgres e2e");
+            return;
+        };
+        let config = chatmail_config::DatabaseConfig {
+            driver: chatmail_config::DbDriver::Postgres,
+            dsn,
+        };
+        let pool = crate::connect_database(&config)
+            .await
+            .expect("connect postgres");
+        crate::pool::run_migrations(&pool)
+            .await
+            .expect("migrate postgres");
+
+        let user = format!(
+            "issue97-{}@test",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        block_user(&pool, &user, ADMIN_DELETE_REASON)
+            .await
+            .expect("block_user");
+        let rows = list_blocked_users(&pool)
+            .await
+            .expect("list_blocked_users must decode TIMESTAMP as String on Postgres");
+        let hit = rows.iter().find(|(u, _, _)| u == &user);
+        let Some((_, reason, blocked_at)) = hit else {
+            panic!("blocked user not listed");
+        };
+        assert_eq!(reason, ADMIN_DELETE_REASON);
+        assert!(
+            !blocked_at.is_empty(),
+            "blocked_at empty on postgres: {blocked_at:?}"
+        );
+
+        // Legacy NULL blocked_at must not break list (boot hydrate path).
+        match &pool {
+            DbPool::Postgres(p) => {
+                let null_user = format!("{user}-null");
+                sqlx::query(
+                    "INSERT INTO blocked_users (username, reason, blocked_at)
+                     VALUES ($1, $2, NULL)
+                     ON CONFLICT (username) DO UPDATE SET blocked_at = NULL",
+                )
+                .bind(&null_user)
+                .bind("null-legacy")
+                .execute(p)
+                .await
+                .unwrap();
+            }
+            _ => unreachable!(),
+        }
+        let rows = list_blocked_users(&pool)
+            .await
+            .expect("NULL blocked_at must not fail list on Postgres");
+        assert!(rows
+            .iter()
+            .any(|(u, r, at)| { u.ends_with("-null") && r == "null-legacy" && at.is_empty() }));
+
+        // Cleanup test rows.
+        let _ = unblock_user(&pool, &user).await;
+        let _ = unblock_user(&pool, &format!("{user}-null")).await;
     }
 }


### PR DESCRIPTION
## Summary

Deleting a user (admin UI/API) inserts a `blocked_users` row. On **PostgreSQL**, `list_blocked_users` then tries to decode `blocked_at` (a `TIMESTAMP`, sometimes `NULL` on legacy schemas) as a non-optional Rust `String`. That fails SQLx decode, so the admin UI errors on refresh and **boot hydrate can refuse to start**.

This PR:
- Casts `blocked_at` to `TEXT` and `COALESCE`s nulls when listing
- Sets `blocked_at = CURRENT_TIMESTAMP` on insert (helps legacy tables without a DEFAULT)
- Adds unit tests + optional Postgres e2e (`MADMAIL_TEST_PG_DSN`)

Fixes #97

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Build / CI / tooling
- [ ] Refactor (no functional change)

## Area

- [ ] SMTP
- [ ] IMAP
- [ ] Federation / delivery queue
- [x] Authentication / JIT
- [x] Admin API / admin web UI (`external/madmail-admin-web`)
- [ ] TURN / Iroh / proxy services
- [x] Storage / quota / DB migrations
- [x] Configuration / CLI
- [ ] Docs (`docs/project/`, `docs/TDD/`, user guide)
- [ ] Other:

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (or targeted crate/tests: `chatmail-db` blocklist, `chatmail-state` auth, `chatmail` blocklist/CLI, `chatmail-admin` lib; full workspace + `make test-e2e`)
- [x] Manual / E2E verification (describe below)

**Manual verification (if any):**

```text
# Postgres (Docker) smoke for #97:
# - madmail with auth + imapsql driver postgres
# - POST /admin/accounts → DELETE /admin/accounts
# - GET /admin/blocklist → 200 (was 500: TIMESTAMP / null decode on column 2)
# - process restart with blocked_users row present → boots (was fatal on AuthCache hydrate)

# Automated:
cargo test -p chatmail-db blocklist
MADMAIL_TEST_PG_DSN='host=… user=… password=… dbname=… sslmode=disable' \
  cargo test -p chatmail-db postgres_list_blocked_users_after_block
cargo test -p chatmail-state auth::
cargo test -p chatmail blocklist
make lint
make test-e2e
```

## Documentation

- [x] No doc updates needed
- [ ] Updated operator/user docs (`docs/project/user-guide/`, install guides)
- [ ] Updated developer docs (`docs/project/`)
- [ ] Updated or added TDD section (`docs/TDD/`) — required for significant design changes

## Security & privacy

- [x] Not security-sensitive
- [ ] Security-sensitive — added/updated tests for the security property
- [ ] Reviewed error messages for information leakage

## Commits

- `fix:` bug fix

## Checklist

- [x] PR is focused and reviewable (small vertical slices preferred)
- [x] No secrets, `data/`, `target/`, or `node_modules/` committed
- [x] Submodule pointers updated if `external/madmail-admin-web` changed
- [x] Behavior parity with Madmail v1 considered (or intentional difference documented)

Go/v1 used `time.Time` via GORM and did not crash on list/boot. This restores that reliability on Postgres while keeping the existing string-based API for admin/CLI display.