### PR TITLE
build(windows): amd64/arm64 artifact targets without publishing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@
 	test test-unit test-integration test-e2e test-maintenance test-imap test-turn test-docker-turn-e2e test-core-turn test-deltachat test-deltachat-cmlxc test-mini-cmlxc test-full-cmlxc test-cmlxc-fullrun test-cmlxc-fullrun-madmail _test-cmlxc-prereqs test-dclogin relay-ping-build relay-ping-clean t1-bench t1-report-demo \
 	check vet lint fmt fmt-check cov run run-bg run-debug restart stop logs reset-db dev-certs clean help \
 	sign push push1 push2 log1 log2 push-signed publish init-publish build-publish \
+	build-windows build-windows-amd64 build-windows-arm64 \
 	man man-lint man-check incus-up incus-down docker-up docker-down
 
 # Optional overrides (copy .env.example → .env; publish merges context/madmail/.env into .env)
@@ -452,10 +453,9 @@ build-publish: build-release
 		rm -f build/madmail-linux-arm; \
 		echo "Skipping madmail-linux-arm (32-bit): install arm-linux-gnueabihf-gcc" >&2; \
 	fi
-	@command -v x86_64-w64-mingw32-gcc >/dev/null || { echo "Install mingw-w64-gcc (x86_64-w64-mingw32-gcc) for Windows release" >&2; exit 1; }
-	@CHATMAIL_ADMIN_WEB_BUILD="$(abspath $(ADMIN_WEB_BUILD))" \
-		cargo build -p chatmail --release --target x86_64-pc-windows-gnu
-	@cp target/x86_64-pc-windows-gnu/release/madmail.exe build/madmail-windows-amd64.exe
+	@$(MAKE) build-windows-amd64
+	# Optional arm64 (skips cleanly without MSVC/xwin — see packaging/windows/README.md)
+	@$(MAKE) build-windows-arm64 || true
 	@$(MAKE) build-release-static
 	@cp $(BINARY_RELEASE) build/madmail-linux-amd64-legacy
 	@rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl >/dev/null 2>&1 || true
@@ -467,6 +467,20 @@ build-publish: build-release
 	@CHATMAIL_ADMIN_WEB_BUILD="$(abspath $(ADMIN_WEB_BUILD))" \
 		cargo zigbuild -p chatmail --release --target aarch64-unknown-linux-musl
 	@cp target/aarch64-unknown-linux-musl/release/madmail build/madmail-linux-arm64-musl
+
+# ── Windows cross / native builds (artifacts only; no GitHub Release upload) ─
+# Docs: packaging/windows/README.md  Script: scripts/build-windows.sh
+build-windows:
+	@chmod +x scripts/build-windows.sh
+	@CHATMAIL_ADMIN_WEB_BUILD="$(abspath $(ADMIN_WEB_BUILD))" ./scripts/build-windows.sh all
+
+build-windows-amd64:
+	@chmod +x scripts/build-windows.sh
+	@CHATMAIL_ADMIN_WEB_BUILD="$(abspath $(ADMIN_WEB_BUILD))" ./scripts/build-windows.sh amd64
+
+build-windows-arm64:
+	@chmod +x scripts/build-windows.sh
+	@CHATMAIL_ADMIN_WEB_BUILD="$(abspath $(ADMIN_WEB_BUILD))" ./scripts/build-windows.sh arm64
 
 # First-time assets (iroh-relay, admin-web submodule) then full release publish.
 init-publish: init publish
@@ -529,6 +543,7 @@ help:
 	@echo "relay-ping: relay-ping-build (in $(RELAY_PING_DIR))"
 	@echo "Init:      init (download iroh-relay $(IROH_RELAY_VERSION) into $(IROH_ASSETS)/)"
 	@echo "Release:   build-publish, publish (PUBLISH_ARGS=…), init-publish (init + publish)"
