### PR TITLE
feat(windows): Inno Setup wizard for amd64 and arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 	test test-unit test-integration test-e2e test-maintenance test-imap test-turn test-docker-turn-e2e test-core-turn test-deltachat test-deltachat-cmlxc test-mini-cmlxc test-full-cmlxc test-cmlxc-fullrun test-cmlxc-fullrun-madmail _test-cmlxc-prereqs test-dclogin relay-ping-build relay-ping-clean t1-bench t1-report-demo \
 	check vet lint fmt fmt-check cov run run-bg run-debug restart stop logs reset-db dev-certs clean help \
 	sign push push1 push2 log1 log2 push-signed publish init-publish build-publish \
-	build-windows build-windows-amd64 build-windows-arm64 \
+	build-windows build-windows-amd64 build-windows-arm64 build-windows-setup \
 	man man-lint man-check incus-up incus-down docker-up docker-down
 
 # Optional overrides (copy .env.example → .env; publish merges context/madmail/.env into .env)
@@ -482,6 +482,12 @@ build-windows-arm64:
 	@chmod +x scripts/build-windows.sh
 	@CHATMAIL_ADMIN_WEB_BUILD="$(abspath $(ADMIN_WEB_BUILD))" ./scripts/build-windows.sh arm64
 
+# Inno Setup (must run on Windows with ISCC + build/*.exe present)
+build-windows-setup:
+	@echo "Run on Windows:  powershell -File packaging/windows/build-setup.ps1 -Arch amd64"
+	@echo "                 powershell -File packaging/windows/build-setup.ps1 -Arch arm64"
+	@echo "See packaging/windows/README.md"
+
 # First-time assets (iroh-relay, admin-web submodule) then full release publish.
 init-publish: init publish
 
@@ -543,7 +549,7 @@ help:
 	@echo "relay-ping: relay-ping-build (in $(RELAY_PING_DIR))"
 	@echo "Init:      init (download iroh-relay $(IROH_RELAY_VERSION) into $(IROH_ASSETS)/)"
 	@echo "Release:   build-publish, publish (PUBLISH_ARGS=…), init-publish (init + publish)"
-	@echo "Windows:   build-windows, build-windows-amd64, build-windows-arm64 (see packaging/windows/README.md)"
+	@echo "Windows:   build-windows, build-windows-amd64, build-windows-arm64, build-windows-setup (packaging/windows/README.md)"
 	@echo "           publish.sh: --no-github-release, --no-release-notes, --sync-keys, …"
 	@echo "Other:     clean, help"
 	@echo ""

