### PR TITLE
feat(windows): firewall rules, install service flags, uninstall

### DIFF
--- a/crates/chatmail-config/src/cli.rs
+++ b/crates/chatmail-config/src/cli.rs
@@ -220,6 +220,11 @@ pub enum Command {
     /// On non-Windows platforms these subcommands return a clear error.
     #[command(subcommand)]
     Service(ServiceCommand),
+    /// Windows Firewall rules for Madmail listeners (`apply`, `remove`).
+    ///
+    /// On non-Windows platforms these subcommands return a clear error.
+    #[command(subcommand)]
+    Firewall(FirewallCommand),
     /// Local credentials management.
     Creds,
     /// Enable, disable, or inspect WebIMAP HTTP API.
@@ -660,6 +665,28 @@ pub enum ServiceCommand {
     },
 }
 
+/// Prefix for Madmail Windows Firewall rule display names (`Madmail (SMTP)`, …).
+pub const FIREWALL_RULE_PREFIX: &str = "Madmail";
+
+/// `madmail firewall` — Windows Firewall inbound rules (error on Unix).
+#[derive(Debug, Subcommand, Clone)]
+pub enum FirewallCommand {
+    /// Create named inbound allow rules for mail/HTTP ports.
+    Apply {
+        /// Also open TURN (UDP/TCP 3478).
+        #[arg(long)]
+        turn: bool,
+        /// Also open Shadowsocks (TCP 8388).
+        #[arg(long)]
+        ss: bool,
+        /// Also open Iroh relay (TCP 3340).
+        #[arg(long)]
+        iroh: bool,
+    },
+    /// Delete all firewall rules whose names start with `Madmail`.
+    Remove,
+}
+
 /// `chatmail registration` — `__REGISTRATION_OPEN__`.
 #[derive(Debug, Subcommand, Clone)]
 pub enum RegistrationCommand {
@@ -1020,6 +1047,29 @@ mod tests {
                 name,
                 start: true,
             })) if name == "MadmailTest"
+        ));
+    }
+
+    #[test]
+    fn firewall_subcommands_parse() {
+        use super::FirewallCommand;
+
+        let cli = Cli::try_parse_from(["chatmail", "firewall", "remove"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Firewall(FirewallCommand::Remove))
+        ));
+
+        let cli =
+            Cli::try_parse_from(["chatmail", "firewall", "apply", "--turn", "--ss", "--iroh"])
+                .unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Firewall(FirewallCommand::Apply {
+                turn: true,
+                ss: true,
+                iroh: true,
+            }))
         ));
     }
 

