### PR TITLE
feat(windows): platform install paths and TLS first-run bootstrap

### DIFF
--- a/crates/chatmail/src/ctl/install/mod.rs
+++ b/crates/chatmail/src/ctl/install/mod.rs
@@ -113,6 +113,7 @@ pub async fn install(global: &Args, args: &InstallArgs) -> Result<()> {
         system::install_binary(&cfg, false)?;
         docs::install_cli_docs(&cfg.binary_name, false)?;
     }
+    #[cfg(unix)]
     if cfg.system_install && !args.skip_systemd {
         systemd::install_unit(&cfg)?;
         systemd::daemon_reload()?;
@@ -360,6 +361,13 @@ fn print_next_steps(cfg: &InstallConfig) {
             cfg.config_path.display(),
             cfg.state_dir.display()
         );
+        #[cfg(windows)]
+        {
+            println!(
+                "  • Windows service (later): madmail service install|start  (when available)"
+            );
+            println!("  • Prefer the Madmail setup wizard for non-technical installs.");
+        }
     }
     println!("  • Admin:  madmail admin-token");
     if cfg.system_install {
@@ -426,14 +434,25 @@ impl InstallConfig {
             .clone()
             .unwrap_or_else(|| cert_dir.join("privkey.pem"));
 
+        // System install (service user + systemd unit) is Unix-only. On Windows,
+        // install always writes local ProgramData-style paths without systemd.
+        #[cfg(windows)]
+        let system_install = false;
+        #[cfg(not(windows))]
         let system_install = config_dir.starts_with("/etc/")
             || state_dir.starts_with("/var/lib/")
             || (args.simple && !paths_explicit);
 
-        let binary_path = args
-            .binary_path
-            .clone()
-            .unwrap_or_else(|| PathBuf::from(format!("/usr/local/bin/{binary_name}")));
+        let binary_path = args.binary_path.clone().unwrap_or_else(|| {
+            #[cfg(windows)]
+            {
+                PathBuf::from(format!("{binary_name}.exe"))
+            }
+            #[cfg(not(windows))]
+            {
+                PathBuf::from(format!("/usr/local/bin/{binary_name}"))
+            }
+        });
 
         let (primary_domain, hostname, public_ip, local_domains, turn_off_tls) = if args.simple {
             if let Some(domain) = args.domain.clone() {
@@ -523,8 +542,17 @@ impl InstallConfig {
             hostname,
             primary_domain,
             local_domains,
+            runtime_dir: {
+                #[cfg(windows)]
+                {
+                    state_dir.join("run").to_string_lossy().into_owned()
+                }
+                #[cfg(not(windows))]
+                {
+                    format!("/run/{binary_name}")
+                }
+            },
             state_dir,
-            runtime_dir: format!("/run/{binary_name}"),
             public_ip,
             tls_mode: args.tls_mode.clone().unwrap_or_default(),
             cert_path,
@@ -566,13 +594,37 @@ fn ensure_ss_password(cfg: &mut InstallConfig) -> Result<()> {
     Ok(())
 }
 
-/// Madmail `install.go` always uses `/var/lib/<binary>` for production installs, never cwd `./data`.
+/// Production install config dir: FHS on Unix, `%ProgramData%\Madmail\config` on Windows.
 fn default_install_config_dir() -> PathBuf {
-    PathBuf::from("/etc/madmail")
+    #[cfg(windows)]
+    {
+        windows_madmail_root().join("config")
+    }
+    #[cfg(not(windows))]
+    {
+        PathBuf::from("/etc/madmail")
+    }
 }
 
+/// Production install state dir: `/var/lib/<binary>` on Unix, `%ProgramData%\Madmail\data` on Windows.
 fn default_install_state_dir(binary_name: &str) -> PathBuf {
-    PathBuf::from(format!("/var/lib/{binary_name}"))
+    #[cfg(windows)]
+    {
+        let _ = binary_name;
+        windows_madmail_root().join("data")
+    }
+    #[cfg(not(windows))]
+    {
+        PathBuf::from(format!("/var/lib/{binary_name}"))
+    }
+}
+
+#[cfg(windows)]
+fn windows_madmail_root() -> PathBuf {
+    std::env::var_os("PROGRAMDATA")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(r"C:\ProgramData"))
+        .join("Madmail")
 }
 
 fn resolve_install_state_dir(
@@ -584,13 +636,21 @@ fn resolve_install_state_dir(
     if let Some(dir) = &args.state_dir {
         return dir.clone();
     }
-    if args.simple || config_dir.starts_with("/etc/") {
-        return PathBuf::from(format!("/var/lib/{binary_name}"));
+    #[cfg(windows)]
+    {
+        let _ = (global, config_dir);
+        return default_install_state_dir(binary_name);
     }
-    if global.state_dir.is_relative() || is_local_dev_state_dir(&global.state_dir) {
-        return PathBuf::from(format!("/var/lib/{binary_name}"));
+    #[cfg(not(windows))]
+    {
+        if args.simple || config_dir.starts_with("/etc/") {
+            return PathBuf::from(format!("/var/lib/{binary_name}"));
+        }
+        if global.state_dir.is_relative() || is_local_dev_state_dir(&global.state_dir) {
+            return PathBuf::from(format!("/var/lib/{binary_name}"));
+        }
+        global.state_dir.clone()
     }
-    global.state_dir.clone()
 }
 
 fn chrono_like_now() -> String {
@@ -665,16 +725,51 @@ mod tests {
         assert!(!cfg_ip.turn_off_tls);
         assert!(cfg.enable_ss);
         assert!(cfg.enable_turn);
-        assert!(cfg.cert_path.starts_with("/etc/madmail/certs"));
-        assert!(
-            cfg.state_dir.starts_with("/var/lib/"),
-            "state_dir {:?}",
-            cfg.state_dir
-        );
-        assert!(!cfg.state_dir.to_string_lossy().contains("./data"));
-        assert!(cfg.system_install);
-        assert!(cfg.use_default_systemd_paths);
+        #[cfg(not(windows))]
+        {
+            assert!(cfg.cert_path.starts_with("/etc/madmail/certs"));
+            assert!(
+                cfg.state_dir.starts_with("/var/lib/"),
+                "state_dir {:?}",
+                cfg.state_dir
+            );
+            assert!(!cfg.state_dir.to_string_lossy().contains("./data"));
+            assert!(cfg.system_install);
+            assert!(cfg.use_default_systemd_paths);
+        }
+        #[cfg(windows)]
+        {
+            assert!(!cfg.system_install);
+            assert!(
+                cfg.config_dir.ends_with("Madmail\\config")
+                    || cfg.config_dir.ends_with("Madmail/config"),
+                "config_dir {:?}",
+                cfg.config_dir
+            );
+            assert!(
+                cfg.state_dir.ends_with("Madmail\\data") || cfg.state_dir.ends_with("Madmail/data"),
+                "state_dir {:?}",
+                cfg.state_dir
+            );
+            assert!(cfg.runtime_dir.contains("run"));
+        }
         assert_eq!(cfg.language, "en");
+    }
+
+    #[test]
+    fn default_install_paths_are_platform_specific() {
+        let config = default_install_config_dir();
+        let state = default_install_state_dir("madmail");
+        #[cfg(not(windows))]
+        {
+            assert_eq!(config, PathBuf::from("/etc/madmail"));
+            assert_eq!(state, PathBuf::from("/var/lib/madmail"));
+        }
+        #[cfg(windows)]
+        {
+            assert!(config.ends_with("Madmail\\config") || config.ends_with("Madmail/config"));
+            assert!(state.ends_with("Madmail\\data") || state.ends_with("Madmail/data"));
+        }
     }
 
     #[test]

--- a/crates/chatmail/src/lib.rs
+++ b/crates/chatmail/src/lib.rs
@@ -26,5 +26,6 @@ pub mod push_boot;
 pub mod servers;
 pub mod ss_boot;
 pub mod supervisor;
+pub mod tls_boot;
 pub mod turn_boot;
 pub mod upgrade;

--- a/crates/chatmail/src/supervisor.rs
+++ b/crates/chatmail/src/supervisor.rs
@@ -22,8 +22,7 @@ use axum::Router;
 use chatmail_config::{
     effective_http_plain_listen, effective_http_tls_listen, effective_imap_plain_listen,
     effective_imap_tls_listen, effective_smtp_listen, effective_submission_plain_listen,
-    effective_submission_tls_listen, effective_tls_pem_paths, listeners_need_tls_cert, AppConfig,
-    RuntimeListeners,
+    effective_submission_tls_listen, listeners_need_tls_cert, AppConfig, RuntimeListeners,
 };
 use chatmail_db::{load_mail_port_overrides, DbPool};
 use chatmail_delivery::{start_outbound_queue, DeliveryContext};
@@ -312,7 +311,8 @@ impl SupervisorInner {
         if !listeners_need_tls_cert(&runtime) {
             return Ok(None);
         }
-        let (cert, key) = effective_tls_pem_paths(&self.file_config, &self.state_dir);
+        let (cert, key) =
+            crate::tls_boot::ensure_tls_pem_files(&self.file_config, &self.state_dir)?;
         Ok(Some(load_server_config(&cert, &key)?))
     }
 

--- a/crates/chatmail/src/tls_boot.rs
+++ b/crates/chatmail/src/tls_boot.rs
@@ -89,9 +89,7 @@ fn identity_name(config: &AppConfig) -> String {
 }
 
 fn strip_brackets(s: &str) -> String {
-    s.trim()
-        .trim_matches(|c| c == '[' || c == ']')
-        .to_string()
+    s.trim().trim_matches(|c| c == '[' || c == ']').to_string()
 }
 
 fn missing_tls_error(cert: &Path, key: &Path) -> ChatmailError {

--- a/crates/chatmail/src/tls_boot.rs
+++ b/crates/chatmail/src/tls_boot.rs
@@ -1,0 +1,188 @@
+// Copyright (C) 2026 themadorg
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Bootstrap TLS PEMs for first-run / `tls_mode self_signed`, with actionable errors.
+
+use std::path::{Path, PathBuf};
+
+use chatmail_acme::generate_self_signed;
+use chatmail_config::{effective_tls_pem_paths, AppConfig};
+use chatmail_types::{ChatmailError, Result};
+
+/// Ensure cert/key PEMs exist for listeners that need TLS.
+///
+/// When files are missing:
+/// - `tls_mode self_signed`, or bare defaults (no mode and no explicit `tls file` paths):
+///   generate a self-signed pair under the effective PEM paths.
+/// - `autocert` / `file` / explicit paths: return a configuration error with next steps.
+pub fn ensure_tls_pem_files(config: &AppConfig, state_dir: &Path) -> Result<(PathBuf, PathBuf)> {
+    let (cert, key) = effective_tls_pem_paths(config, state_dir);
+    if cert.is_file() && key.is_file() {
+        return Ok((cert, key));
+    }
+
+    if should_bootstrap_self_signed(config) {
+        let domain = identity_name(config);
+        let hostname = config
+            .hostname
+            .as_deref()
+            .map(strip_brackets)
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| domain.clone());
+        let public_ip = config
+            .public_ip
+            .as_deref()
+            .map(strip_brackets)
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| domain.clone());
+
+        eprintln!(
+            "TLS certificates missing; generating self-signed certificate for {domain}\n  cert: {}\n  key:  {}",
+            cert.display(),
+            key.display()
+        );
+        generate_self_signed(&domain, &hostname, &public_ip, &cert, &key)?;
+        return Ok((cert, key));
+    }
+
+    Err(missing_tls_error(&cert, &key))
+}
+
+/// Bootstrap when operators chose self-signed, or when running with no TLS mode and
+/// no explicit PEM paths (typical first double-click / bare `madmail run`).
+pub fn should_bootstrap_self_signed(config: &AppConfig) -> bool {
+    match config
+        .tls_mode
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        Some("self_signed") => true,
+        Some(_) => false,
+        None => config.tls_cert_path.is_none() && config.tls_key_path.is_none(),
+    }
+}
+
+fn identity_name(config: &AppConfig) -> String {
+    config
+        .primary_domain
+        .as_deref()
+        .or(config.hostname.as_deref())
+        .or(config.public_ip.as_deref())
+        .map(strip_brackets)
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "127.0.0.1".into())
+}
+
+fn strip_brackets(s: &str) -> String {
+    s.trim()
+        .trim_matches(|c| c == '[' || c == ']')
+        .to_string()
+}
+
+fn missing_tls_error(cert: &Path, key: &Path) -> ChatmailError {
+    ChatmailError::config(format!(
+        "TLS certificate not found: {}\n  private key: {}\n\n\
+         Madmail needs PEM files before SMTP/IMAP/HTTPS listeners can start.\n\n\
+         First-time / local setup (self-signed):\n\
+           madmail install --simple --ip <YOUR_IP_OR_127.0.0.1> --tls-mode self_signed --lang en\n\
+         On Windows, defaults write under %ProgramData%\\Madmail (no Unix FHS paths).\n\
+         Prefer the Windows setup wizard when available.\n\n\
+         Then start:\n\
+           madmail --config <config> run --libexec <state-dir>\n\n\
+         Let's Encrypt (public IP/domain, port 80 free):\n\
+           madmail install --simple --ip <PUBLIC_IP> --auto-ip-cert --acme-email you@example.com\n\
+           # or: madmail certificate get\n\n\
+         Or place fullchain.pem + privkey.pem at the paths above.",
+        cert.display(),
+        key.display()
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chatmail_tls::load_server_config;
+
+    #[test]
+    fn bootstrap_when_self_signed_mode() {
+        let cfg = AppConfig {
+            tls_mode: Some("self_signed".into()),
+            ..Default::default()
+        };
+        assert!(should_bootstrap_self_signed(&cfg));
+    }
+
+    #[test]
+    fn bootstrap_when_no_tls_mode_and_no_explicit_paths() {
+        assert!(should_bootstrap_self_signed(&AppConfig::default()));
+    }
+
+    #[test]
+    fn no_bootstrap_for_autocert_or_file() {
+        for mode in ["autocert", "file"] {
+            let cfg = AppConfig {
+                tls_mode: Some(mode.into()),
+                ..Default::default()
+            };
+            assert!(!should_bootstrap_self_signed(&cfg), "mode={mode}");
+        }
+    }
+
+    #[test]
+    fn no_bootstrap_when_explicit_pem_paths_without_mode() {
+        let cfg = AppConfig {
+            tls_cert_path: Some(PathBuf::from("/etc/madmail/certs/fullchain.pem")),
+            tls_key_path: Some(PathBuf::from("/etc/madmail/certs/privkey.pem")),
+            ..Default::default()
+        };
+        assert!(!should_bootstrap_self_signed(&cfg));
+    }
+
+    #[test]
+    fn ensure_generates_loadable_self_signed() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = AppConfig {
+            tls_mode: Some("self_signed".into()),
+            hostname: Some("127.0.0.1".into()),
+            primary_domain: Some("127.0.0.1".into()),
+            ..Default::default()
+        };
+        let (cert, key) = ensure_tls_pem_files(&cfg, dir.path()).unwrap();
+        assert!(cert.is_file());
+        assert!(key.is_file());
+        load_server_config(&cert, &key).unwrap();
+        // Second call is a no-op load path.
+        let (cert2, key2) = ensure_tls_pem_files(&cfg, dir.path()).unwrap();
+        assert_eq!(cert, cert2);
+        assert_eq!(key, key2);
+    }
+
+    #[test]
+    fn ensure_errors_helpfully_for_file_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = AppConfig {
+            tls_mode: Some("file".into()),
+            ..Default::default()
+        };
+        let err = ensure_tls_pem_files(&cfg, dir.path()).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("TLS certificate not found"), "{msg}");
+        assert!(msg.contains("install --simple"), "{msg}");
+        assert!(msg.contains("Windows"), "{msg}");
+    }
+}


### PR DESCRIPTION
## Summary

Windows install foundation for the installer stack (issue #99): platform-specific install defaults and first-run TLS bootstrap so bare `madmail.exe` / missing PEMs no longer fail with only `os error 3`.

- Windows install defaults to `%ProgramData%\Madmail\{config,data}`; `system_install` is always false (no systemd).
- Unix FHS defaults (`/etc/madmail`, `/var/lib/<binary>`) unchanged.
- New `tls_boot`: auto-generate self-signed PEMs for `tls_mode self_signed` or bare defaults; otherwise multi-line actionable error pointing at `install` / certificate steps.
- Supervisor loads PEMs via `ensure_tls_pem_files`.

**Stack:** PR 1 of 7 → base `feat/windows-installer` (not `main`).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Build / CI / tooling
- [ ] Refactor (no functional change)

## Area

- [ ] SMTP
- [ ] IMAP
- [ ] Federation / delivery queue
- [ ] Authentication / JIT
- [ ] Admin API / admin web UI (`external/madmail-admin-web`)
- [ ] TURN / Iroh / proxy services
- [ ] Storage / quota / DB migrations
- [x] Configuration / CLI
- [ ] Docs (`docs/project/`, `docs/TDD/`, user guide)
- [x] Other: Windows install paths / first-run TLS bootstrap

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (or targeted crate/tests: `cargo test -p chatmail --lib tls_boot`; `simple_ip_install`; `default_install_paths`)
- [ ] Manual / E2E verification (describe below)

**Manual verification (if any):**

```text
Unit tests only on Linux CI host. Full Windows smoke deferred to feature-branch Windows CI (later PRs).
```

## Documentation

- [x] No doc updates needed
- [ ] Updated operator/user docs (`docs/project/user-guide/`, install guides)
- [ ] Updated developer docs (`docs/project/`)
- [ ] Updated or added TDD section (`docs/TDD/`) — required for significant design changes

## Security & privacy

- [x] Not security-sensitive
- [ ] Security-sensitive — added/updated tests for the security property
- [x] Reviewed error messages for information leakage

## Commits

- `feat:` new feature
- `fix:` bug fix
- `docs:` documentation
- `refactor:` code change without feature/fix
- `test:` tests only
- `chore:` tooling, deps, release

## Checklist

- [x] PR is focused and reviewable (small vertical slices preferred)
- [x] No secrets, `data/`, `target/`, or `node_modules/` committed
- [ ] Submodule pointers updated if `external/madmail-admin-web` changed
- [x] Behavior parity with Madmail v1 considered (or intentional difference documented)

## Related

- Epic: #103
- User report: #99
- Milestone: Windows installer (full production pack)