### PR TITLE
fix(www): migrate legacy /qr and warn on literal template braces

### DIFF
--- a/crates/chatmail-config/src/cli.rs
+++ b/crates/chatmail-config/src/cli.rs
@@ -136,10 +136,10 @@ pub enum Command {
         #[arg(value_name = "WWW_DIR")]
         www_dir: String,
     },
-    /// Convert custom `www_dir` Go templates to Minijinja (interactive).
+    /// Migrate custom `www_dir`: Go templates → Minijinja and legacy `/qr` → client-side QR.
     #[command(name = "html-migrate")]
     HtmlMigrate {
-        /// Apply migration without prompting (default: ask when Go-style HTML is found).
+        /// Apply migration without prompting (default: ask when work is found).
         #[arg(long, short = 'y')]
         yes: bool,
     },

--- a/crates/chatmail-www/src/lib.rs
+++ b/crates/chatmail-www/src/lib.rs
@@ -35,8 +35,9 @@ pub use export::export_www_files;
 pub use go_template::{looks_like_go_template, prepare_template};
 pub use router::{www_router, WwwState};
 pub use www_migrate::{
-    migrate_www_dir, migrate_www_html_file, scan_www_dir_for_go_templates, FileMigrateOutcome,
-    MigrateReport,
+    format_www_template_error, migrate_www_dir, migrate_www_html_file, rewrite_legacy_qr_js,
+    scan_literal_brace_warnings, scan_www_dir_for_go_templates, transform_html_source,
+    FileMigrateOutcome, MigrateReport,
 };
 
 #[cfg(test)]

--- a/crates/chatmail-www/src/template.rs
+++ b/crates/chatmail-www/src/template.rs
@@ -152,11 +152,18 @@ impl TemplateEngine {
         let env = self.embedded.as_ref().ok_or_else(|| {
             chatmail_types::ChatmailError::config("www template engine not initialized")
         })?;
-        let tmpl = env
-            .get_template(name)
-            .map_err(|e| chatmail_types::ChatmailError::config(e.to_string()))?;
-        tmpl.render(ctx)
-            .map_err(|e| chatmail_types::ChatmailError::config(e.to_string()))
+        let tmpl = env.get_template(name).map_err(|e| {
+            chatmail_types::ChatmailError::config(crate::www_migrate::format_www_template_error(
+                name,
+                &e.to_string(),
+            ))
+        })?;
+        tmpl.render(ctx).map_err(|e| {
+            chatmail_types::ChatmailError::config(crate::www_migrate::format_www_template_error(
+                name,
+                &e.to_string(),
+            ))
+        })
     }
 
     /// Read and render one HTML file from `www_dir` (picks up edits without restart).
@@ -167,12 +174,25 @@ impl TemplateEngine {
         })?;
         let mut env = Environment::new();
         add_filters(&mut env);
-        env.add_template_owned(name.to_string(), prepare_template(&src))
-            .map_err(|e| chatmail_types::ChatmailError::config(e.to_string()))?;
+        let prepared = prepare_template(&src);
+        env.add_template_owned(name.to_string(), prepared)
+            .map_err(|e| {
+                chatmail_types::ChatmailError::config(
+                    crate::www_migrate::format_www_template_error(name, &e.to_string()),
+                )
+            })?;
         env.get_template(name)
-            .map_err(|e| chatmail_types::ChatmailError::config(e.to_string()))?
+            .map_err(|e| {
+                chatmail_types::ChatmailError::config(
+                    crate::www_migrate::format_www_template_error(name, &e.to_string()),
+                )
+            })?
             .render(ctx)
-            .map_err(|e| chatmail_types::ChatmailError::config(e.to_string()))
+            .map_err(|e| {
+                chatmail_types::ChatmailError::config(
+                    crate::www_migrate::format_www_template_error(name, &e.to_string()),
+                )
+            })
     }
 }
 

--- a/crates/chatmail-www/src/www_migrate.rs
+++ b/crates/chatmail-www/src/www_migrate.rs
@@ -15,7 +15,10 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-//! On-disk migration of custom `www_dir` HTML from Go templates to Minijinja.
+//! On-disk migration of custom `www_dir`:
+//! - Go `html/template` → Minijinja
+//! - Legacy `/qr?data=` image assignments → client-side `setQrCodeImage`
+//! - Warnings for literal `{%` / `{{` that can break Minijinja (e.g. Obtainium URLs)
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -23,12 +26,32 @@ use std::path::{Path, PathBuf};
 use chatmail_types::{ChatmailError, Result};
 use serde::Serialize;
 
+use crate::assets::WwwAssets;
 use crate::go_template::{looks_like_go_template, prepare_template};
 
-/// Result of migrating one HTML file.
+/// Client-side QR helper shipped in embedded `main.js` (appended when missing).
+const SET_QR_CODE_IMAGE_JS: &str = r#"
+/** Render a dclogin / invite QR into an <img> (client-side, no /qr backend). */
+function setQrCodeImage(imgEl, text, cellSize) {
+    if (!imgEl || !text || typeof qrcode !== 'function') {
+        return;
+    }
+    try {
+        var qr = qrcode(0, 'M');
+        qr.addData(text);
+        qr.make();
+        imgEl.src = qr.createDataURL(cellSize || 4, 2);
+        imgEl.alt = 'QR Code';
+    } catch (err) {
+        console.error('QR generation failed', err);
+    }
+}
+"#;
+
+/// Result of migrating one HTML file (Go syntax and/or QR).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FileMigrateOutcome {
-    /// No Go markers or content unchanged after convert.
+    /// No Go markers / QR legacy / content unchanged after convert.
     Unchanged,
     /// File rewritten; optional backup path.
     Migrated { backup: PathBuf },
@@ -44,6 +67,23 @@ pub struct MigrateReport {
     pub unchanged: usize,
     pub backups: Vec<String>,
     pub errors: Vec<String>,
+    /// HTML/JS paths that still referenced legacy `/qr?data=` (before apply) or were QR-fixed.
+    pub qr_legacy_files: Vec<String>,
+    /// Files rewritten for client-side QR (HTML and/or `main.js`).
+    pub qr_migrated: Vec<String>,
+    /// `qrcode.min.js` was copied from embedded assets into `www_dir`.
+    pub qrcode_js_copied: bool,
+    /// `main.js` gained `setQrCodeImage` (appended).
+    pub main_js_qr_helper_added: bool,
+    /// Suspicious literal `{%` / `{{` that may break Minijinja (not auto-fixed).
+    pub literal_brace_warnings: Vec<String>,
+}
+
+impl MigrateReport {
+    /// Dry-run: would apply rewrite something (or copy assets)?
+    pub fn dry_needs_apply(&self) -> bool {
+        !self.go_style_files.is_empty() || !self.qr_legacy_files.is_empty()
+    }
 }
 
 /// List HTML files under `www_dir` that still look like Go `html/template`.
@@ -66,19 +106,16 @@ pub fn scan_www_dir_for_go_templates(www_dir: &Path) -> Result<Vec<PathBuf>> {
     Ok(out)
 }
 