--- a/packaging/windows/Madmail.iss
+++ b/packaging/windows/Madmail.iss
@@ -1,0 +1,384 @@
+; Madmail Windows installer (Inno Setup 6+)
+; Build:  .\build-setup.ps1 -Arch amd64
+;         iscc /DArch=arm64 Madmail.iss
+;
+; Expects pre-built binaries under repo build/:
+;   madmail-windows-{amd64,arm64}.exe
+;   madmail-tray-windows-{amd64,arm64}.exe (optional)
+
+#ifndef Arch
+  #define Arch "amd64"
+#endif
+
+#define MyAppName "Madmail"
+#define MyAppVersion "2.17.3"
+#define MyAppPublisher "themadorg"
+#define MyAppURL "https://github.com/themadorg/madmail"
+#define MyAppExeName "madmail.exe"
+#define MyTrayExeName "madmail-tray.exe"
+#define MyServiceName "Madmail"
+
+#if Arch == "arm64"
+  #define SetupArch "arm64"
+  #define SourceMadmail "..\..\build\madmail-windows-arm64.exe"
+  #define SourceTray "..\..\build\madmail-tray-windows-arm64.exe"
+#else
+  #define SetupArch "amd64"
+  #define SourceMadmail "..\..\build\madmail-windows-amd64.exe"
+  #define SourceTray "..\..\build\madmail-tray-windows-amd64.exe"
+#endif
+
+[Setup]
+AppId={{8F3C2A91-6B4E-4D2A-9C71-0A1B2C3D4E5F}
+AppName={#MyAppName}
+AppVersion={#MyAppVersion}
+AppPublisher={#MyAppPublisher}
+AppPublisherURL={#MyAppURL}
+AppSupportURL={#MyAppURL}
+AppUpdatesURL={#MyAppURL}/releases
+DefaultDirName={autopf}\{#MyAppName}
+DefaultGroupName={#MyAppName}
+DisableProgramGroupPage=yes
+LicenseFile=license.txt
+OutputDir=..\..\build
+OutputBaseFilename=madmail-windows-{#SetupArch}-setup
+Compression=lzma2
+SolidCompression=yes
+WizardStyle=modern
+PrivilegesRequired=admin
+MinVersion=10.0
+UninstallDisplayIcon={app}\{#MyAppExeName}
+#if Arch == "arm64"
+ArchitecturesAllowed=arm64
+ArchitecturesInstallIn64BitMode=arm64
+#else
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+#endif
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "Create a &desktop shortcut for Madmail tray"; GroupDescription: "Additional icons:"; Flags: unchecked
+Name: "autostart"; Description: "Start &tray when I log in"; GroupDescription: "Startup:"; Flags: checkedonce
+Name: "firewall"; Description: "Open Windows &Firewall ports for mail/HTTP"; GroupDescription: "Network:"; Flags: checkedonce
+Name: "startservice"; Description: "Start Madmail &service after install"; GroupDescription: "Service:"; Flags: checkedonce
+
+[Files]
+; Server binary (required)
+Source: "{#SourceMadmail}"; DestDir: "{app}"; DestName: "{#MyAppExeName}"; Flags: ignoreversion
+; Tray helper (skip if not built yet)
+Source: "{#SourceTray}"; DestDir: "{app}"; DestName: "{#MyTrayExeName}"; Flags: ignoreversion skipifsourcedoesntexist
+
+[Icons]
+Name: "{group}\Madmail Tray"; Filename: "{app}\{#MyTrayExeName}"; WorkingDir: "{app}"; Check: TrayPresent
+Name: "{group}\Madmail Service Status"; Filename: "{app}\{#MyAppExeName}"; Parameters: "service status"; WorkingDir: "{app}"
+Name: "{group}\Uninstall Madmail"; Filename: "{uninstallexe}"
+Name: "{autodesktop}\Madmail Tray"; Filename: "{app}\{#MyTrayExeName}"; Tasks: desktopicon; Check: TrayPresent
+
+[Run]
+; Configure server (self-signed / LE based on wizard), register service, optional firewall
+Filename: "{app}\{#MyAppExeName}"; \
+  Parameters: "{code:InstallCliArgs}"; \
+  StatusMsg: "Configuring Madmail (TLS, service)…"; \
+  Flags: runhidden waituntilterminated
+; Tray autostart
+Filename: "{app}\{#MyTrayExeName}"; \
+  Parameters: "install-autostart"; \
+  StatusMsg: "Registering tray autostart…"; \
+  Flags: runhidden waituntilterminated; \
+  Tasks: autostart; Check: TrayPresent
+; Launch tray now
+Filename: "{app}\{#MyTrayExeName}"; \
+  Description: "Launch Madmail tray now"; \
+  Flags: nowait postinstall skipifsilent; Check: TrayPresent
+
+[UninstallRun]
+; Best-effort: stop service + firewall; keep data by default (see UninstallKeepData)
+Filename: "{app}\{#MyAppExeName}"; \
+  Parameters: "{code:UninstallCliArgs}"; \
+  RunOnceId: "MadmailUninstall"; \
+  Flags: runhidden waituntilterminated
+Filename: "{app}\{#MyTrayExeName}"; \
+  Parameters: "uninstall-autostart"; \
+  RunOnceId: "MadmailTrayUninstallAutostart"; \
+  Flags: runhidden waituntilterminated; Check: TrayPresent
+
+[Code]
+var
+  ModePage: TInputOptionWizardPage;
+  IdentityPage: TInputQueryWizardPage;
+  TlsPage: TInputOptionWizardPage;
+  AcmePage: TInputQueryWizardPage;
+  DnsPage: TOutputMsgWizardPage;
+  LangPage: TInputOptionWizardPage;
+  FeaturePage: TInputOptionWizardPage;
+  FinishedMsg: String;
+
+function TrayPresent: Boolean;
+begin
+  Result := FileExists(ExpandConstant('{app}\{#MyTrayExeName}'));
+end;
+
+function IsDomainMode: Boolean;
+begin
+  Result := ModePage.SelectedValueIndex = 2;
+end;
+
+function IsLocalMode: Boolean;
+begin
+  Result := ModePage.SelectedValueIndex = 0;
+end;
+
+function IsPublicIpMode: Boolean;
+begin
+  Result := ModePage.SelectedValueIndex = 1;
+end;
+
+function GetIdentity: String;
+begin
+  Result := Trim(IdentityPage.Values[0]);
+end;
+
+function GetAcmeEmail: String;
+begin
+  Result := Trim(AcmePage.Values[0]);
+end;
+
+function GetLangCode: String;
+begin
+  case LangPage.SelectedValueIndex of
+    1: Result := 'fa';
+    2: Result := 'ru';
+    3: Result := 'es';
+  else
+    Result := 'en';
+  end;
+end;
+
+function Quoted(const S: String): String;
+begin
+  Result := '"' + S + '"';
+end;
+
+function ConfigDir: String;
+begin
+  Result := ExpandConstant('{commonappdata}\Madmail\config');
+end;
+
+function StateDir: String;
+begin
+  Result := ExpandConstant('{commonappdata}\Madmail\data');
+end;
+
+{ Build madmail install CLI args from wizard + tasks }
+function InstallCliArgs(Param: String): String;
+var
+  Args: String;
+  Ident: String;
+  TlsMode: Integer;
+begin
+  Ident := GetIdentity;
+  if Ident = '' then
+    Ident := '127.0.0.1';
+
+  Args := 'install --simple --lang ' + GetLangCode;
+  Args := Args + ' --config-dir ' + Quoted(ConfigDir);
+  Args := Args + ' --state-dir ' + Quoted(StateDir);
+  Args := Args + ' --binary-path ' + Quoted(ExpandConstant('{app}\{#MyAppExeName}'));
+
+  if IsDomainMode then
+  begin
+    Args := Args + ' --domain ' + Ident;
+    if GetAcmeEmail <> '' then
+      Args := Args + ' --acme-email ' + GetAcmeEmail;
+  end
+  else
+  begin
+    Args := Args + ' --ip ' + Ident;
+  end;
+
+  TlsMode := TlsPage.SelectedValueIndex;
+  { 0 = self-signed, 1 = Let's Encrypt (domain or auto-IP) }
+  if TlsMode = 0 then
+    Args := Args + ' --tls-mode self_signed --no-obtain-certificate'
+  else if IsDomainMode then
+    Args := Args + ' --tls-mode autocert'
+  else
+    Args := Args + ' --auto-ip-cert --acme-email ' + GetAcmeEmail;
+
+  if FeaturePage.Values[0] then
+    Args := Args + ' --enable-ss';
+  if FeaturePage.Values[1] then
+    Args := Args + ' --enable-iroh';
+
+  Args := Args + ' --install-service';
+  if WizardIsTaskSelected('startservice') then
+    Args := Args + ' --start-service';
+  if WizardIsTaskSelected('firewall') then
+    Args := Args + ' --firewall';
+
+  Result := Args;
+  Log('Install CLI: madmail ' + Args);
+end;
+
+function UninstallCliArgs(Param: String): String;
+begin
+  { Keep mail data by default; operators can wipe ProgramData manually }
+  Result := 'uninstall --force --keep-data --keep-binary';
+  Result := Result + ' --config ' + Quoted(ConfigDir + '\madmail.conf');
+  Result := Result + ' --state-dir ' + Quoted(StateDir);
+end;
+
+function ShouldSkipPage(PageID: Integer): Boolean;
+begin
+  Result := False;
+  if PageID = AcmePage.ID then
+  begin
+    { ACME email only when LE selected }
+    Result := (TlsPage.SelectedValueIndex = 0);
+  end
+  else if PageID = DnsPage.ID then
+  begin
+    Result := not IsDomainMode;
+  end;
+end;
+
+function NextButtonClick(CurPageID: Integer): Boolean;
+var
+  Ident: String;
+begin
+  Result := True;
+  if CurPageID = IdentityPage.ID then
+  begin
+    Ident := GetIdentity;
+    if Ident = '' then
+    begin
+      MsgBox('Please enter an IP address or domain name.', mbError, MB_OK);
+      Result := False;
+      Exit;
+    end;
+  end
+  else if CurPageID = AcmePage.ID then
+  begin
+    if (TlsPage.SelectedValueIndex <> 0) and (GetAcmeEmail = '') then
+    begin
+      MsgBox('Let''s Encrypt requires an email address (user@domain).', mbError, MB_OK);
+      Result := False;
+      Exit;
+    end;
+  end;
+end;
+
+procedure InitializeWizard;
+begin
+  ModePage := CreateInputOptionPage(wpLicense,
+    'Deployment mode', 'How will this Madmail server be used?',
+    'Choose the primary identity for this install.',
+    True, False);
+  ModePage.Add('Local / lab (127.0.0.1, self-signed recommended)');
+  ModePage.Add('Public IP (self-signed or Let''s Encrypt IP certificate)');
+  ModePage.Add('Domain name (Let''s Encrypt DNS certificate)');
+  ModePage.SelectedValueIndex := 0;
+
+  IdentityPage := CreateInputQueryPage(ModePage.ID,
+    'Server identity', 'IP address or domain',
+    'Local mode typically uses 127.0.0.1. Public IP mode needs a routable address. Domain mode needs a DNS hostname.');
+  IdentityPage.Add('IP or domain:', False);
+  IdentityPage.Values[0] := '127.0.0.1';
+
+  TlsPage := CreateInputOptionPage(IdentityPage.ID,
+    'TLS certificate', 'How should Madmail obtain TLS certificates?',
+    'Self-signed is fine for local testing and Delta Chat with trust-on-first-use. Let''s Encrypt needs port 80 free and a public identity.',
+    True, False);
+  TlsPage.Add('Self-signed (recommended for local / lab)');
+  TlsPage.Add('Let''s Encrypt (domain or public IP certificate)');
+  TlsPage.SelectedValueIndex := 0;
+
+  AcmePage := CreateInputQueryPage(TlsPage.ID,
+    'Let''s Encrypt contact', 'ACME account email',
+    'Used for expiry notices. Must be user@domain (not user@IP).');
+  AcmePage.Add('Email:', False);
+
+  LangPage := CreateInputOptionPage(AcmePage.ID,
+    'Language', 'Website / UI language',
+    'Seeds the Madmail language setting.',
+    True, False);
+  LangPage.Add('English (en)');
+  LangPage.Add('Persian (fa)');
+  LangPage.Add('Russian (ru)');
+  LangPage.Add('Spanish (es)');
+  LangPage.SelectedValueIndex := 0;
+
+  FeaturePage := CreateInputOptionPage(LangPage.ID,
+    'Optional features', 'Enable additional services in the generated config',
+    'You can change these later via config / CLI.',
+    False, False);
+  FeaturePage.Add('Shadowsocks proxy');
+  FeaturePage.Add('Iroh relay discovery');
+  FeaturePage.Values[0] := True;
+  FeaturePage.Values[1] := False;
+
+  DnsPage := CreateOutputMsgPage(wpSelectTasks,
+    'DNS checklist', 'Domain deployment reminders',
+    'Before clients and federation work reliably:'#13#10#13#10 +
+    '  1. A / AAAA for your hostname pointing at this server'#13#10 +
+    '  2. MX record for the mail domain'#13#10 +
+    '  3. Optional: SPF, DKIM, DMARC'#13#10#13#10 +
+    'Docs: https://github.com/themadorg/madmail (user guide: DNS and mail authentication)'#13#10#13#10 +
+    'Port 80 must be free during install if using Let''s Encrypt.');
+end;
+
+procedure CurPageChanged(CurPageID: Integer);
+begin
+  if CurPageID = IdentityPage.ID then
+  begin
+    if IsLocalMode and (Trim(IdentityPage.Values[0]) = '') then
+      IdentityPage.Values[0] := '127.0.0.1';
+  end;
+  if CurPageID = TlsPage.ID then
+  begin
+    if IsLocalMode then
+      TlsPage.SelectedValueIndex := 0;
+  end;
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+begin
+  if CurStep = ssPostInstall then
+  begin
+    FinishedMsg :=
+      'Madmail is installed under:'#13#10 +
+      '  App:   ' + ExpandConstant('{app}') + #13#10 +
+      '  Config: ' + ConfigDir + #13#10 +
+      '  State:  ' + StateDir + #13#10#13#10 +
+      'Service name: {#MyServiceName}'#13#10 +
+      'Admin token file: ' + StateDir + '\admin_token'#13#10#13#10 +
+      'Useful commands:'#13#10 +
+      '  madmail service status'#13#10 +
+      '  madmail admin-token'#13#10 +
+      '  madmail-tray --smoke-exit';
+  end;
+end;
+
+function UpdateReadyMemo(Space, NewLine, MemoUserInfoInfo, MemoDirInfo, MemoTypeInfo,
+  MemoComponentsInfo, MemoGroupInfo, MemoTasksInfo: String): String;
+var
+  S: String;
+begin
+  S := 'Mode: ';
+  case ModePage.SelectedValueIndex of
+    0: S := S + 'Local / lab';
+    1: S := S + 'Public IP';
+    2: S := S + 'Domain';
+  end;
+  S := S + NewLine + 'Identity: ' + GetIdentity + NewLine;
+  if TlsPage.SelectedValueIndex = 0 then
+    S := S + 'TLS: self-signed' + NewLine
+  else
+    S := S + 'TLS: Let''s Encrypt (' + GetAcmeEmail + ')' + NewLine;
+  S := S + 'Language: ' + GetLangCode + NewLine + NewLine;
+  S := S + MemoDirInfo + NewLine + NewLine + MemoTasksInfo;
+  Result := S;
+end;

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -13,10 +13,59 @@ Operator-facing Windows installers and release binaries for Madmail.
 | `madmail-tray-windows-amd64.exe` | x64 | System tray helper |
 | `madmail-windows-arm64.exe` | arm64 | Server + CLI |
 | `madmail-tray-windows-arm64.exe` | arm64 | System tray helper |
-| `madmail-windows-amd64-setup.exe` | x64 | Inno Setup (PR6) |
-| `madmail-windows-arm64-setup.exe` | arm64 | Inno Setup (PR6) |
+| `madmail-windows-amd64-setup.exe` | x64 | Inno Setup wizard |
+| `madmail-windows-arm64-setup.exe` | arm64 | Inno Setup wizard |
 
-## Build (no publish)
+## Installer (Inno Setup)
+
+**Requires:** [Inno Setup 6](https://jrsoftware.org/isinfo.php) (`ISCC.exe`) on a Windows host, plus pre-built exes under `build/`.
+
+```powershell
+# From repo root on Windows, after building binaries:
+make build-windows-amd64   # or build natively / CI artifacts
+.\packaging\windows\build-setup.ps1 -Arch amd64
+# → build\madmail-windows-amd64-setup.exe
+
+.\packaging\windows\build-setup.ps1 -Arch arm64
+# → build\madmail-windows-arm64-setup.exe
+```
+
+Or:
+
+```text
+iscc /DArch=amd64 packaging\windows\Madmail.iss
+iscc /DArch=arm64 packaging\windows\Madmail.iss
+```
+
+### Wizard flow
+
+1. License (AGPL summary)  
+2. **Deployment mode** — local / public IP / domain  
+3. **Identity** — IP or hostname  
+4. **TLS** — self-signed or Let's Encrypt  
+5. ACME email (if LE)  
+6. Language + optional Shadowsocks / Iroh  
+7. Install directory + tasks (firewall, start service, tray autostart)  
+8. DNS checklist (domain mode)  
+9. Post-install: `madmail install … --install-service [--start-service] [--firewall]`  
+10. Optional: tray autostart + launch tray  
+
+### Silent / unattended
+
+Inno supports `/VERYSILENT /SUPPRESSMSGBOXES`. Wizard defaults are used unless you extend `[Setup]` with custom `/MODE=` parsing later. Recommended unattended path for automation:
+
+```text
+madmail.exe install --simple --ip 127.0.0.1 --tls-mode self_signed ^
+  --config-dir "%ProgramData%\Madmail\config" ^
+  --state-dir "%ProgramData%\Madmail\data" ^
+  --install-service --start-service --firewall
+```
+
+### Uninstall
+
+Add/Remove Programs runs `madmail uninstall --force --keep-data --keep-binary` (mail data retained by default), removes tray autostart, then deletes Program Files files.
+
+## Build binaries (no publish)
 
 From the repo root:
 

--- a/packaging/windows/build-setup.ps1
+++ b/packaging/windows/build-setup.ps1
@@ -1,0 +1,77 @@
+# Build Madmail Inno Setup installer(s).
+# Prerequisites: Inno Setup 6 (ISCC.exe), pre-built Windows binaries under build/.
+#
+# Usage (from repo root or this directory):
+#   .\packaging\windows\build-setup.ps1 -Arch amd64
+#   .\packaging\windows\build-setup.ps1 -Arch arm64
+#   .\packaging\windows\build-setup.ps1 -Arch all
+#
+# Does NOT publish GitHub Releases.
+
+param(
+    [ValidateSet("amd64", "arm64", "all")]
+    [string]$Arch = "amd64",
+    [string]$IsccPath = ""
+)
+
+$ErrorActionPreference = "Stop"
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$Root = Resolve-Path (Join-Path $Here "..\..")
+$Build = Join-Path $Root "build"
+$Iss = Join-Path $Here "Madmail.iss"
+
+function Find-Iscc {
+    if ($IsccPath -and (Test-Path $IsccPath)) { return $IsccPath }
+    $candidates = @(
+        "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe",
+        "$env:ProgramFiles\Inno Setup 6\ISCC.exe",
+        "${env:LOCALAPPDATA}\Programs\Inno Setup 6\ISCC.exe"
+    )
+    foreach ($c in $candidates) {
+        if (Test-Path $c) { return $c }
+    }
+    $cmd = Get-Command iscc -ErrorAction SilentlyContinue
+    if ($cmd) { return $cmd.Source }
+    throw "ISCC.exe not found. Install Inno Setup 6 or pass -IsccPath."
+}
+
+function Ensure-Binary([string]$Name) {
+    $p = Join-Path $Build $Name
+    if (-not (Test-Path $p)) {
+        throw "Missing $p — build Windows binaries first (make build-windows / build-windows.ps1)."
+    }
+}
+
+function Build-One([string]$A) {
+    Write-Host "==> Inno Setup Arch=$A"
+    if ($A -eq "amd64") {
+        Ensure-Binary "madmail-windows-amd64.exe"
+    } else {
+        Ensure-Binary "madmail-windows-arm64.exe"
+    }
+    $iscc = Find-Iscc
+    Write-Host "    ISCC: $iscc"
+    & $iscc "/DArch=$A" $Iss
+    if ($LASTEXITCODE -ne 0) { throw "ISCC failed for Arch=$A (exit $LASTEXITCODE)" }
+    $out = Join-Path $Build "madmail-windows-$A-setup.exe"
+    if (Test-Path $out) {
+        Write-Host "    wrote $out"
+    } else {
+        Write-Warning "Expected output not found: $out"
+    }
+}
+
+New-Item -ItemType Directory -Force -Path $Build | Out-Null
+Set-Location $Here
+
+switch ($Arch) {
+    "amd64" { Build-One "amd64" }
+    "arm64" { Build-One "arm64" }
+    "all" {
+        Build-One "amd64"
+        Build-One "arm64"
+    }
+}
+
+Write-Host "==> done"
+Get-ChildItem (Join-Path $Build "madmail-windows-*-setup.exe") -ErrorAction SilentlyContinue | Format-Table Name, Length, LastWriteTime

--- a/packaging/windows/license.txt
+++ b/packaging/windows/license.txt
@@ -1,0 +1,13 @@
+Madmail — chatmail / mail server
+Copyright (C) 2026 themadorg
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+Full license text: https://www.gnu.org/licenses/agpl-3.0.html
+Source: https://github.com/themadorg/madmail


### PR DESCRIPTION
## Summary

PR 6 of the Windows installer stack (epic #103).

- **`packaging/windows/Madmail.iss`** — elevated Inno Setup 6 wizard:
  - Mode: local / public IP / domain
  - Identity, TLS (self-signed vs Let's Encrypt), ACME email, language, SS/Iroh
  - Tasks: firewall, start service, tray autostart, desktop icon
  - Installs to Program Files; config/state under `%ProgramData%\Madmail`
  - Post-install runs `madmail install … --install-service [--start-service] [--firewall]`
  - Uninstall keeps data by default (`--keep-data`)
- **`build-setup.ps1`** — `ISCC /DArch=amd64|arm64`
- **`license.txt`**, README installer section
- **`make build-windows-setup`** — prints Windows build instructions

**Stack:** base `feat/windows-installer` (not `main`). Does not publish releases.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [x] Build / CI / tooling
- [ ] Refactor (no functional change)

## Area

- [ ] SMTP
- [ ] IMAP
- [ ] Federation / delivery queue
- [ ] Authentication / JIT
- [ ] Admin API / admin web UI (`external/madmail-admin-web`)
- [ ] TURN / Iroh / proxy services
- [ ] Storage / quota / DB migrations
- [x] Configuration / CLI
- [x] Docs (`docs/project/`, `docs/TDD/`, user guide)
- [x] Other: Windows packaging / Inno Setup

## Testing

- [x] `make lint`
- [ ] Compile with ISCC on Windows (needs Inno Setup 6 + `build/madmail-windows-*.exe`)
- [ ] Manual wizard run (local self-signed)

**Manual verification (if any):**

```text
On Windows after binary build:
  powershell -File packaging/windows/build-setup.ps1 -Arch amd64
```

## Documentation

- [ ] No doc updates needed
- [x] Updated operator/user docs (`packaging/windows/README.md`)
- [ ] Updated developer docs (`docs/project/`)
- [ ] Updated or added TDD section (`docs/TDD/`) — required for significant design changes

## Security & privacy

- [x] Not security-sensitive
- [ ] Security-sensitive — added/updated tests for the security property
- [x] Reviewed error messages for information leakage

## Commits

- `feat:` packaging

## Checklist

- [x] PR is focused and reviewable (small vertical slices preferred)
- [x] No secrets, `data/`, `target/`, or `node_modules/` committed
- [ ] Submodule pointers updated if `external/madmail-admin-web` changed
- [x] Behavior parity with Madmail v1 considered (or intentional difference documented)

## Related

- Epic: #103
- User report: #99
- Milestone: Windows installer (full production pack)