--- a/crates/chatmail-config/src/install_cli.rs
+++ b/crates/chatmail-config/src/install_cli.rs
@@ -88,6 +88,18 @@ pub struct InstallArgs {
     #[arg(long)]
     pub skip_user: bool,
 
+    /// Register a Windows service after install (no-op notice on Unix).
+    #[arg(long)]
+    pub install_service: bool,
+
+    /// Start the Windows service after install (implies service registration on Windows).
+    #[arg(long)]
+    pub start_service: bool,
+
+    /// Open Windows Firewall rules for standard mail/HTTP ports (no-op notice on Unix).
+    #[arg(long)]
+    pub firewall: bool,
+
     /// Install path for the binary (default: `/usr/local/bin/<argv0>`).
     #[arg(long)]
     pub binary_path: Option<PathBuf>,

--- a/crates/chatmail-config/src/lib.rs
+++ b/crates/chatmail-config/src/lib.rs
@@ -42,10 +42,10 @@ pub use autoconfig::{build_autoconfig_xml, AutoconfigParams};
 pub use bool_str::{is_falsy, is_truthy, parse_bool_str, parse_bool_str_opt};
 pub use cli::{
     AdminWebCommand, Args, Cli, Command, CompletionShell, EndpointCacheCommand, FederationCommand,
-    LanguageCommand, PortCommand, PortServiceCommand, ProxyCommand, ProxySettingCommand,
-    PushCommand, RegistrationCommand, RegistrationTokensCommand, ServiceCommand,
-    ServiceToggleCommand, SharingCommand, TasksCommand, UninstallArgs,
-    DEFAULT_WINDOWS_SERVICE_NAME,
+    FirewallCommand, LanguageCommand, PortCommand, PortServiceCommand, ProxyCommand,
+    ProxySettingCommand, PushCommand, RegistrationCommand, RegistrationTokensCommand,
+    ServiceCommand, ServiceToggleCommand, SharingCommand, TasksCommand, UninstallArgs,
+    DEFAULT_WINDOWS_SERVICE_NAME, FIREWALL_RULE_PREFIX,
 };
 pub use client_mail::{
     build_dclogin_link, client_connect_host, effective_http_listen, effective_http_plain_listen,

--- a/crates/chatmail/src/ctl/dispatch.rs
+++ b/crates/chatmail/src/ctl/dispatch.rs
@@ -22,9 +22,9 @@ use chatmail_db::settings_keys;
 
 use super::{
     accounts, admin_token, admin_web, blocklist_cmd, certificate, delete_cmd, docs, endpoint_cache,
-    federation, html, install, language, message_size, port, proxy, push, registration,
-    registration_tokens, reload, service_cmd, service_toggle, sharing, status_cmd, tasks,
-    uninstall, version, webmail_cors,
+    federation, firewall_cmd, html, install, language, message_size, port, proxy, push,
+    registration, registration_tokens, reload, service_cmd, service_toggle, sharing, status_cmd,
+    tasks, uninstall, version, webmail_cors,
 };
 
 pub async fn dispatch(cli: &Cli) -> Result<()> {
@@ -110,6 +110,7 @@ pub async fn dispatch(cli: &Cli) -> Result<()> {
         Some(Command::Status { details }) => status_cmd::status(&cli.args, *details).await,
         Some(Command::Uninstall(flags)) => uninstall::uninstall(&cli.args, flags).await,
         Some(Command::Service(cmd)) => service_cmd::service(&cli.args, cmd).await,
+        Some(Command::Firewall(cmd)) => firewall_cmd::firewall(&cli.args, cmd).await,
         Some(Command::EndpointCache(cmd)) => endpoint_cache::endpoint_cache(&cli.args, cmd).await,
         Some(Command::Port(cmd)) => port::port(&cli.args, cmd).await,
         Some(Command::Reload { url, insecure }) => {
@@ -131,7 +132,7 @@ fn not_implemented(cmd: &Command) -> Result<()> {
          Implemented: run, upgrade, update, version, admin-token, admin-web, install, certificate, \
          accounts, ban-list, blocklist, create-user, delete, registration, language, \
          html-export, html-serve, html-migrate, webimap, websmtp, webmail-cors, push, federation, registration-tokens, sharing, \
-         status, uninstall, service, endpoint-cache, port, proxy, reload, message-size, tasks, completion"
+         status, uninstall, service, firewall, endpoint-cache, port, proxy, reload, message-size, tasks, completion"
     )))
 }
 
@@ -172,6 +173,7 @@ fn command_name(cmd: &Command) -> &'static str {
         Command::SubmissionAccess => "submission-access",
         Command::Uninstall { .. } => "uninstall",
         Command::Service { .. } => "service",
+        Command::Firewall { .. } => "firewall",
         Command::Creds => "creds",
         Command::Webimap { .. } => "webimap",
         Command::Websmtp { .. } => "websmtp",

--- a/crates/chatmail/src/ctl/firewall_cmd.rs
+++ b/crates/chatmail/src/ctl/firewall_cmd.rs
@@ -1,0 +1,265 @@
+// Copyright (C) 2026 themadorg
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! `madmail firewall` — Windows Firewall inbound rules for mail/HTTP listeners.
+
+use chatmail_config::{Args, FirewallCommand, FIREWALL_RULE_PREFIX};
+use chatmail_types::{ChatmailError, Result};
+
+use super::output::CtlOut;
+
+/// Core ports always opened by `firewall apply`.
+const CORE_RULES: &[(&str, &str, u16)] = &[
+    ("SMTP", "TCP", 25),
+    ("IMAP", "TCP", 143),
+    ("Submission", "TCP", 587),
+    ("SubmissionTLS", "TCP", 465),
+    ("IMAPTLS", "TCP", 993),
+    ("HTTP", "TCP", 80),
+    ("HTTPS", "TCP", 443),
+];
+
+pub async fn firewall(args: &Args, cmd: &FirewallCommand) -> Result<()> {
+    match cmd {
+        FirewallCommand::Apply { turn, ss, iroh } => apply(args, *turn, *ss, *iroh),
+        FirewallCommand::Remove => remove(args),
+    }
+}
+
+/// Open standard Madmail ports (and optional TURN / SS / Iroh).
+pub fn apply_rules(turn: bool, ss: bool, iroh: bool) -> Result<Vec<String>> {
+    require_windows()?;
+    let mut names = Vec::new();
+    for (label, proto, port) in CORE_RULES {
+        let name = rule_name(label);
+        add_rule(&name, proto, *port)?;
+        names.push(name);
+    }
+    if turn {
+        let name = rule_name("TURN");
+        add_rule(&name, "UDP", 3478)?;
+        names.push(name.clone());
+        // TCP TURN as well (config often binds both).
+        let name_tcp = rule_name("TURN-TCP");
+        add_rule(&name_tcp, "TCP", 3478)?;
+        names.push(name_tcp);
+    }
+    if ss {
+        let name = rule_name("Shadowsocks");
+        add_rule(&name, "TCP", 8388)?;
+        names.push(name);
+    }
+    if iroh {
+        let name = rule_name("Iroh");
+        add_rule(&name, "TCP", 3340)?;
+        names.push(name);
+    }
+    Ok(names)
+}
+
+/// Delete all inbound rules with the Madmail display-name prefix.
+pub fn remove_rules() -> Result<usize> {
+    require_windows()?;
+    let listed = list_madmail_rules()?;
+    let mut removed = 0usize;
+    for name in &listed {
+        if delete_rule(name).is_ok() {
+            removed += 1;
+        }
+    }
+    Ok(removed)
+}
+
+fn apply(args: &Args, turn: bool, ss: bool, iroh: bool) -> Result<()> {
+    let out = CtlOut::from_args(args, "firewall");
+    let names = apply_rules(turn, ss, iroh)?;
+    if out.is_json() {
+        out.emit(serde_json::json!({
+            "applied": true,
+            "rules": names,
+            "turn": turn,
+            "ss": ss,
+            "iroh": iroh,
+        }))?;
+    } else {
+        println!("✓ Windows Firewall: {} rule(s)", names.len());
+        for n in &names {
+            println!("  • {n}");
+        }
+    }
+    Ok(())
+}
+
+fn remove(args: &Args) -> Result<()> {
+    let out = CtlOut::from_args(args, "firewall");
+    let n = remove_rules()?;
+    if out.is_json() {
+        out.emit(serde_json::json!({ "removed": n }))?;
+    } else {
+        println!("✓ Removed {n} Madmail firewall rule(s)");
+    }
+    Ok(())
+}
+
+fn rule_name(label: &str) -> String {
+    format!("{FIREWALL_RULE_PREFIX} ({label})")
+}
+
+fn require_windows() -> Result<()> {
+    #[cfg(windows)]
+    {
+        Ok(())
+    }
+    #[cfg(not(windows))]
+    {
+        Err(ChatmailError::config(
+            "madmail firewall is only supported on Windows\n\
+             On Linux open ports with your distro firewall (firewalld/ufw/nftables).",
+        ))
+    }
+}
+
+#[cfg(windows)]
+fn add_rule(name: &str, protocol: &str, port: u16) -> Result<()> {
+    use std::process::Command;
+    // Idempotent: delete existing same-name rule first.
+    let _ = delete_rule(name);
+    let status = Command::new("netsh")
+        .args([
+            "advfirewall",
+            "firewall",
+            "add",
+            "rule",
+            &format!("name={name}"),
+            "dir=in",
+            "action=allow",
+            &format!("protocol={protocol}"),
+            &format!("localport={port}"),
+            "profile=any",
+            "enable=yes",
+        ])
+        .status()
+        .map_err(|e| ChatmailError::config(format!("netsh add rule: {e}")))?;
+    if !status.success() {
+        return Err(ChatmailError::config(format!(
+            "netsh add rule failed for {name} (exit {:?})",
+            status.code()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn add_rule(_name: &str, _protocol: &str, _port: u16) -> Result<()> {
+    require_windows()
+}
+
+#[cfg(windows)]
+fn delete_rule(name: &str) -> Result<()> {
+    use std::process::Command;
+    let status = Command::new("netsh")
+        .args([
+            "advfirewall",
+            "firewall",
+            "delete",
+            "rule",
+            &format!("name={name}"),
+        ])
+        .status()
+        .map_err(|e| ChatmailError::config(format!("netsh delete rule: {e}")))?;
+    if !status.success() {
+        return Err(ChatmailError::config(format!(
+            "netsh delete rule failed for {name} (exit {:?})",
+            status.code()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn delete_rule(_name: &str) -> Result<()> {
+    require_windows()
+}
+
+#[cfg(windows)]
+fn list_madmail_rules() -> Result<Vec<String>> {
+    use std::process::Command;
+    let output = Command::new("netsh")
+        .args(["advfirewall", "firewall", "show", "rule", "name=all"])
+        .output()
+        .map_err(|e| ChatmailError::config(format!("netsh show rule: {e}")))?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut names = Vec::new();
+    for line in stdout.lines() {
+        let line = line.trim();
+        // English and some locales: "Rule Name:                Madmail (SMTP)"
+        if let Some(rest) = line
+            .strip_prefix("Rule Name:")
+            .or_else(|| line.strip_prefix("Rule name:"))
+        {
+            let name = rest.trim();
+            if name.starts_with(FIREWALL_RULE_PREFIX) {
+                names.push(name.to_string());
+            }
+        }
+    }
+    names.sort();
+    names.dedup();
+    Ok(names)
+}
+
+#[cfg(not(windows))]
+fn list_madmail_rules() -> Result<Vec<String>> {
+    require_windows().map(|_| unreachable!())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rule_names_use_prefix() {
+        assert_eq!(rule_name("SMTP"), "Madmail (SMTP)");
+        assert!(rule_name("HTTPS").starts_with(FIREWALL_RULE_PREFIX));
+    }
+
+    #[test]
+    fn core_rules_cover_mail_and_http() {
+        let ports: Vec<u16> = CORE_RULES.iter().map(|(_, _, p)| *p).collect();
+        for p in [25u16, 143, 587, 465, 993, 80, 443] {
+            assert!(ports.contains(&p), "missing port {p}");
+        }
+    }
+
+    #[tokio::test]
+    async fn firewall_errors_on_non_windows() {
+        #[cfg(not(windows))]
+        {
+            let args = Args {
+                config: std::path::PathBuf::from("/tmp/x.conf"),
+                state_dir: std::path::PathBuf::from("/tmp/x"),
+                boot_once: false,
+                json: false,
+            };
+            let err = firewall(&args, &FirewallCommand::Remove).await.unwrap_err();
+            assert!(
+                err.to_string().contains("only supported on Windows"),
+                "{err}"
+            );
+        }
+    }
+}

--- a/crates/chatmail/src/ctl/install/mod.rs
+++ b/crates/chatmail/src/ctl/install/mod.rs
@@ -119,6 +119,8 @@ pub async fn install(global: &Args, args: &InstallArgs) -> Result<()> {
         systemd::daemon_reload()?;
     }
 
+    let post = run_post_install_windows_steps(global, args, &cfg).await?;
+
     if global.json {
         let doc_paths = docs::CliDocPaths::for_binary(&cfg.binary_name);
         CtlOut::from_args(global, "install").emit(serde_json::json!({
@@ -127,6 +129,9 @@ pub async fn install(global: &Args, args: &InstallArgs) -> Result<()> {
             "paths_explicit": cfg.paths_explicit,
             "config": cfg.config_path.display().to_string(),
             "state_dir": cfg.state_dir.display().to_string(),
+            "service_installed": post.service_installed,
+            "service_started": post.service_started,
+            "firewall_applied": post.firewall_applied,
             "man_page": if cfg.system_install { Some(doc_paths.man_page.display().to_string()) } else { None },
             "completions": if cfg.system_install {
                 Some({
@@ -146,6 +151,78 @@ pub async fn install(global: &Args, args: &InstallArgs) -> Result<()> {
         println!("\nInstallation completed successfully.");
     }
     Ok(())
+}
+
+#[derive(Default)]
+struct PostInstallWindows {
+    service_installed: bool,
+    service_started: bool,
+    firewall_applied: bool,
+}
+
+/// `--install-service` / `--start-service` / `--firewall` (Windows only; notice on Unix).
+async fn run_post_install_windows_steps(
+    global: &Args,
+    args: &InstallArgs,
+    cfg: &InstallConfig,
+) -> Result<PostInstallWindows> {
+    let want_service = args.install_service || args.start_service;
+    let want_firewall = args.firewall;
+    if !want_service && !want_firewall {
+        return Ok(PostInstallWindows::default());
+    }
+
+    #[cfg(not(windows))]
+    {
+        let _ = (global, cfg);
+        if want_service {
+            eprintln!(
+                "note: --install-service / --start-service apply on Windows only (use systemd unit on Linux)"
+            );
+        }
+        if want_firewall {
+            eprintln!(
+                "note: --firewall applies on Windows only (configure firewalld/ufw on Linux)"
+            );
+        }
+        Ok(PostInstallWindows::default())
+    }
+
+    #[cfg(windows)]
+    {
+        use chatmail_config::{ServiceCommand, DEFAULT_WINDOWS_SERVICE_NAME};
+
+        use super::firewall_cmd;
+        use super::service_cmd;
+
+        let mut post = PostInstallWindows::default();
+        // Service registration must use the written config/state paths.
+        let mut service_args = global.clone();
+        service_args.config = cfg.config_path.clone();
+        service_args.state_dir = cfg.state_dir.clone();
+
+        if want_service {
+            let start = args.start_service;
+            service_cmd::service(
+                &service_args,
+                &ServiceCommand::Install {
+                    name: DEFAULT_WINDOWS_SERVICE_NAME.into(),
+                    start,
+                },
+            )
+            .await?;
+            post.service_installed = true;
+            post.service_started = start;
+        }
+        if want_firewall {
+            firewall_cmd::apply_rules(cfg.enable_turn, cfg.enable_ss, cfg.enable_iroh)?;
+            post.firewall_applied = true;
+            if !global.json {
+                println!("✓ Windows Firewall rules applied");
+            }
+        }
+        Ok(post)
+    }
 }
 
 fn resolve_tls_mode(cfg: &mut InstallConfig, args: &InstallArgs) -> Result<()> {
@@ -702,6 +779,9 @@ mod tests {
             dry_run: false,
             skip_systemd: false,
             skip_user: false,
+            install_service: false,
+            start_service: false,
+            firewall: false,
             binary_path: None,
             obtain_certificate: true,
             no_obtain_certificate: false,
@@ -801,6 +881,9 @@ mod tests {
             dry_run: false,
             skip_systemd: false,
             skip_user: false,
+            install_service: false,
+            start_service: false,
+            firewall: false,
             binary_path: None,
             obtain_certificate: true,
             no_obtain_certificate: false,
@@ -849,6 +932,9 @@ mod tests {
             dry_run: false,
             skip_systemd: false,
             skip_user: false,
+            install_service: false,
+            start_service: false,
+            firewall: false,
             binary_path: None,
             obtain_certificate: true,
             no_obtain_certificate: false,
@@ -898,6 +984,9 @@ mod tests {
             dry_run: false,
             skip_systemd: false,
             skip_user: false,
+            install_service: false,
+            start_service: false,
+            firewall: false,
             binary_path: None,
             obtain_certificate: true,
             no_obtain_certificate: false,
@@ -942,6 +1031,9 @@ mod tests {
                 dry_run: false,
                 skip_systemd: false,
                 skip_user: false,
+                install_service: false,
+                start_service: false,
+                firewall: false,
                 binary_path: None,
                 obtain_certificate: true,
                 no_obtain_certificate: false,
@@ -984,6 +1076,9 @@ mod tests {
             dry_run: false,
             skip_systemd: false,
             skip_user: false,
+            install_service: false,
+            start_service: false,
+            firewall: false,
             binary_path: None,
             obtain_certificate: true,
             no_obtain_certificate: false,
@@ -1034,6 +1129,9 @@ mod tests {
                 dry_run: false,
                 skip_systemd: false,
                 skip_user: false,
+                install_service: false,
+                start_service: false,
+                firewall: false,
                 binary_path: None,
                 obtain_certificate: true,
                 no_obtain_certificate: false,
@@ -1070,6 +1168,9 @@ mod tests {
                 dry_run: false,
                 skip_systemd: false,
                 skip_user: false,
+                install_service: false,
+                start_service: false,
+                firewall: false,
                 binary_path: None,
                 obtain_certificate: true,
                 no_obtain_certificate: false,
@@ -1114,6 +1215,9 @@ mod tests {
                 dry_run: false,
                 skip_systemd: false,
                 skip_user: false,
+                install_service: false,
+                start_service: false,
+                firewall: false,
                 binary_path: None,
                 obtain_certificate: true,
                 no_obtain_certificate: false,
@@ -1153,6 +1257,9 @@ mod tests {
             dry_run: false,
             skip_systemd: false,
             skip_user: false,
+            install_service: false,
+            start_service: false,
+            firewall: false,
             binary_path: None,
             obtain_certificate: true,
             no_obtain_certificate: false,

--- a/crates/chatmail/src/ctl/mod.rs
+++ b/crates/chatmail/src/ctl/mod.rs
@@ -31,6 +31,7 @@ mod dispatch;
 mod docs;
 mod endpoint_cache;
 mod federation;
+mod firewall_cmd;
 mod html;
 mod install;
 mod language;

--- a/crates/chatmail/src/ctl/uninstall.rs
+++ b/crates/chatmail/src/ctl/uninstall.rs
@@ -58,6 +58,17 @@ struct UninstallPlan {
 }
 
 pub async fn uninstall(args: &Args, flags: &UninstallArgs) -> Result<()> {
+    #[cfg(windows)]
+    {
+        return uninstall_windows(args, flags).await;
+    }
+
+    #[cfg(not(windows))]
+    uninstall_unix(args, flags).await
+}
+
+#[cfg(not(windows))]
+async fn uninstall_unix(args: &Args, flags: &UninstallArgs) -> Result<()> {
     let ctx = CtlContext::from_args(args)?;
 
     if !flags.dry_run && !is_root() {
@@ -139,6 +150,167 @@ pub async fn uninstall(args: &Args, flags: &UninstallArgs) -> Result<()> {
                 "binary": plan.primary_binary_name,
                 "dry_run": flags.dry_run,
                 "keep_data": flags.keep_data,
+            }),
+            "Uninstallation completed successfully",
+        )?;
+    } else {
+        println!("\n🎉 Uninstallation completed successfully!");
+        if !flags.keep_data {
+            println!("⚠️  All mail data has been permanently deleted.");
+        }
+    }
+    Ok(())
+}
+
+/// Windows uninstall: SCM service, firewall rules, ProgramData layout, optional binary.
+#[cfg(windows)]
+async fn uninstall_windows(args: &Args, flags: &UninstallArgs) -> Result<()> {
+    use chatmail_config::{ServiceCommand, DEFAULT_WINDOWS_SERVICE_NAME};
+
+    use super::firewall_cmd;
+    use super::service_cmd;
+
+    let ctx = CtlContext::from_args(args)?;
+    let primary = current_binary_name();
+    let _ = append_log(&flags.log_file, "Starting Windows uninstall");
+
+    println!("🗑️  {primary} — uninstall (Windows)");
+    println!("====================================");
+
+    let program_data = std::env::var_os("PROGRAMDATA")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(r"C:\ProgramData"));
+    let madmail_root = program_data.join("Madmail");
+    let config_dir = madmail_root.join("config");
+    let state_dir = if ctx.state_dir.is_dir() {
+        ctx.state_dir.clone()
+    } else {
+        madmail_root.join("data")
+    };
+
+    // Always attempt service + firewall cleanup; only skip disk deletes when nothing exists.
+    let disk_present = madmail_root.is_dir() || config_dir.is_dir() || state_dir.is_dir();
+    if !disk_present && !args.json {
+        println!(
+            "No ProgramData tree at {} — will still try service + firewall cleanup.",
+            madmail_root.display()
+        );
+    }
+
+    if !args.json {
+        println!("Config dir: {}", config_dir.display());
+        println!("State dir:  {}", state_dir.display());
+        println!("Service:    {DEFAULT_WINDOWS_SERVICE_NAME}");
+        println!("Firewall:   remove Madmail rules");
+        if flags.dry_run {
+            println!("\n(dry-run — no changes will be made)");
+        }
+    }
+
+    if !flags.force
+        && !flags.dry_run
+        && !util::confirm(
+            "Are you sure you want to proceed with uninstallation",
+            false,
+        )?
+    {
+        if args.json {
+            CtlOut::from_args(args, "uninstall").aborted()?;
+        } else {
+            println!("Uninstallation cancelled.");
+        }
+        return Ok(());
+    }
+
+    if flags.dry_run {
+        println!("Would: stop/delete service {DEFAULT_WINDOWS_SERVICE_NAME}");
+        println!("Would: remove Madmail firewall rules");
+        if !flags.keep_config {
+            println!("Would: remove {}", config_dir.display());
+        }
+        if !flags.keep_data {
+            println!("Would: remove {}", state_dir.display());
+        }
+        if !flags.keep_binary {
+            if let Ok(exe) = std::env::current_exe() {
+                println!(
+                    "Would: leave binary in place unless under Program Files: {}",
+                    exe.display()
+                );
+            }
+        }
+        if args.json {
+            CtlOut::from_args(args, "uninstall").emit(serde_json::json!({
+                "uninstalled": true,
+                "dry_run": true,
+                "keep_data": flags.keep_data,
+            }))?;
+        } else {
+            println!("\n🎉 Dry-run completed.");
+        }
+        return Ok(());
+    }
+
+    println!("\n[1/4] Stopping and removing Windows service...");
+    // service uninstall does not need matching config for delete
+    let _ = service_cmd::service(
+        args,
+        &ServiceCommand::Uninstall {
+            name: DEFAULT_WINDOWS_SERVICE_NAME.into(),
+        },
+    )
+    .await;
+    println!("✅ Service cleanup attempted");
+
+    println!("\n[2/4] Removing firewall rules...");
+    match firewall_cmd::remove_rules() {
+        Ok(n) => println!("✅ Removed {n} firewall rule(s)"),
+        Err(e) => println!("⚠️  Firewall cleanup: {e}"),
+    }
+
+    if !flags.keep_config {
+        println!("\n[3/4] Removing configuration...");
+        if config_dir.exists() {
+            remove_path(&config_dir, false)?;
+        }
+        println!("✅ Configuration removed");
+    } else {
+        println!("\n[3/4] Keeping configuration (--keep-config)");
+    }
+
+    if !flags.keep_data {
+        println!("\n[4/4] Removing state / mail data...");
+        if state_dir.exists() {
+            remove_path(&state_dir, false)?;
+        }
+        // Parent ProgramData\Madmail if empty-ish
+        if madmail_root.is_dir() {
+            let _ = fs::remove_dir(&madmail_root);
+        }
+        println!("✅ State removed");
+    } else {
+        println!("\n[4/4] Keeping state / mail data (--keep-data)");
+    }
+
+    if !flags.keep_binary {
+        if let Ok(exe) = std::env::current_exe() {
+            let s = exe.to_string_lossy().to_lowercase();
+            if s.contains("program files") && s.contains("madmail") {
+                println!("Note: remove the install directory via the setup uninstaller when using setup.exe.");
+                println!("  binary: {}", exe.display());
+            }
+        }
+    }
+
+    if args.json {
+        CtlOut::from_args(args, "uninstall").done_msg(
+            "",
+            serde_json::json!({
+                "uninstalled": true,
+                "binary": primary,
+                "dry_run": false,
+                "keep_data": flags.keep_data,
+                "platform": "windows",
             }),
             "Uninstallation completed successfully",
         )?;


### PR DESCRIPTION
## Summary

PR 3 of the Windows installer stack (epic #103, issue #99).

- **`madmail firewall apply|remove`** — named Windows Firewall inbound rules (`Madmail (SMTP)`, …); optional `--turn` / `--ss` / `--iroh`
- **Install flags:** `--install-service`, `--start-service`, `--firewall` (Windows post-install; notice on Unix)
- **Uninstall (Windows):** stop/delete `Madmail` service, remove firewall rules, delete ProgramData config/state honoring `--keep-data` / `--keep-config`
- Unix uninstall unchanged (still root + systemd)

**Stack:** base `feat/windows-installer` (not `main`).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Build / CI / tooling
- [ ] Refactor (no functional change)

## Area

- [ ] SMTP
- [ ] IMAP
- [ ] Federation / delivery queue
- [ ] Authentication / JIT
- [ ] Admin API / admin web UI (`external/madmail-admin-web`)
- [ ] TURN / Iroh / proxy services
- [ ] Storage / quota / DB migrations
- [x] Configuration / CLI
- [ ] Docs (`docs/project/`, `docs/TDD/`, user guide)
- [x] Other: Windows firewall / uninstall

## Testing

- [x] `cargo fmt --all -- --check` (via `make lint`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (via `make lint`)
- [x] `cargo test --workspace` (or targeted: `cargo test -p chatmail --lib` 140; `cargo test -p chatmail-config --lib` 104)
- [ ] Manual / E2E verification (describe below)

**Manual verification (if any):**

```text
Linux: madmail firewall remove → only supported on Windows
make lint exit 0
Windows netsh apply deferred to Windows CI/lab
```

## Documentation

- [x] No doc updates needed
- [ ] Updated operator/user docs (`docs/project/user-guide/`, install guides)
- [ ] Updated developer docs (`docs/project/`)
- [ ] Updated or added TDD section (`docs/TDD/`) — required for significant design changes

## Security & privacy

- [x] Not security-sensitive
- [ ] Security-sensitive — added/updated tests for the security property
- [x] Reviewed error messages for information leakage

## Commits

- `feat:` new feature
- `fix:` bug fix
- `docs:` documentation
- `refactor:` code change without feature/fix
- `test:` tests only
- `chore:` tooling, deps, release

## Checklist

- [x] PR is focused and reviewable (small vertical slices preferred)
- [x] No secrets, `data/`, `target/`, or `node_modules/` committed
- [ ] Submodule pointers updated if `external/madmail-admin-web` changed
- [x] Behavior parity with Madmail v1 considered (or intentional difference documented)

## Related

- Epic: #103
- User report: #99
- Milestone: Windows installer (full production pack)