+	@echo "Windows:   build-windows, build-windows-amd64, build-windows-arm64 (see packaging/windows/README.md)"
 	@echo "           publish.sh: --no-github-release, --no-release-notes, --sync-keys, …"
 	@echo "Other:     clean, help"
 	@echo ""

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -1,0 +1,80 @@
+# Windows packaging
+
+Operator-facing Windows installers and release binaries for Madmail.
+
+> Integration work lives on branch `feat/windows-installer` (epic [#103](https://github.com/themadorg/madmail/issues/103)).  
+> This tree does **not** publish GitHub Releases by itself.
+
+## Artifacts
+
+| File | Arch | Notes |
+|------|------|--------|
+| `madmail-windows-amd64.exe` | x64 | Server + CLI (`chatmail` package) |
+| `madmail-tray-windows-amd64.exe` | x64 | System tray helper |
+| `madmail-windows-arm64.exe` | arm64 | Server + CLI |
+| `madmail-tray-windows-arm64.exe` | arm64 | System tray helper |
+| `madmail-windows-amd64-setup.exe` | x64 | Inno Setup (PR6) |
+| `madmail-windows-arm64-setup.exe` | arm64 | Inno Setup (PR6) |
+
+## Build (no publish)
+
+From the repo root:
+
+```bash
+# Both arches when toolchains allow (arm64 may skip on plain Linux)
+make build-windows
+
+# Or:
+./scripts/build-windows.sh amd64
+./scripts/build-windows.sh arm64
+./scripts/build-windows.sh all
+```
+
+### amd64 (Linux cross)
+
+Requires `mingw-w64` (`x86_64-w64-mingw32-gcc`):
+
+```bash
+make build-windows-amd64
+# → build/madmail-windows-amd64.exe
+# → build/madmail-tray-windows-amd64.exe (may fail if tray deps need a Windows host)
+```
+
+### arm64
+
+Preferred: **Windows** with VS arm64 toolset:
+
+```powershell
+rustup target add aarch64-pc-windows-msvc
+cargo build -p chatmail -p madmail-tray --release --target aarch64-pc-windows-msvc
+# copy *.exe to build/
+```
+
+Optional on Linux: [`cargo-xwin`](https://github.com/rust-cross/cargo-xwin):
+
+```bash
+cargo install cargo-xwin
+./scripts/build-windows.sh arm64
+```
+
+Until arm64 CI runners or cargo-xwin are available, **compile-only** checks and the manual lab checklist (epic #103 L6/L8) gate arm64 claims.
+
+## Default install layout
+
+| Item | Path |
+|------|------|
+| Binary | `C:\Program Files\Madmail\madmail.exe` |
+| Tray | `C:\Program Files\Madmail\madmail-tray.exe` |
+| Config | `%ProgramData%\Madmail\config\` |
+| State | `%ProgramData%\Madmail\data\` |
+| Service | `Madmail` |
+
+## Related CLI
+
+```text
+madmail install --simple --ip … --install-service --start-service --firewall
+madmail service install|start|stop|status
+madmail firewall apply|remove
+madmail-tray --smoke-exit
+madmail-tray install-autostart
+```

--- a/scripts/build-windows.sh
+++ b/scripts/build-windows.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Build Windows release artifacts (madmail + madmail-tray) into build/.
+# Does NOT upload releases or create tags — local/CI artifact production only.
+#
+# Usage:
+#   ./scripts/build-windows.sh              # amd64 (mingw) + arm64 if toolchain present
+#   ./scripts/build-windows.sh amd64
+#   ./scripts/build-windows.sh arm64
+#   ARCH=amd64 ./scripts/build-windows.sh
+#
+# Environment:
+#   CHATMAIL_ADMIN_WEB_BUILD  — path to admin-web embed (optional; same as Makefile)
+#   SKIP_TRAY=1               — build server only
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+mkdir -p build
+
+ADMIN_WEB_BUILD="${CHATMAIL_ADMIN_WEB_BUILD:-}"
+if [[ -z "$ADMIN_WEB_BUILD" && -d "$ROOT/crates/chatmail-admin-web/embed" ]]; then
+  # Prefer Makefile's ADMIN_WEB_BUILD when exported; otherwise leave empty for default embed.
+  :
+fi
+
+export_admin() {
+  if [[ -n "${CHATMAIL_ADMIN_WEB_BUILD:-}" ]]; then
+    export CHATMAIL_ADMIN_WEB_BUILD
+  fi
+}
+
+build_amd64() {
+  echo "==> Windows amd64 (x86_64-pc-windows-gnu)"
+  if ! command -v x86_64-w64-mingw32-gcc >/dev/null 2>&1; then
+    echo "error: need mingw-w64 (x86_64-w64-mingw32-gcc)" >&2
+    exit 1
+  fi
+  rustup target add x86_64-pc-windows-gnu >/dev/null 2>&1 || true
+  export_admin
+  cargo build -p chatmail --release --target x86_64-pc-windows-gnu
+  cp -f target/x86_64-pc-windows-gnu/release/madmail.exe build/madmail-windows-amd64.exe
+  echo "    wrote build/madmail-windows-amd64.exe"
+  if [[ "${SKIP_TRAY:-0}" != "1" ]]; then
+    # tray-icon/winit may need extra link flags; fail soft with a clear note
+    if cargo build -p madmail-tray --release --target x86_64-pc-windows-gnu; then
+      cp -f target/x86_64-pc-windows-gnu/release/madmail-tray.exe build/madmail-tray-windows-amd64.exe
+      echo "    wrote build/madmail-tray-windows-amd64.exe"
+    else
+      echo "warning: madmail-tray amd64 cross-build failed (tray deps often need a Windows host)" >&2
+      echo "         build tray on windows-latest or use native MSVC later" >&2
+    fi
+  fi
+}
+
+build_arm64() {
+  echo "==> Windows arm64 (aarch64-pc-windows-msvc preferred)"
+  local target="aarch64-pc-windows-msvc"
+  rustup target add "$target" >/dev/null 2>&1 || true
+
+  # Native Windows arm64 or VS cross from x64 Windows.
+  if [[ "$(uname -s)" == MINGW* || "$(uname -s)" == MSYS* || "$(uname -s)" == CYGWIN* || "$(uname -s)" == Windows_NT ]]; then
+    export_admin
+    cargo build -p chatmail --release --target "$target"
+    cp -f "target/${target}/release/madmail.exe" build/madmail-windows-arm64.exe
+    echo "    wrote build/madmail-windows-arm64.exe"
+    if [[ "${SKIP_TRAY:-0}" != "1" ]]; then
+      cargo build -p madmail-tray --release --target "$target"
+      cp -f "target/${target}/release/madmail-tray.exe" build/madmail-tray-windows-arm64.exe
+      echo "    wrote build/madmail-tray-windows-arm64.exe"
+    fi
+    return 0
+  fi
+
+  # Optional: cargo-xwin on Linux (install: cargo install cargo-xwin)
+  if command -v cargo-xwin >/dev/null 2>&1; then
+    echo "    using cargo-xwin for ${target}"
+    export_admin
+    cargo xwin build -p chatmail --release --target "$target"
+    cp -f "target/${target}/release/madmail.exe" build/madmail-windows-arm64.exe
+    echo "    wrote build/madmail-windows-arm64.exe"
+    if [[ "${SKIP_TRAY:-0}" != "1" ]]; then
+      if cargo xwin build -p madmail-tray --release --target "$target"; then
+        cp -f "target/${target}/release/madmail-tray.exe" build/madmail-tray-windows-arm64.exe
+        echo "    wrote build/madmail-tray-windows-arm64.exe"
+      else
+        echo "warning: madmail-tray arm64 xwin build failed" >&2
+      fi
+    fi
+    return 0
+  fi
+
+  cat >&2 <<'EOF'
+skip: Windows arm64 build needs one of:
+  • Windows host with Visual Studio arm64 toolset:
+      rustup target add aarch64-pc-windows-msvc
+      cargo build -p chatmail -p madmail-tray --release --target aarch64-pc-windows-msvc
+  • Linux with cargo-xwin:
+      cargo install cargo-xwin
+      cargo xwin build -p chatmail --release --target aarch64-pc-windows-msvc
+Artifacts (when built): build/madmail-windows-arm64.exe, build/madmail-tray-windows-arm64.exe
+EOF
+  return 0
+}
+
+ARCH="${1:-${ARCH:-all}}"
+case "$ARCH" in
+  amd64|x86_64|x64) build_amd64 ;;
+  arm64|aarch64) build_arm64 ;;
+  all)
+    build_amd64
+    build_arm64
+    ;;
+  *)
+    echo "usage: $0 [amd64|arm64|all]" >&2
+    exit 2
+    ;;
+esac
+
+echo "==> done (artifacts under build/)"
+ls -la build/madmail*windows* 2>/dev/null || true
+ls -la build/madmail-tray*windows* 2>/dev/null || true


### PR DESCRIPTION
## Summary

PR 5 of the Windows installer stack (epic #103).

- **`make build-windows` / `build-windows-amd64` / `build-windows-arm64`**
- **`scripts/build-windows.sh`** — builds `madmail` + `madmail-tray` into `build/`
  - amd64: `x86_64-pc-windows-gnu` (mingw)
  - arm64: `aarch64-pc-windows-msvc` (Windows host) or `cargo-xwin` on Linux; skips with instructions otherwise
- **`packaging/windows/README.md`** — layout + build docs
- **`build-publish`** uses the new amd64 target and best-effort arm64
- **No GitHub Releases / tags / publish execution**

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [x] Build / CI / tooling
- [ ] Refactor (no functional change)

## Area

- [ ] SMTP
- [ ] IMAP
- [ ] Federation / delivery queue
- [ ] Authentication / JIT
- [ ] Admin API / admin web UI (`external/madmail-admin-web`)
- [ ] TURN / Iroh / proxy services
- [ ] Storage / quota / DB migrations
- [ ] Configuration / CLI
- [x] Docs (`docs/project/`, `docs/TDD/`, user guide)
- [x] Other: Windows packaging / cross-build

## Testing

- [x] `make lint`
- [x] `./scripts/build-windows.sh arm64` skips cleanly without MSVC/xwin
- [x] `./scripts/build-windows.sh amd64` errors clearly without mingw
- [ ] Full mingw/MSVC cross-build on a machine with those toolchains

**Manual verification (if any):**

```text
Linux without mingw/xwin: arm64 skip message; amd64 missing-gcc message
```

## Documentation

- [ ] No doc updates needed
- [ ] Updated operator/user docs (`docs/project/user-guide/`, install guides)
- [x] Updated developer docs (`packaging/windows/README.md`)
- [ ] Updated or added TDD section (`docs/TDD/`) — required for significant design changes

## Security & privacy

- [x] Not security-sensitive
- [ ] Security-sensitive — added/updated tests for the security property
- [x] Reviewed error messages for information leakage

## Commits

- `build:` tooling

## Checklist

- [x] PR is focused and reviewable (small vertical slices preferred)
- [x] No secrets, `data/`, `target/`, or `node_modules/` committed
- [ ] Submodule pointers updated if `external/madmail-admin-web` changed
- [x] Behavior parity with Madmail v1 considered (or intentional difference documented)

## Related

- Epic: #103
- User report: #99
- Milestone: Windows installer (full production pack)