-/// Convert one HTML file in place if it uses Go template syntax.
+/// Convert one HTML file in place if it uses Go template syntax and/or legacy QR.
 ///
 /// Writes `path` with a `.go-template.bak` sibling backup when content changes.
 pub fn migrate_www_html_file(path: &Path) -> Result<FileMigrateOutcome> {
     let src = fs::read_to_string(path).map_err(ChatmailError::from)?;
-    if !looks_like_go_template(&src) {
-        return Ok(FileMigrateOutcome::Unchanged);
-    }
-    let converted = prepare_template(&src);
+    let converted = transform_html_source(&src);
     if converted == src {
         return Ok(FileMigrateOutcome::Unchanged);
     }
-    let backup = backup_path(path);
+    let backup = backup_path(path, ".go-template.bak");
     if !backup.exists() {
         fs::write(&backup, &src).map_err(ChatmailError::from)?;
     }
@@ -86,9 +123,19 @@ pub fn migrate_www_html_file(path: &Path) -> Result<FileMigrateOutcome> {
     Ok(FileMigrateOutcome::Migrated { backup })
 }
 
-/// Scan and optionally rewrite all Go-style HTML under `www_dir`.
+/// Go convert + QR rewrite for one HTML body (no I/O).
+pub fn transform_html_source(src: &str) -> String {
+    let mut s = src.to_string();
+    if looks_like_go_template(&s) {
+        s = prepare_template(&s);
+    }
+    rewrite_legacy_qr_js(&s)
+}
+
+/// Scan and optionally rewrite all Go-style HTML and QR/static assets under `www_dir`.
 ///
-/// When `apply` is false, only scans and fills `go_style_files` (dry run).
+/// When `apply` is false, only scans (dry run): fills `go_style_files`, `qr_legacy_files`,
+/// and `literal_brace_warnings` without writing.
 pub fn migrate_www_dir(www_dir: &Path, apply: bool) -> Result<MigrateReport> {
     let mut report = MigrateReport {
         www_dir: www_dir.display().to_string(),
@@ -109,12 +156,9 @@ pub fn migrate_www_dir(www_dir: &Path, apply: bool) -> Result<MigrateReport> {
     })?;
     report.scanned = all_html.len();
 
-    for path in all_html {
-        let rel = path
-            .strip_prefix(www_dir)
-            .map(|p| p.display().to_string())
-            .unwrap_or_else(|_| path.display().to_string());
-        let src = match fs::read_to_string(&path) {
+    for path in &all_html {
+        let rel = rel_under(www_dir, path);
+        let src = match fs::read_to_string(path) {
             Ok(s) => s,
             Err(e) => {
                 report
@@ -123,24 +167,109 @@ pub fn migrate_www_dir(www_dir: &Path, apply: bool) -> Result<MigrateReport> {
                 continue;
             }
         };
-        if !looks_like_go_template(&src) {
+
+        for w in scan_literal_brace_warnings(&src, &rel) {
+            report.literal_brace_warnings.push(w);
+        }
+
+        let has_go = looks_like_go_template(&src);
+        let has_qr = source_has_legacy_qr(&src);
+        if has_go {
+            report.go_style_files.push(rel.clone());
+        }
+        if has_qr {
+            report.qr_legacy_files.push(rel.clone());
+        }
+
+        if !has_go && !has_qr {
             report.unchanged += 1;
             continue;
         }
-        report.go_style_files.push(rel.clone());
         if !apply {
             continue;
         }
-        match migrate_www_html_file(&path) {
-            Ok(FileMigrateOutcome::Migrated { backup }) => {
-                report.migrated.push(rel);
-                report.backups.push(backup.display().to_string());
+
+        let converted = transform_html_source(&src);
+        if converted == src {
+            report.unchanged += 1;
+            continue;
+        }
+        let backup = backup_path(path, ".go-template.bak");
+        if !backup.exists() {
+            if let Err(e) = fs::write(&backup, &src) {
+                report
+                    .errors
+                    .push(format!("{}: backup failed: {e}", path.display()));
+                continue;
             }
-            Ok(FileMigrateOutcome::Unchanged) => {
-                report.unchanged += 1;
+        }
+        if let Err(e) = fs::write(path, converted.as_bytes()) {
+            report
+                .errors
+                .push(format!("{}: write failed: {e}", path.display()));
+            continue;
+        }
+        report.migrated.push(rel.clone());
+        report.backups.push(backup.display().to_string());
+        if has_qr && !source_has_legacy_qr(&converted) {
+            report.qr_migrated.push(rel);
+        }
+    }
+
+    // `main.js` may still assign `/qr?data=` or lack setQrCodeImage.
+    migrate_main_js(www_dir, apply, &mut report)?;
+
+    // Ensure qrcode.min.js when pages need client QR (legacy or setQrCodeImage).
+    ensure_qrcode_min_js(www_dir, apply, &mut report)?;
+
+    // Inject <script src="…qrcode.min.js"> before main.js when missing.
+    if apply {
+        inject_qrcode_script_tags(www_dir, &mut report)?;
+    } else {
+        // Dry-run: note HTML that reference setQrCodeImage/legacy QR but lack qrcode script.
+        for path in &all_html {
+            let rel = rel_under(www_dir, path);
+            let Ok(src) = fs::read_to_string(path) else {
+                continue;
+            };
+            if needs_qrcode_script(&src)
+                && !html_loads_qrcode_js(&src)
+                && !report.qr_legacy_files.contains(&rel)
+            {
+                report.qr_legacy_files.push(rel);
             }
-            Err(e) => {
-                report.errors.push(format!("{}: {e}", path.display()));
+        }
+        let main_js = www_dir.join("main.js");
+        if main_js.is_file() {
+            if let Ok(src) = fs::read_to_string(&main_js) {
+                if source_has_legacy_qr(&src) || !src.contains("function setQrCodeImage") {
+                    // If any html has QR usage and helper missing, flag main.js
+                    let any_qr_html = report.qr_legacy_files.iter().any(|f| f.ends_with(".html"));
+                    let any_set_qr = all_html.iter().any(|p| {
+                        fs::read_to_string(p)
+                            .map(|s| s.contains("setQrCodeImage(") || source_has_legacy_qr(&s))
+                            .unwrap_or(false)
+                    });
+                    if (any_qr_html || any_set_qr || source_has_legacy_qr(&src))
+                        && !report.qr_legacy_files.iter().any(|f| f == "main.js")
+                    {
+                        report.qr_legacy_files.push("main.js".into());
+                    }
+                }
+            }
+        }
+        if !www_dir.join("qrcode.min.js").is_file() {
+            let needs = !report.qr_legacy_files.is_empty()
+                || all_html.iter().any(|p| {
+                    fs::read_to_string(p)
+                        .map(|s| s.contains("setQrCodeImage(") || source_has_legacy_qr(&s))
+                        .unwrap_or(false)
+                });
+            if needs {
+                // Signal work via qr_legacy placeholder when only asset missing
+                if report.qr_legacy_files.is_empty() {
+                    report.qr_legacy_files.push("qrcode.min.js".into());
+                }
             }
         }
     }
@@ -148,10 +277,360 @@ pub fn migrate_www_dir(www_dir: &Path, apply: bool) -> Result<MigrateReport> {
     Ok(report)
 }
 
-fn backup_path(path: &Path) -> PathBuf {
+fn migrate_main_js(www_dir: &Path, apply: bool, report: &mut MigrateReport) -> Result<()> {
+    let path = www_dir.join("main.js");
+    if !path.is_file() {
+        // No main.js — only care if HTML still has legacy QR after transform intent
+        return Ok(());
+    }
+    let src = fs::read_to_string(&path).map_err(ChatmailError::from)?;
+    let mut next = rewrite_legacy_qr_js(&src);
+    let mut helper_added = false;
+    if !next.contains("function setQrCodeImage") {
+        // Append helper when pages need it (legacy QR or call sites).
+        let html_needs = report.qr_legacy_files.iter().any(|f| f.ends_with(".html"))
+            || walk_html_any(www_dir, |p| {
+                fs::read_to_string(p)
+                    .map(|s| s.contains("setQrCodeImage(") || source_has_legacy_qr(&s))
+                    .unwrap_or(false)
+            });
+        if html_needs || source_has_legacy_qr(&src) || next.contains("setQrCodeImage(") {
+            if !next.ends_with('\n') {
+                next.push('\n');
+            }
+            next.push_str(SET_QR_CODE_IMAGE_JS);
+            helper_added = true;
+        }
+    }
+
+    let changed = next != src;
+    if (source_has_legacy_qr(&src) || helper_added)
+        && !report.qr_legacy_files.iter().any(|f| f == "main.js")
+    {
+        report.qr_legacy_files.push("main.js".into());
+    }
+    if !changed {
+        return Ok(());
+    }
+    if !apply {
+        return Ok(());
+    }
+
+    let backup = backup_path(&path, ".qr-compat.bak");
+    if !backup.exists() {
+        fs::write(&backup, &src).map_err(ChatmailError::from)?;
+        report.backups.push(backup.display().to_string());
+    }
+    fs::write(&path, next.as_bytes()).map_err(ChatmailError::from)?;
+    report.qr_migrated.push("main.js".into());
+    if helper_added {
+        report.main_js_qr_helper_added = true;
+    }
+    Ok(())
+}
+
+fn ensure_qrcode_min_js(www_dir: &Path, apply: bool, report: &mut MigrateReport) -> Result<()> {
+    let dest = www_dir.join("qrcode.min.js");
+    if dest.is_file() {
+        return Ok(());
+    }
+    let needs = report
+        .qr_legacy_files
+        .iter()
+        .any(|f| f.ends_with(".html") || f == "main.js")
+        || report.qr_migrated.iter().any(|f| f.ends_with(".html"))
+        || report.main_js_qr_helper_added
+        || walk_html_any(www_dir, |p| {
+            fs::read_to_string(p)
+                .map(|s| s.contains("setQrCodeImage(") || source_has_legacy_qr(&s))
+                .unwrap_or(false)
+        });
+    if !needs {
+        return Ok(());
+    }
+    if !apply {
+        if !report.qr_legacy_files.iter().any(|f| f == "qrcode.min.js") {
+            report.qr_legacy_files.push("qrcode.min.js".into());
+        }
+        return Ok(());
+    }
+    let Some(file) = WwwAssets::get("qrcode.min.js") else {
+        report
+            .errors
+            .push("embedded qrcode.min.js missing from binary".into());
+        return Ok(());
+    };
+    fs::write(&dest, file.data.as_ref()).map_err(ChatmailError::from)?;
+    report.qrcode_js_copied = true;
+    report.qr_migrated.push("qrcode.min.js".into());
+    Ok(())
+}
+
+fn inject_qrcode_script_tags(www_dir: &Path, report: &mut MigrateReport) -> Result<()> {
+    let mut all_html = Vec::new();
+    walk_html(www_dir, &mut |path| {
+        all_html.push(path.to_path_buf());
+        Ok(())
+    })?;
+    for path in all_html {
+        let src = match fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        if !needs_qrcode_script(&src) || html_loads_qrcode_js(&src) {
+            continue;
+        }
+        let Some(next) = inject_qrcode_script_before_main_js(&src) else {
+            continue;
+        };
+        if next == src {
+            continue;
+        }
+        let backup = backup_path(&path, ".go-template.bak");
+        if !backup.exists() {
+            let _ = fs::write(&backup, &src);
+            report.backups.push(backup.display().to_string());
+        }
+        fs::write(&path, next.as_bytes()).map_err(ChatmailError::from)?;
+        let rel = rel_under(www_dir, &path);
+        if !report.qr_migrated.contains(&rel) {
+            report.qr_migrated.push(rel.clone());
+        }
+        if !report.migrated.contains(&rel) {
+            report.migrated.push(rel);
+        }
+    }
+    Ok(())
+}
+
+fn needs_qrcode_script(src: &str) -> bool {
+    // Call site only — avoid injecting into docs that merely mention the name.
+    src.contains("setQrCodeImage(") || source_has_legacy_qr(src)
+}
+
+fn html_loads_qrcode_js(src: &str) -> bool {
+    src.contains("qrcode.min.js")
+}
+
+/// Insert `<script src="…qrcode.min.js">` immediately before the first `main.js` script tag.
+fn inject_qrcode_script_before_main_js(src: &str) -> Option<String> {
+    // Match common forms: <script src="./main.js"></script> or src="/main.js" or 'main.js'
+    let markers = [
+        r#"src="./main.js""#,
+        r#"src='/main.js'"#,
+        r#"src="/main.js""#,
+        r#"src='./main.js'"#,
+        r#"src="main.js""#,
+        r#"src='main.js'"#,
+    ];
+    let mut best: Option<usize> = None;
+    for m in markers {
+        if let Some(i) = src.find(m) {
+            best = Some(match best {
+                Some(b) => b.min(i),
+                None => i,
+            });
+        }
+    }
+    let idx = best?;
+    // Walk back to start of <script
+    let head = &src[..idx];
+    let script_start = head.rfind("<script")?;
+    // Detect path style from main.js src
+    let main_attr = &src[idx..];
+    let qr_src = if main_attr.contains("\"./main.js\"") || main_attr.contains("'./main.js'") {
+        "./qrcode.min.js"
+    } else if main_attr.contains("\"/main.js\"") || main_attr.contains("'/main.js'") {
+        "/qrcode.min.js"
+    } else {
+        "./qrcode.min.js"
+    };
+    let indent = {
+        let line_start = head.rfind('\n').map(|i| i + 1).unwrap_or(0);
+        src[line_start..script_start]
+            .chars()
+            .take_while(|c| *c == ' ' || *c == '\t')
+            .collect::<String>()
+    };
+    let injection = format!("{indent}<script src=\"{qr_src}\"></script>\n{indent}");
+    let mut out = String::with_capacity(src.len() + injection.len());
+    out.push_str(&src[..script_start]);
+    out.push_str(&injection);
+    out.push_str(&src[script_start..]);
+    Some(out)
+}
+
+/// True when this source still has a **rewriteable** legacy `/qr?data=` assignment.
+///
+/// Plain mentions in docs/prose (e.g. “the old `/qr?data=` endpoint”) do **not** count —
+/// otherwise migrate would spuriously prompt and inject `qrcode.min.js` into unrelated pages.
+fn source_has_legacy_qr(src: &str) -> bool {
+    if !src.contains("/qr?data=") {
+        return false;
+    }
+    rewrite_legacy_qr_js(src) != src
+}
+
+/// Rewrite `el.src = `/qr?data=${encodeURIComponent(var)}`` → `setQrCodeImage(el, var)`.
+pub fn rewrite_legacy_qr_js(src: &str) -> String {
+    let mut s = src.to_string();
+    // Fast paths for the common Madmail index/invite snippets.
+    const PAIRS: &[(&str, &str)] = &[
+        (
+            r#"document.getElementById("result-qr").src = `/qr?data=${encodeURIComponent(currentLink)}`;"#,
+            r#"setQrCodeImage(document.getElementById("result-qr"), currentLink);"#,
+        ),
+        (
+            r#"document.getElementById('result-qr').src = `/qr?data=${encodeURIComponent(currentLink)}`;"#,
+            r#"setQrCodeImage(document.getElementById('result-qr'), currentLink);"#,
+        ),
+        (
+            r#"document.getElementById("result-qr").src = `/qr?data=${encodeURIComponent(currentLink)}`"#,
+            r#"setQrCodeImage(document.getElementById("result-qr"), currentLink)"#,
+        ),
+        (
+            r#"document.getElementById('result-qr').src = `/qr?data=${encodeURIComponent(currentLink)}`"#,
+            r#"setQrCodeImage(document.getElementById('result-qr'), currentLink)"#,
+        ),
+    ];
+    for (from, to) in PAIRS {
+        s = s.replace(from, to);
+    }
+    // Generic: any getElementById(...).src = `/qr?data=${encodeURIComponent(VAR)}`
+    loop {
+        let next = rewrite_one_backtick_qr_assignment(&s);
+        if next == s {
+            break;
+        }
+        s = next;
+    }
+    s
+}
+
+fn rewrite_one_backtick_qr_assignment(src: &str) -> String {
+    const MARK: &str = "/qr?data=${encodeURIComponent(";
+    let Some(mark_at) = src.find(MARK) else {
+        return src.to_string();
+    };
+    let after_mark = &src[mark_at + MARK.len()..];
+    let Some(var_end) = after_mark.find(')') else {
+        return src.to_string();
+    };
+    let var = after_mark[..var_end].trim();
+    if var.is_empty()
+        || !var
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.')
+    {
+        // Skip this occurrence: advance past MARK so we do not loop forever.
+        let mut out = String::with_capacity(src.len());
+        out.push_str(&src[..mark_at + MARK.len()]);
+        out.push_str(&rewrite_one_backtick_qr_assignment(
+            &src[mark_at + MARK.len()..],
+        ));
+        return out;
+    }
+    let after_var = &after_mark[var_end..];
+    if !after_var.starts_with(")}") {
+        let mut out = String::with_capacity(src.len());
+        out.push_str(&src[..mark_at + 1]);
+        out.push_str(&rewrite_one_backtick_qr_assignment(&src[mark_at + 1..]));
+        return out;
+    }
+    let mut end = mark_at + MARK.len() + var_end + 2; // through `)}
+    if src[end..].starts_with(';') {
+        end += 1;
+    }
+
+    // Walk back: optional whitespace, backtick, `=`, `.src`, getElementById(...)
+    let mut i = mark_at;
+    while i > 0 && src.as_bytes()[i - 1].is_ascii_whitespace() {
+        i -= 1;
+    }
+    if i == 0 || src.as_bytes()[i - 1] != b'`' {
+        let mut out = String::with_capacity(src.len());
+        out.push_str(&src[..mark_at + 1]);
+        out.push_str(&rewrite_one_backtick_qr_assignment(&src[mark_at + 1..]));
+        return out;
+    }
+    i -= 1; // backtick
+    while i > 0 && src.as_bytes()[i - 1].is_ascii_whitespace() {
+        i -= 1;
+    }
+    if i == 0 || src.as_bytes()[i - 1] != b'=' {
+        let mut out = String::with_capacity(src.len());
+        out.push_str(&src[..mark_at + 1]);
+        out.push_str(&rewrite_one_backtick_qr_assignment(&src[mark_at + 1..]));
+        return out;
+    }
+    i -= 1; // =
+    while i > 0 && src.as_bytes()[i - 1].is_ascii_whitespace() {
+        i -= 1;
+    }
+    if i < 4 || &src[i - 4..i] != ".src" {
+        let mut out = String::with_capacity(src.len());
+        out.push_str(&src[..mark_at + 1]);
+        out.push_str(&rewrite_one_backtick_qr_assignment(&src[mark_at + 1..]));
+        return out;
+    }
+    let expr_end = i - 4; // before .src
+    let head = &src[..expr_end];
+    let Some(ge) = head.rfind("document.getElementById(") else {
+        let mut out = String::with_capacity(src.len());
+        out.push_str(&src[..mark_at + 1]);
+        out.push_str(&rewrite_one_backtick_qr_assignment(&src[mark_at + 1..]));
+        return out;
+    };
+    // Between ge and expr_end should only be the call (+ whitespace).
+    let call = &src[ge..expr_end].trim_end();
+    if !is_balanced_get_element_by_id(call) {
+        let mut out = String::with_capacity(src.len());
+        out.push_str(&src[..mark_at + 1]);
+        out.push_str(&rewrite_one_backtick_qr_assignment(&src[mark_at + 1..]));
+        return out;
+    }
+    let semi = if end > 0 && src.as_bytes()[end - 1] == b';' {
+        ";"
+    } else {
+        ""
+    };
+    let mut out = String::with_capacity(src.len());
+    out.push_str(&src[..ge]);
+    out.push_str(&format!("setQrCodeImage({call}, {var}){semi}"));
+    out.push_str(&src[end..]);
+    out
+}
+
+fn is_balanced_get_element_by_id(call: &str) -> bool {
+    if !call.starts_with("document.getElementById(") {
+        return false;
+    }
+    let mut depth = 0i32;
+    for (i, c) in call.char_indices() {
+        match c {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return call[i + c.len_utf8()..].trim().is_empty();
+                }
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
+fn backup_path(path: &Path, suffix: &str) -> PathBuf {
     let mut s = path.as_os_str().to_os_string();
-    s.push(".go-template.bak");
+    s.push(suffix);
     PathBuf::from(s)
+}
+
+fn rel_under(www_dir: &Path, path: &Path) -> String {
+    path.strip_prefix(www_dir)
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| path.display().to_string())
 }
 
 fn walk_html(dir: &Path, f: &mut dyn FnMut(&Path) -> Result<()>) -> Result<()> {
@@ -170,6 +649,130 @@ fn walk_html(dir: &Path, f: &mut dyn FnMut(&Path) -> Result<()>) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn walk_html_any(dir: &Path, mut pred: impl FnMut(&Path) -> bool) -> bool {
+    let mut found = false;
+    let _ = walk_html(dir, &mut |path| {
+        if pred(path) {
+            found = true;
+        }
+        Ok(())
+    });
+    found
+}
+
+/// Known Minijinja (and leftover Go-control) tag names after `{%` / `{%-`.
+const KNOWN_TAG_STARTS: &[&str] = &[
+    "if",
+    "else",
+    "elif",
+    "endif",
+    "for",
+    "endfor",
+    "raw",
+    "endraw",
+    "block",
+    "endblock",
+    "set",
+    "include",
+    "extends",
+    "macro",
+    "endmacro",
+    "filter",
+    "endfilter",
+    "with",
+    "endwith",
+    "import",
+    "from",
+    "call",
+    "endcall",
+    "autoescape",
+    "endautoescape",
+    "do",
+    "break",
+    "continue",
+];
+
+/// Scan template source for `{%` / `{{` that look like literal content (e.g. `{%22` in URLs).
+pub fn scan_literal_brace_warnings(src: &str, rel_path: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let bytes = src.as_bytes();
+    let mut i = 0usize;
+    while i + 1 < bytes.len() {
+        if bytes[i] == b'{' && (bytes[i + 1] == b'%' || bytes[i + 1] == b'{') {
+            let kind = if bytes[i + 1] == b'%' { "{%" } else { "{{" };
+            let rest = &src[i + 2..];
+            let rest_trim = rest.trim_start_matches(|c: char| c == '-' || c.is_whitespace());
+            let ok = if kind == "{%" {
+                looks_like_known_tag(rest_trim)
+            } else {
+                // `{{` variable/expression: letter, `_`, or filter-ish start; not digits alone like `{{22`
+                looks_like_known_var_expr(rest_trim)
+            };
+            if !ok {
+                let line = src[..i].bytes().filter(|&b| b == b'\n').count() + 1;
+                let snippet: String = src[i..].chars().take(40).collect();
+                let snippet = snippet.replace('\n', " ");
+                out.push(format!(
+                    "{rel_path}:{line}: possible literal `{kind}` in content ({snippet}…). \
+                     Wrap with {{% raw %}}…{{% endraw %}} if this is a URL or plain text \
+                     (e.g. Obtainium links with {{%22)."
+                ));
+            }
+            i += 2;
+            continue;
+        }
+        i += 1;
+    }
+    out
+}
+
+fn looks_like_known_tag(rest: &str) -> bool {
+    for tag in KNOWN_TAG_STARTS {
+        if let Some(after) = rest.strip_prefix(tag) {
+            if after.is_empty()
+                || after.starts_with(|c: char| c.is_whitespace() || c == '%' || c == '-')
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn looks_like_known_var_expr(rest: &str) -> bool {
+    let rest = rest.trim_start();
+    if rest.is_empty() {
+        return false;
+    }
+    // Valid: Field, .Field (Go, converted later), _, space then name, end `}}`
+    let c = rest.chars().next().unwrap();
+    if c.is_ascii_alphabetic() || c == '_' || c == '.' {
+        return true;
+    }
+    // Filters / paren expressions rare at start; reject digits (e.g. broken) and quotes
+    false
+}
+
+/// Enrich a Minijinja / template engine error for operators.
+pub fn format_www_template_error(file: &str, err: &str) -> String {
+    let mut msg = format!("www template render failed for {file}: {err}");
+    let lower = err.to_ascii_lowercase();
+    if lower.contains("syntax")
+        || lower.contains("unexpected")
+        || lower.contains("unknown")
+        || lower.contains("parse")
+        || lower.contains("invalid")
+    {
+        msg.push_str(
+            ". Hint: Minijinja treats `{%` and `{{` as template syntax — if this page embeds \
+             literal URLs containing those sequences (e.g. Obtainium `{%22…`), wrap them in \
+             `{% raw %}…{% endraw %}`. After a Go Madmail upgrade, run \
+             `madmail html-migrate --yes` for Go→Minijinja and legacy `/qr?data=` → client-side QR.",
+        );
+    }
+    msg
 }
 
 #[cfg(test)]
@@ -270,9 +873,13 @@ mod tests {
             "got: {after_open}"
         );
 
-        // Second migrate is a no-op.
+        // Second migrate is a no-op for Go templates.
         let again = migrate_www_dir(dir.path(), true).unwrap();
-        assert!(again.migrated.is_empty(), "expected idempotent migrate");
+        assert!(
+            again.go_style_files.is_empty() && again.migrated.is_empty(),
+            "expected idempotent migrate: {:?}",
+            again
+        );
     }
 
     #[test]
@@ -301,7 +908,7 @@ mod tests {
 
         let out = migrate_www_html_file(&path).unwrap();
         assert!(matches!(out, FileMigrateOutcome::Migrated { .. }));
-        let bak = backup_path(&path);
+        let bak = backup_path(&path, ".go-template.bak");
         assert!(bak.is_file(), "backup missing: {}", bak.display());
         assert_eq!(fs::read_to_string(&bak).unwrap(), go);
 
@@ -441,5 +1048,188 @@ mod tests {
             fs::read_to_string(dir.path().join("app.js")).unwrap(),
             r#"const x = "{{if .X}}";"#
         );
+    }
+
+    #[test]
+    fn rewrite_qr_assignment_common_forms() {
+        let old = r#"document.getElementById("result-qr").src = `/qr?data=${encodeURIComponent(currentLink)}`;"#;
+        let new = rewrite_legacy_qr_js(old);
+        assert_eq!(
+            new,
+            r#"setQrCodeImage(document.getElementById("result-qr"), currentLink);"#
+        );
+        let old2 =
+            r#"document.getElementById('result-qr').src = `/qr?data=${encodeURIComponent(link)}`;"#;
+        let new2 = rewrite_legacy_qr_js(old2);
+        assert!(new2.contains("setQrCodeImage"), "{new2}");
+        assert!(!new2.contains("/qr?data="), "{new2}");
+    }
+
+    #[test]
+    fn migrate_qr_legacy_html_and_assets() {
+        let dir = tempfile::tempdir().unwrap();
+        let html = r#"<!DOCTYPE html>
+<html><head>
+<script src="./main.js"></script>
+</head><body>
+<script>
+document.getElementById("result-qr").src = `/qr?data=${encodeURIComponent(currentLink)}`;
+</script>
+</body></html>"#;
+        fs::write(dir.path().join("index.html"), html).unwrap();
+        fs::write(dir.path().join("main.js"), "function noop() {}\n").unwrap();
+
+        let dry = migrate_www_dir(dir.path(), false).unwrap();
+        assert!(
+            dry.qr_legacy_files.iter().any(|f| f == "index.html"),
+            "{:?}",
+            dry.qr_legacy_files
+        );
+        assert!(dry.dry_needs_apply());
+
+        let applied = migrate_www_dir(dir.path(), true).unwrap();
+        assert!(
+            applied.qr_migrated.iter().any(|f| f == "index.html"),
+            "{:?}",
+            applied.qr_migrated
+        );
+        let body = fs::read_to_string(dir.path().join("index.html")).unwrap();
+        assert!(body.contains("setQrCodeImage"), "{body}");
+        assert!(!body.contains("/qr?data="), "{body}");
+        assert!(
+            body.contains("qrcode.min.js"),
+            "script tag injected: {body}"
+        );
+        assert!(dir.path().join("qrcode.min.js").is_file());
+        let main = fs::read_to_string(dir.path().join("main.js")).unwrap();
+        assert!(main.contains("function setQrCodeImage"), "{main}");
+        assert!(applied.main_js_qr_helper_added || main.contains("setQrCodeImage"));
+        assert!(applied.qrcode_js_copied);
+
+        // Idempotent
+        let again = migrate_www_dir(dir.path(), true).unwrap();
+        assert!(
+            again.qr_legacy_files.is_empty() || again.qr_migrated.is_empty(),
+            "{again:?}"
+        );
+        assert!(!again.qrcode_js_copied);
+    }
+
+    #[test]
+    fn scan_warns_on_obtainium_style_percent_brace() {
+        let src = r#"<!DOCTYPE html><a href="https://example.com/x?j={%22a%22:1}">x</a>"#;
+        let w = scan_literal_brace_warnings(src, "download.html");
+        assert!(!w.is_empty(), "expected warning");
+        assert!(w[0].contains("download.html"));
+        assert!(w[0].contains("raw"));
+    }
+
+    #[test]
+    fn scan_ok_for_normal_minijinja() {
+        let src = r#"{% if RegistrationOpen %}yes{% endif %} {{ MailDomain }}"#;
+        let w = scan_literal_brace_warnings(src, "index.html");
+        assert!(w.is_empty(), "{w:?}");
+    }
+
+    #[test]
+    fn format_template_error_mentions_raw_and_migrate() {
+        let m = format_www_template_error(
+            "download.html",
+            "syntax error: unexpected `.` (in download.html:6)",
+        );
+        assert!(m.contains("download.html"));
+        assert!(m.contains("raw"));
+        assert!(m.contains("html-migrate"));
+    }
+
+    #[test]
+    fn migrate_go_and_qr_together() {
+        let dir = tempfile::tempdir().unwrap();
+        let html = r#"<!DOCTYPE html>
+<head><script src="./main.js"></script></head>
+<body>{{if .RegistrationOpen}}open{{end}}
+<script>
+document.getElementById('result-qr').src = `/qr?data=${encodeURIComponent(currentLink)}`;
+</script>
+</body>"#;
+        fs::write(dir.path().join("index.html"), html).unwrap();
+        fs::write(dir.path().join("main.js"), "// empty\n").unwrap();
+        let r = migrate_www_dir(dir.path(), true).unwrap();
+        assert!(r.go_style_files.iter().any(|f| f == "index.html"));
+        let body = fs::read_to_string(dir.path().join("index.html")).unwrap();
+        assert!(body.contains("{% if RegistrationOpen %}"));
+        assert!(body.contains("setQrCodeImage"));
+        assert!(!body.contains("/qr?data="));
+    }
+
+    /// Prose mentioning `/qr?data=` must not trigger QR migration / script injection.
+    #[test]
+    fn migrate_ignores_qr_prose_mentions() {
+        let dir = tempfile::tempdir().unwrap();
+        let html = r#"<!DOCTYPE html><body>
+<p>The old /qr?data= endpoint was removed; use client-side QR.</p>
+<script src="./main.js"></script>
+</body>"#;
+        fs::write(dir.path().join("docs.html"), html).unwrap();
+        fs::write(dir.path().join("main.js"), "function other() {}\n").unwrap();
+
+        let dry = migrate_www_dir(dir.path(), false).unwrap();
+        assert!(
+            !dry.dry_needs_apply(),
+            "prose-only /qr?data= must not need apply: {:?}",
+            dry.qr_legacy_files
+        );
+
+        let applied = migrate_www_dir(dir.path(), true).unwrap();
+        assert!(applied.migrated.is_empty(), "{applied:?}");
+        assert!(applied.qr_migrated.is_empty(), "{applied:?}");
+        assert!(!applied.qrcode_js_copied);
+        assert!(!applied.main_js_qr_helper_added);
+        let body = fs::read_to_string(dir.path().join("docs.html")).unwrap();
+        assert!(
+            !body.contains("qrcode.min.js"),
+            "must not inject qrcode into prose-only page: {body}"
+        );
+        assert!(!dir.path().join("qrcode.min.js").is_file());
+        let main = fs::read_to_string(dir.path().join("main.js")).unwrap();
+        assert!(
+            !main.contains("setQrCodeImage"),
+            "must not append helper: {main}"
+        );
+    }
+
+    /// Already-modern custom tree (client QR + Minijinja) is a no-op.
+    #[test]
+    fn migrate_modern_client_qr_tree_is_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        let html = r#"<!DOCTYPE html><head>
+<script src="./qrcode.min.js"></script>
+<script src="./main.js"></script>
+</head><body>
+<script>setQrCodeImage(document.getElementById('result-qr'), currentLink);</script>
+{% if RegistrationOpen %}open{% endif %}
+</body>"#;
+        fs::write(dir.path().join("index.html"), html).unwrap();
+        fs::write(
+            dir.path().join("main.js"),
+            "function setQrCodeImage(imgEl, text, cellSize) {}\n",
+        )
+        .unwrap();
+        fs::write(dir.path().join("qrcode.min.js"), "/* stub */\n").unwrap();
+
+        let dry = migrate_www_dir(dir.path(), false).unwrap();
+        assert!(!dry.dry_needs_apply(), "{dry:?}");
+        let applied = migrate_www_dir(dir.path(), true).unwrap();
+        assert!(applied.migrated.is_empty());
+        assert!(applied.qr_migrated.is_empty());
+        assert!(!applied.qrcode_js_copied);
+    }
+
+    #[test]
+    fn source_has_legacy_qr_requires_rewriteable_assignment() {
+        assert!(!source_has_legacy_qr("see /qr?data= in docs"));
+        assert!(source_has_legacy_qr(
+            r#"document.getElementById("result-qr").src = `/qr?data=${encodeURIComponent(currentLink)}`;"#
+        ));
     }
 }

--- a/crates/chatmail/src/ctl/html.rs
+++ b/crates/chatmail/src/ctl/html.rs
@@ -113,7 +113,7 @@ pub async fn html_serve(args: &Args, www_dir: &str) -> Result<()> {
     Ok(())
 }
 
-/// Convert custom `www_dir` Go `html/template` files to Minijinja on disk.
+/// Convert custom `www_dir` Go templates to Minijinja and fix legacy QR/static assets.
 ///
 /// Used interactively by operators and non-interactively from `madmail update`
 /// (re-exec of the new binary after replace).
@@ -150,11 +150,21 @@ pub async fn html_migrate(args: &Args, yes: bool) -> Result<()> {
     }
 
     let dry = migrate_www_dir(www_dir, false)?;
-    if dry.go_style_files.is_empty() {
+    print_literal_brace_warnings(&out, &dry.literal_brace_warnings);
+
+    if !dry.dry_needs_apply() {
         let msg = format!(
-            "Custom www_dir {} has no Go-style HTML templates (already Minijinja or no templates).",
+            "Custom www_dir {} has no Go-style HTML templates and no legacy /qr?data= QR usage \
+             (already Minijinja / client-side QR, or no templates).",
             www_dir.display()
         );
+        if !out.is_json() && !dry.literal_brace_warnings.is_empty() {
+            out.blank();
+            out.line(
+                "Literal `{%` / `{{` warnings above are not auto-fixed — wrap with \
+                 `{% raw %}…{% endraw %}` if they are plain text or URLs.",
+            );
+        }
         return out.done_msg(
             &msg,
             serde_json::json!({
@@ -162,32 +172,54 @@ pub async fn html_migrate(args: &Args, yes: bool) -> Result<()> {
                 "www_dir": www_dir.display().to_string(),
                 "scanned": dry.scanned,
                 "go_style_files": dry.go_style_files,
+                "qr_legacy_files": dry.qr_legacy_files,
+                "literal_brace_warnings": dry.literal_brace_warnings,
                 "action": "noop_already_migrated",
             }),
-            "No Go-style templates found",
+            "No Go-style templates or legacy QR found",
         );
     }
 
     if !out.is_json() {
-        out.line(format!(
-            "Found {} Go-style HTML template(s) under {}:",
-            dry.go_style_files.len(),
-            www_dir.display()
-        ));
-        for (i, f) in dry.go_style_files.iter().enumerate() {
-            if i >= 12 {
-                out.line(format!(
-                    "  … and {} more",
-                    dry.go_style_files.len().saturating_sub(12)
-                ));
-                break;
+        if !dry.go_style_files.is_empty() {
+            out.line(format!(
+                "Found {} Go-style HTML template(s) under {}:",
+                dry.go_style_files.len(),
+                www_dir.display()
+            ));
+            for (i, f) in dry.go_style_files.iter().enumerate() {
+                if i >= 12 {
+                    out.line(format!(
+                        "  … and {} more",
+                        dry.go_style_files.len().saturating_sub(12)
+                    ));
+                    break;
+                }
+                out.line(format!("  - {f}"));
             }
-            out.line(format!("  - {f}"));
+            out.blank();
         }
-        out.blank();
+        if !dry.qr_legacy_files.is_empty() {
+            out.line(format!(
+                "Found {} legacy QR / client-QR asset issue(s) under {}:",
+                dry.qr_legacy_files.len(),
+                www_dir.display()
+            ));
+            for (i, f) in dry.qr_legacy_files.iter().enumerate() {
+                if i >= 12 {
+                    out.line(format!(
+                        "  … and {} more",
+                        dry.qr_legacy_files.len().saturating_sub(12)
+                    ));
+                    break;
+                }
+                out.line(format!("  - {f}"));
+            }
+            out.blank();
+        }
         out.line(
-            "madmail-v2 uses Minijinja. Converting rewrites these files in place \
-             (creates .go-template.bak backups).",
+            "This rewrites Go html/template → Minijinja and/or `/qr?data=` → client-side QR \
+             (setQrCodeImage + qrcode.min.js). Backups: *.go-template.bak / main.js.qr-compat.bak.",
         );
     }
 
@@ -196,7 +228,7 @@ pub async fn html_migrate(args: &Args, yes: bool) -> Result<()> {
         true
     } else if interactive {
         confirm(
-            "Convert custom www templates from Go html/template style to Minijinja?",
+            "Migrate custom www (Go templates → Minijinja and/or legacy QR → client-side)?",
             false,
         )?
     } else {
@@ -213,6 +245,8 @@ pub async fn html_migrate(args: &Args, yes: bool) -> Result<()> {
                 "www_dir": www_dir.display().to_string(),
                 "scanned": dry.scanned,
                 "go_style_files": dry.go_style_files,
+                "qr_legacy_files": dry.qr_legacy_files,
+                "literal_brace_warnings": dry.literal_brace_warnings,
                 "action": "skipped_noninteractive",
             }),
             "Skipped non-interactive",
@@ -221,12 +255,14 @@ pub async fn html_migrate(args: &Args, yes: bool) -> Result<()> {
 
     if !should_apply {
         return out.done_msg(
-            "Left custom www templates unchanged.",
+            "Left custom www templates and QR assets unchanged.",
             serde_json::json!({
                 "config": args.config.display().to_string(),
                 "www_dir": www_dir.display().to_string(),
                 "scanned": dry.scanned,
                 "go_style_files": dry.go_style_files,
+                "qr_legacy_files": dry.qr_legacy_files,
+                "literal_brace_warnings": dry.literal_brace_warnings,
                 "action": "declined",
             }),
             "Declined",
@@ -235,25 +271,58 @@ pub async fn html_migrate(args: &Args, yes: bool) -> Result<()> {
 
     let report = migrate_www_dir(www_dir, true)?;
     if !out.is_json() {
-        out.line(format!(
-            "Migrated {} file(s); backups: {}",
-            report.migrated.len(),
-            report.backups.len()
-        ));
-        for f in &report.migrated {
-            out.line(format!("  ✓ {f}"));
+        if !report.migrated.is_empty() || !report.qr_migrated.is_empty() {
+            out.line(format!(
+                "Migrated {} HTML file(s); QR/static updates: {}; backups: {}",
+                report.migrated.len(),
+                report.qr_migrated.len(),
+                report.backups.len()
+            ));
+            for f in &report.migrated {
+                out.line(format!("  ✓ {f}"));
+            }
+            for f in &report.qr_migrated {
+                if !report.migrated.contains(f) {
+                    out.line(format!("  ✓ QR/static: {f}"));
+                }
+            }
+            if report.qrcode_js_copied {
+                out.line("  ✓ copied qrcode.min.js from embedded assets");
+            }
+            if report.main_js_qr_helper_added {
+                out.line("  ✓ appended setQrCodeImage to main.js");
+            }
         }
         if !report.errors.is_empty() {
             for e in &report.errors {
                 out.line(format!("  ⚠ {e}"));
             }
         }
+        print_literal_brace_warnings(&out, &report.literal_brace_warnings);
+        if !report.literal_brace_warnings.is_empty() {
+            out.blank();
+            out.line(
+                "Literal `{%` / `{{` warnings are not auto-fixed — wrap with \
+                 `{% raw %}…{% endraw %}` if they are plain text or URLs.",
+            );
+        }
     }
+
+    let action = if report.migrated.is_empty()
+        && report.qr_migrated.is_empty()
+        && !report.qrcode_js_copied
+        && !report.main_js_qr_helper_added
+    {
+        "noop_already_migrated"
+    } else {
+        "migrated"
+    };
 
     out.done_msg(
         format!(
-            "Migrated {} template(s) under {}",
+            "Migrated {} template(s), {} QR/static update(s) under {}",
             report.migrated.len(),
+            report.qr_migrated.len(),
             www_dir.display()
         ),
         serde_json::json!({
@@ -262,10 +331,37 @@ pub async fn html_migrate(args: &Args, yes: bool) -> Result<()> {
             "scanned": report.scanned,
             "go_style_files": report.go_style_files,
             "migrated": report.migrated,
+            "qr_legacy_files": report.qr_legacy_files,
+            "qr_migrated": report.qr_migrated,
+            "qrcode_js_copied": report.qrcode_js_copied,
+            "main_js_qr_helper_added": report.main_js_qr_helper_added,
+            "literal_brace_warnings": report.literal_brace_warnings,
             "backups": report.backups,
             "errors": report.errors,
-            "action": "migrated",
+            "action": action,
         }),
-        format!("Migrated {} file(s)", report.migrated.len()),
+        format!(
+            "Migrated {} file(s), {} QR/static",
+            report.migrated.len(),
+            report.qr_migrated.len()
+        ),
     )
+}
+
+fn print_literal_brace_warnings(out: &CtlOut, warnings: &[String]) {
+    if out.is_json() || warnings.is_empty() {
+        return;
+    }
+    out.blank();
+    out.line(format!(
+        "⚠ {} possible literal `{{%` / `{{{{` sequence(s) (Minijinja may 500):",
+        warnings.len()
+    ));
+    for (i, w) in warnings.iter().enumerate() {
+        if i >= 8 {
+            out.line(format!("  … and {} more", warnings.len().saturating_sub(8)));
+            break;
+        }
+        out.line(format!("  - {w}"));
+    }
 }

--- a/crates/chatmail/src/upgrade.rs
+++ b/crates/chatmail/src/upgrade.rs
@@ -667,15 +667,15 @@ fn run_post_upgrade_www_migrate(new_bin: &Path, args: &Args) {
     // and break scripted `madmail update --json` parsers. Operators can migrate later.
     if args.json {
         eprintln!(
-            "ℹ️ --json upgrade: not prompting for www template migration. \
-             If you use a custom www_dir with Go templates, run: \
-             madmail --config {} html-migrate",
+            "ℹ️ --json upgrade: not prompting for www migration. \
+             If you use a custom www_dir (Go templates and/or legacy /qr), run: \
+             madmail --config {} html-migrate --yes",
             args.config.display()
         );
         return;
     }
 
-    eprintln!("🌐 Checking custom www templates (Go → Minijinja)...");
+    eprintln!("🌐 Checking custom www (Go → Minijinja, legacy /qr → client QR)...");
     let mut cmd = Command::new(new_bin);
     cmd.arg("--config").arg(&args.config).arg("html-migrate");
     // Inherit stdin so interactive [y/N] works when the operator is at a TTY.

--- a/docs/TDD/16-testing.md
+++ b/docs/TDD/16-testing.md
@@ -34,6 +34,7 @@ Chatmail's correctness is defined by **real Delta Chat client behavior**, not ju
 | Area | Crate / path | Key tests |
 |------|--------------|-----------|
 | dclogin / `/new` | `chatmail-config`, `chatmail-www` | `build_dclogin_link_matches_www_shape`, `new_account_returns_dclogin_url_with_ssl_hints` |
+| Custom www migrate (Go→Minijinja + legacy `/qr`) | `chatmail-www`, `chatmail` ctl | `www_migrate::*`, `e2e_html_migrate_go_templates_and_legacy_qr`, `e2e_html_migrate_warns_on_literal_brace_url` |
 | cmping IP setup | `context/cmping/test_cmping_dclogin.py` | `test_ip_dclogin_includes_ssl_host_hints` |
 | Auth cache + JIT | `chatmail-state`, `chatmail-auth` | `hydrate_loads_blocklist_and_jit_flag`, `jit_coalesces_concurrent_creates_for_same_user` |
 | TLS for STARTTLS | `chatmail-config` | `listeners_need_tls_cert_for_starttls_only_ports` |

--- a/docs/guide/cli/html-migrate.md
+++ b/docs/guide/cli/html-migrate.md
@@ -1,8 +1,11 @@
 # `html-migrate`
 
-Convert a custom `www_dir` from **Go `html/template`** syntax to **Minijinja** (madmail-v2) on disk.
+Migrate a custom `www_dir` after Go Madmail → madmail-v2:
 
-Use this after a Go Madmail → madmail-v2 upgrade if you customized public HTML pages. The same check runs automatically during [`update`](update.md) / [`upgrade`](upgrade.md) (interactive prompt).
+1. **Go `html/template` → Minijinja** on disk  
+2. **Legacy `/qr?data=` → client-side QR** (`setQrCodeImage` + `qrcode.min.js`)
+
+Use this after upgrade if you customized public HTML pages. The same check runs automatically during [`update`](update.md) / [`upgrade`](upgrade.md) (interactive prompt).
 
 
 ## Synopsis
@@ -30,18 +33,33 @@ madmail html-migrate --yes
 
 1. Reads `www_dir` from the config (`chatmail { www_dir … }` or `www_dir` in TOML).
 2. If **no** custom `www_dir` (embedded site) → nothing to do.
-3. Scans `*.html` under `www_dir` for Go-style markers (`{{if .Field}}`, `{{if not .Field}}`, `{{.MailDomain}}`, `| cleanDomain`, …).
-4. If none found → already Minijinja-style (or no templates).
-5. If found → list sample paths and ask **`[y/N]`** (unless `--yes`).
-6. On yes: rewrite files in place using the same conversion as the server (`prepare_template`), writing a sibling `*.go-template.bak` backup for each changed file.
+3. Scans `*.html` under `www_dir` for:
+   - Go-style markers (`{{if .Field}}`, `{{if not .Field}}`, `{{.MailDomain}}`, `| cleanDomain`, …)
+   - Legacy QR: `/qr?data=…` image assignments (removed endpoint)
+4. Also checks `main.js` / `qrcode.min.js` for client-side QR readiness.
+5. Scans for **suspicious literal `{%` / `{{`** (e.g. Obtainium URLs with `{%22`) and **warns** (does not rewrite those).
+6. If nothing to convert → reports already migrated.
+7. If work found → list paths and ask **`[y/N]`** (unless `--yes`).
+8. On yes:
+   - Rewrite Go templates with the same conversion as the server (`prepare_template`); backup `*.go-template.bak`
+   - Rewrite `/qr?data=${encodeURIComponent(…)}` → `setQrCodeImage(…)`
+   - Append `setQrCodeImage` to `main.js` if missing (backup `main.js.qr-compat.bak`)
+   - Copy embedded `qrcode.min.js` into `www_dir` if missing
+   - Inject `<script src="./qrcode.min.js">` (or `/qrcode.min.js`) before `main.js` when needed
 
-Converted examples:
+### Template conversion examples
 
 | Go (`html/template`) | Minijinja (on disk / after convert) |
 |----------------------|-------------------------------------|
 | `{{if .RegistrationOpen}}…{{end}}` | `{% if RegistrationOpen %}…{% endif %}` |
 | `{{if not .RegistrationOpen}}…{{end}}` | `{% if not RegistrationOpen %}…{% endif %}` |
 | `{{.MailDomain \| cleanDomain}}` | `{{ MailDomain \| clean_domain }}` |
+
+### QR conversion example
+
+| Legacy (broken on v2) | Client-side |
+|----------------------|-------------|
+| `el.src = \`/qr?data=${encodeURIComponent(link)}\`` | `setQrCodeImage(el, link)` |
 
 ## Examples
 
@@ -56,8 +74,10 @@ sudo madmail --config /etc/maddy/maddy.conf html-migrate --yes
 ## Notes
 
 - Runtime still accepts many Go forms via conversion at render time; migrating on disk is for durable, editor-friendly Minijinja sources.
+- QR is **not** fixed at runtime — custom trees that still call `/qr?data=` get a 404 until this migrate (or a manual edit / re-export).
 - Non-interactive sessions without `--yes` skip conversion and print how to re-run with `--yes`.
 - After migration, `madmail reload` or a service restart picks up the files (live `www_dir` re-reads HTML).
+- Literal `{%` / `{{` in URLs must be wrapped in `{% raw %}…{% endraw %}` — see [Customizing HTML pages](../../project/user-guide/17-customizing-html-pages.md).
 
 ## JSON output (`--json`)
 
@@ -65,7 +85,7 @@ sudo madmail --config /etc/maddy/maddy.conf html-migrate --yes
 madmail html-migrate --json --yes
 ```
 
-Success stdout includes `action` (`noop_embedded`, `noop_already_migrated`, `skipped_noninteractive`, `declined`, `migrated`) and file lists.
+Success stdout includes `action` (`noop_embedded`, `noop_already_migrated`, `skipped_noninteractive`, `declined`, `migrated`) plus `go_style_files`, `qr_legacy_files`, `qr_migrated`, `literal_brace_warnings`, and file lists.
 
 Schema: [json-output.md](json-output.md#html-migrate).
 

--- a/docs/guide/cli/json-output.md
+++ b/docs/guide/cli/json-output.md
@@ -1032,13 +1032,18 @@ Setting `embedded` reverts to built-in HTML.
 {
   "ok": true,
   "command": "html-migrate",
-  "message": "Migrated 3 file(s)",
+  "message": "Migrated 3 file(s), 2 QR/static",
   "data": {
     "config": "/etc/maddy/maddy.conf",
     "www_dir": "/var/lib/maddy/www",
     "scanned": 12,
     "go_style_files": ["index.html", "info.html"],
     "migrated": ["index.html", "info.html"],
+    "qr_legacy_files": ["index.html", "main.js"],
+    "qr_migrated": ["index.html", "main.js", "qrcode.min.js"],
+    "qrcode_js_copied": true,
+    "main_js_qr_helper_added": true,
+    "literal_brace_warnings": [],
     "backups": ["/var/lib/maddy/www/index.html.go-template.bak"],
     "errors": [],
     "action": "migrated"
@@ -1047,6 +1052,8 @@ Setting `embedded` reverts to built-in HTML.
 ```
 
 `action` may be `noop_embedded`, `noop_already_migrated`, `skipped_noninteractive`, `declined`, or `migrated`. Use `--yes` with `--json` to apply without a TTY.
+
+Also rewrites legacy `/qr?data=` to client-side QR and may copy `qrcode.min.js`. `literal_brace_warnings` lists suspicious `{%` / `{{` in content (not auto-fixed).
 
 ---
 

--- a/docs/guide/cli/upgrade.md
+++ b/docs/guide/cli/upgrade.md
@@ -35,7 +35,7 @@ madmail upgrade <PATH_OR_URL> [--accept-unsafe-https]
 3. Verifies an **Ed25519 signature** in the last 64 bytes of the binary.
 4. Stops the systemd service (and iroh-relay when present).
 5. Replaces the current executable.
-6. **Custom www templates:** runs the new binary’s [`html-migrate`](html-migrate.md) against `--config`. If `www_dir` points at a custom site that still uses Go `html/template` syntax, you are prompted to convert files to Minijinja (backups as `*.go-template.bak`). Decline or non-interactive sessions leave files unchanged; re-run `madmail html-migrate` later if needed.
+6. **Custom www templates:** runs the new binary’s [`html-migrate`](html-migrate.md) against `--config`. If `www_dir` points at a custom site that still uses Go `html/template` syntax and/or legacy `/qr?data=` QR image URLs, you are prompted to convert (Minijinja + client-side QR; backups as `*.go-template.bak` / `main.js.qr-compat.bak`). Decline or non-interactive sessions leave files unchanged; re-run `madmail html-migrate --yes` later if needed.
 7. Restarts the systemd service when applicable and refreshes man/completions.
 
 ## Examples

--- a/docs/man/madmail.1
+++ b/docs/man/madmail.1
@@ -82,8 +82,8 @@ preserve selected artifacts.\&
 .RS 4
 Replace this executable from a signed local file or URL
 (raw binary or .tar.gz / .tgz archive).\&
-After replace, may prompt to convert custom \fBwww_dir\fR Go templates
-to Minijinja (see \fBhtml-migrate\fR).\&
+After replace, may prompt to migrate custom \fBwww_dir\fR (Go templates
+to Minijinja and legacy \fB/qr\fR to client-side QR; see \fBhtml-migrate\fR).\&
 .PP
 .RE
 \fBreload\fR
@@ -238,8 +238,9 @@ built-in files).\&
 .RE
 \fBhtml-migrate\fR
 .RS 4
-Convert custom \fBwww_dir\fR HTML from Go \fBhtml/template\fR syntax to
-Minijinja (interactive; \fB--yes\fR for scripts).\&
+Migrate custom \fBwww_dir\fR: Go \fBhtml/template\fR to Minijinja and
+legacy \fB/qr?data=\fR QR to client-side \fBsetQrCodeImage\fR
+(interactive; \fB--yes\fR for scripts).\&
 .PP
 .RE
 \fBhash\fR

--- a/docs/project/user-guide/02-quick-start.md
+++ b/docs/project/user-guide/02-quick-start.md
@@ -105,7 +105,7 @@ sudo madmail upgrade <path-or-url>
   4. If the signature is invalid or missing, the upgrade is **aborted** — the binary is never installed. This protects against compromised or tampered releases.
   5. Stops the `madmail.service` (and iroh-relay if present).
   6. Atomically replaces the running binary.
-  7. May prompt to convert custom `www_dir` Go templates to Minijinja (`html-migrate`).
+  7. May prompt to convert custom `www_dir` Go templates to Minijinja and fix legacy `/qr?data=` QR (`html-migrate`).
   8. Restarts the service(s).
 
 This is the supported way to update a production server with signature verification.

--- a/docs/project/user-guide/17-customizing-html-pages.md
+++ b/docs/project/user-guide/17-customizing-html-pages.md
@@ -113,8 +113,27 @@ If you keep a customized `www_dir` from Go Madmail:
 1. After binary upgrade, `madmail update` / `upgrade` offers to convert those files (or run `madmail html-migrate` yourself).
 2. Accepting creates `*.go-template.bak` backups and rewrites HTML in place.
 3. The server can still convert many Go forms at render time, but migrating on disk keeps your sources consistent with the v2 engine.
+4. The same command also fixes **legacy QR** usage (`/qr?data=…` → client-side `setQrCodeImage` + `qrcode.min.js`). The old `/qr` HTTP endpoint is gone.
 
 See the CLI reference: [html-migrate](../../guide/cli/html-migrate.md).
+
+## Literal `{%` and `{{` in custom HTML (Obtainium URLs, etc.)
+
+Minijinja treats **`{%`** and **`{{`** as template syntax everywhere in the file — including inside `href`, scripts, and plain text.
+
+That breaks custom pages that embed deep links or app-store URLs containing those sequences. A common case is **Obtainium**-style links where URL-encoding produces `{%22` (a `{` followed by `%22…`).
+
+**Symptoms:** HTTP 500 on the page; logs like `www template render` / `syntax error` mentioning the file.
+
+**Fix:** wrap the literal content so the engine does not parse it:
+
+```html
+{% raw %}
+<a href="https://example.com/install?config={%22id%22:%22app%22}">Download</a>
+{% endraw %}
+```
+
+`html-migrate` **warns** about suspicious `{%` / `{{` sequences but does **not** auto-wrap them (that could break real templates). After editing, reload or restart the service.
 
 ## Common Examples
 

--- a/tests/ctl_ops_e2e.rs
+++ b/tests/ctl_ops_e2e.rs
@@ -172,3 +172,153 @@ fn e2e_html_export_writes_files() {
 
     assert!(out.join("index.html").is_file());
 }
+
+/// Go-style custom www + legacy `/qr?data=` → `html-migrate --yes` rewrites templates and QR.
+#[test]
+fn e2e_html_migrate_go_templates_and_legacy_qr() {
+    use std::fs;
+
+    let dir = TempDir::new().expect("tempdir");
+    let state = dir.path().join("state");
+    fs::create_dir_all(&state).unwrap();
+    let www = dir.path().join("www");
+    fs::create_dir_all(&www).unwrap();
+
+    let conf = dir.path().join("chatmail.toml");
+    fs::write(
+        &conf,
+        format!("hostname = \"e2e.test\"\nwww_dir = \"{}\"\n", www.display()),
+    )
+    .unwrap();
+
+    fs::write(
+        www.join("index.html"),
+        r#"<!DOCTYPE html>
+<html>
+<head>
+<script src="./main.js"></script>
+</head>
+<body>
+{{if .RegistrationOpen}}open{{else}}closed{{end}}
+<script>
+document.getElementById("result-qr").src = `/qr?data=${encodeURIComponent(currentLink)}`;
+</script>
+</body>
+</html>"#,
+    )
+    .unwrap();
+    fs::write(www.join("main.js"), "function noop() {}\n").unwrap();
+
+    let assert = chatmail()
+        .args([
+            "--state-dir",
+            state.to_str().unwrap(),
+            "--config",
+            conf.to_str().unwrap(),
+            "--json",
+            "html-migrate",
+            "--yes",
+        ])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(
+        stdout.contains("\"action\":\"migrated\"") || stdout.contains("\"action\": \"migrated\""),
+        "stdout={stdout}"
+    );
+    assert!(
+        stdout.contains("index.html"),
+        "expected index.html in migrate JSON: {stdout}"
+    );
+
+    let body = fs::read_to_string(www.join("index.html")).unwrap();
+    assert!(
+        body.contains("{% if RegistrationOpen %}"),
+        "Go→Minijinja: {body}"
+    );
+    assert!(
+        body.contains("setQrCodeImage"),
+        "legacy QR rewritten: {body}"
+    );
+    assert!(
+        !body.contains("/qr?data="),
+        "legacy /qr?data= should be gone: {body}"
+    );
+    assert!(body.contains("qrcode.min.js"), "qrcode script tag: {body}");
+    assert!(
+        www.join("qrcode.min.js").is_file(),
+        "qrcode.min.js copied into www_dir"
+    );
+    let main = fs::read_to_string(www.join("main.js")).unwrap();
+    assert!(
+        main.contains("function setQrCodeImage"),
+        "helper appended: {main}"
+    );
+    assert!(
+        www.join("index.html.go-template.bak").is_file(),
+        "HTML backup"
+    );
+    assert!(
+        www.join("main.js.qr-compat.bak").is_file(),
+        "main.js backup"
+    );
+
+    // Second run is a no-op (already migrated).
+    chatmail()
+        .args([
+            "--state-dir",
+            state.to_str().unwrap(),
+            "--config",
+            conf.to_str().unwrap(),
+            "--json",
+            "html-migrate",
+            "--yes",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("noop_already_migrated"));
+}
+
+/// Custom page with Obtainium-style `{%22` is warned about (not silently ignored).
+#[test]
+fn e2e_html_migrate_warns_on_literal_brace_url() {
+    use std::fs;
+
+    let dir = TempDir::new().expect("tempdir");
+    let state = dir.path().join("state");
+    fs::create_dir_all(&state).unwrap();
+    let www = dir.path().join("www");
+    fs::create_dir_all(&www).unwrap();
+    let conf = dir.path().join("chatmail.toml");
+    fs::write(
+        &conf,
+        format!("hostname = \"e2e.test\"\nwww_dir = \"{}\"\n", www.display()),
+    )
+    .unwrap();
+
+    // Minijinja-valid structure + Obtainium-style URL (will 500 if rendered without raw).
+    fs::write(
+        www.join("download.html"),
+        r#"<!DOCTYPE html><a href="https://example.com/x?j={%22a%22:1}">x</a>"#,
+    )
+    .unwrap();
+
+    let assert = chatmail()
+        .args([
+            "--state-dir",
+            state.to_str().unwrap(),
+            "--config",
+            conf.to_str().unwrap(),
+            "--json",
+            "html-migrate",
+            "--yes",
+        ])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(stdout.contains("literal_brace_warnings"), "stdout={stdout}");
+    assert!(
+        stdout.contains("download.html") || stdout.contains("raw"),
+        "expected warning payload: {stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

After Go Madmail → madmail-v2 upgrades, custom `www_dir` trees still broke in two ways reported in #96:

1. **QR:** pages still called removed `/qr?data=…` (404).
2. **Templates:** Go → Minijinja was already handled by `html-migrate`, but operators also hit **500s** on custom pages with literal `{%` in URLs (e.g. Obtainium `{%22…`).

This PR extends **`html-migrate`** (also run from `update`/`upgrade`) to fix client-side QR/static assets, improves render-error hints, and documents `{% raw %}` for literal braces.

**Fixes #96**

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Build / CI / tooling
- [ ] Refactor (no functional change)

## Area

- [ ] SMTP
- [ ] IMAP
- [ ] Federation / delivery queue
- [ ] Authentication / JIT
- [ ] Admin API / admin web UI (`external/madmail-admin-web`)
- [ ] TURN / Iroh / proxy services
- [ ] Storage / quota / DB migrations
- [x] Configuration / CLI
- [x] Docs (`docs/project/`, `docs/TDD/`, user guide)
- [x] Other: public www (`chatmail-www` migrate + template render errors)

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (via `make lint`; also `cargo clippy -p chatmail-www -p chatmail --tests -- -D warnings`)
- [x] `cargo test --workspace` (or targeted crate/tests: `cargo test -p chatmail-www --lib`; `cargo test -p chatmail-integration --test ctl_ops_e2e`)
- [x] Manual / E2E verification (describe below)

**Manual verification (if any):**

```text
# Unit / integration
cargo build -p chatmail --bin madmail
cargo test -p chatmail-www --lib
cargo test -p chatmail-integration --test ctl_ops_e2e

# CLI functional (temp www trees)
madmail html-export … / html-migrate --yes
# — modern export migrate, legacy Go+/qr tree, prose /qr ignore,
#   Obtainium brace warnings, embedded noop, node QR data-URL check
# → 27/27 pass

# Live HTTP server (custom www_dir, 127.0.0.1:18080)
# GET / 200 Minijinja + setQrCodeImage; /main.js + /qrcode.min.js 200
# GET /qr?data= 404; go-page.html runtime Go convert 200
# download.html 500 + raw/html-migrate hint in log
# download-raw.html 200; live disk reload; POST /new 200
# → 30/30 pass
```

## Documentation

- [ ] No doc updates needed
- [x] Updated operator/user docs (`docs/project/user-guide/`, install guides)
- [ ] Updated developer docs (`docs/project/`)
- [x] Updated or added TDD section (`docs/TDD/`) — required for significant design changes

Also: `docs/guide/cli/html-migrate.md`, `json-output.md`, `upgrade.md`, `docs/man/madmail.1`

## Security & privacy

- [x] Not security-sensitive
- [ ] Security-sensitive — added/updated tests for the security property
- [x] Reviewed error messages for information leakage

(Render errors add operator hints only; no credentials or path secrets beyond template file names already logged.)

## Commits

- `feat:` new feature
- `fix:` bug fix
- `docs:` documentation
- `refactor:` code change without feature/fix
- `test:` tests only
- `chore:` tooling, deps, release

This PR: `fix(www): migrate legacy /qr and warn on literal template braces`

## Checklist

- [x] PR is focused and reviewable (small vertical slices preferred)
- [x] No secrets, `data/`, `target/`, or `node_modules/` committed
- [x] Submodule pointers updated if `external/madmail-admin-web` changed (N/A)
- [x] Behavior parity with Madmail v1 considered (or intentional difference documented)

`/qr` HTTP PNG endpoint stays removed; custom trees get client-side QR via migrate (same as current embedded `www-src`). Go templates still convert at runtime and on disk.

### Operator note

```bash
sudo madmail --config /path/to/service.conf html-migrate --yes
```

Rewrites Go→Minijinja, `/qr?data=`→`setQrCodeImage`, ensures `qrcode.min.js` / helper; warns on suspicious literal `{%`/`{{` (does not auto-wrap).