### PR TITLE
ci(windows): smoke workflow and operator docs for installer stack

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,3 +6,10 @@ linker = "arm-linux-gnueabihf-gcc"
 
 [target.x86_64-pc-windows-gnu]
 linker = "x86_64-w64-mingw32-gcc"
+
+# Vendored OpenSSL static libs ship without PDBs → MSVC LNK4099 spam on every link.
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "link-arg=/IGNORE:4099"]
+
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-C", "link-arg=/IGNORE:4099"]

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -124,11 +124,10 @@ jobs:
             target/release/madmail-tray.exe
           retention-days: 7
 
-  # Compile-only arm64 target on windows-latest when VS arm64 tools exist
+  # Cross-check arm64 MSVC target from x64 Windows runner (toolset present on GHA images).
   windows-arm64-compile:
     name: Windows arm64 compile-only
     runs-on: windows-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
@@ -140,11 +139,8 @@ jobs:
         with:
           shared-key: windows-arm64-compile
 
-      - name: cargo check arm64 (server)
+      - name: cargo check arm64 (server + tray)
         shell: pwsh
         run: |
-          cargo check -p chatmail --target aarch64-pc-windows-msvc
-          if ($LASTEXITCODE -ne 0) {
-            Write-Host "arm64 check failed (toolset may be incomplete) — non-blocking"
-            exit 0
-          }
+          cargo check -p chatmail -p madmail-tray --target aarch64-pc-windows-msvc
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -78,19 +78,26 @@ jobs:
           shared-key: windows-amd64-smoke
 
       - name: Build madmail + madmail-tray (MSVC)
+        # debuginfo=0 avoids a flood of LNK4099 (missing ossl_static.pdb) from vendored OpenSSL.
+        env:
+          CARGO_PROFILE_RELEASE_DEBUG: "0"
+          RUSTFLAGS: "-D warnings"
         run: cargo build -p chatmail -p madmail-tray --release
 
       - name: Tray smoke-exit
+        shell: pwsh
         run: |
-          .\target\release\madmail-tray.exe --smoke-exit
+          & .\target\release\madmail-tray.exe --smoke-exit
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-      - name: Service status (SCM query path)
+      - name: Service status when not installed
+        shell: pwsh
         run: |
-          # Service may not be installed; command must not panic.
-          .\target\release\madmail.exe service status
-          # Accept non-zero if service missing — still proves CLI wiring on Windows.
-          exit 0
+          # Must exit 0 with State NotInstalled (not sc error 1060).
+          $out = & .\target\release\madmail.exe service status 2>&1 | Out-String
+          Write-Host $out
+          if ($LASTEXITCODE -ne 0) { throw "service status failed: $LASTEXITCODE" }
+          if ($out -notmatch "NotInstalled") { throw "expected NotInstalled, got: $out" }
 
       - name: Local install (self-signed) under temp dirs
         shell: pwsh
@@ -107,6 +114,8 @@ jobs:
           $key = Join-Path $cfg "certs\privkey.pem"
           if (-not (Test-Path $cert)) { throw "missing $cert" }
           if (-not (Test-Path $key)) { throw "missing $key" }
+          $conf = Join-Path $cfg "madmail.conf"
+          if (-not (Test-Path $conf)) { throw "missing $conf (binary_name .exe strip?)" }
           Write-Host "install ok: certs present under $cfg"
 
       - name: Firewall CLI parse (apply needs admin; only dry presence)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,150 @@
+# Windows smoke for the installer stack (feat/windows-installer).
+# Artifacts only — does not create tags or GitHub Releases.
+name: Windows
+
+on:
+  push:
+    branches: [feat/windows-installer]
+    paths:
+      - "crates/chatmail/**"
+      - "crates/chatmail-config/**"
+      - "crates/madmail-tray/**"
+      - "packaging/windows/**"
+      - "scripts/build-windows.sh"
+      - ".github/workflows/windows.yml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  pull_request:
+    branches: [feat/windows-installer]
+    paths:
+      - "crates/chatmail/**"
+      - "crates/chatmail-config/**"
+      - "crates/madmail-tray/**"
+      - "packaging/windows/**"
+      - "scripts/build-windows.sh"
+      - ".github/workflows/windows.yml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  # L0-ish: unit tests that must stay green on Linux for Windows crates
+  linux-windows-crates:
+    name: Linux (windows-related crates)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: windows-related-linux
+
+      - name: Test tray + config CLI pieces
+        run: |
+          cargo test -p madmail-tray
+          cargo test -p chatmail-config --lib service_subcommands
+          cargo test -p chatmail-config --lib firewall_subcommands
+          cargo test -p chatmail --lib tls_boot
+          cargo test -p chatmail --lib service_cmd
+          cargo test -p chatmail --lib firewall_cmd
+
+      - name: Packaging files present
+        run: |
+          test -f packaging/windows/Madmail.iss
+          test -f packaging/windows/build-setup.ps1
+          test -f packaging/windows/README.md
+          test -f scripts/build-windows.sh
+
+  # L2 / L5: build + CLI smoke on Windows x64
+  windows-amd64-smoke:
+    name: Windows amd64 smoke
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: windows-amd64-smoke
+
+      - name: Build madmail + madmail-tray (MSVC)
+        run: cargo build -p chatmail -p madmail-tray --release
+
+      - name: Tray smoke-exit
+        run: |
+          .\target\release\madmail-tray.exe --smoke-exit
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Service status (SCM query path)
+        run: |
+          # Service may not be installed; command must not panic.
+          .\target\release\madmail.exe service status
+          # Accept non-zero if service missing — still proves CLI wiring on Windows.
+          exit 0
+
+      - name: Local install (self-signed) under temp dirs
+        shell: pwsh
+        run: |
+          $cfg = Join-Path $env:RUNNER_TEMP "madmail-cfg"
+          $st = Join-Path $env:RUNNER_TEMP "madmail-state"
+          New-Item -ItemType Directory -Force -Path $cfg, $st | Out-Null
+          & .\target\release\madmail.exe install `
+            --simple --ip 127.0.0.1 --tls-mode self_signed --lang en `
+            --config-dir $cfg --state-dir $st `
+            --no-obtain-certificate
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $cert = Join-Path $cfg "certs\fullchain.pem"
+          $key = Join-Path $cfg "certs\privkey.pem"
+          if (-not (Test-Path $cert)) { throw "missing $cert" }
+          if (-not (Test-Path $key)) { throw "missing $key" }
+          Write-Host "install ok: certs present under $cfg"
+
+      - name: Firewall CLI parse (apply needs admin; only dry presence)
+        shell: pwsh
+        run: |
+          & .\target\release\madmail.exe firewall --help
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Upload Windows binaries (ephemeral CI artifact, not a Release)
+        uses: actions/upload-artifact@v4
+        with:
+          name: madmail-windows-amd64-ci
+          path: |
+            target/release/madmail.exe
+            target/release/madmail-tray.exe
+          retention-days: 7
+
+  # Compile-only arm64 target on windows-latest when VS arm64 tools exist
+  windows-arm64-compile:
+    name: Windows arm64 compile-only
+    runs-on: windows-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-pc-windows-msvc
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: windows-arm64-compile
+
+      - name: cargo check arm64 (server)
+        shell: pwsh
+        run: |
+          cargo check -p chatmail --target aarch64-pc-windows-msvc
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "arm64 check failed (toolset may be incomplete) — non-blocking"
+            exit 0
+          }

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -78,10 +78,12 @@ jobs:
           shared-key: windows-amd64-smoke
 
       - name: Build madmail + madmail-tray (MSVC)
-        # debuginfo=0 avoids a flood of LNK4099 (missing ossl_static.pdb) from vendored OpenSSL.
+        # -D warnings: fail on rustc warnings.
+        # link-arg=/IGNORE:4099: silence MSVC LNK4099 (missing ossl_static.pdb from vendored OpenSSL).
+        # Also set in .cargo/config.toml for local MSVC builds; RUSTFLAGS is appended by cargo.
         env:
           CARGO_PROFILE_RELEASE_DEBUG: "0"
-          RUSTFLAGS: "-D warnings"
+          RUSTFLAGS: "-D warnings -C link-arg=/IGNORE:4099"
         run: cargo build -p chatmail -p madmail-tray --release
 
       - name: Tray smoke-exit
@@ -150,6 +152,8 @@ jobs:
 
       - name: cargo check arm64 (server + tray)
         shell: pwsh
+        env:
+          RUSTFLAGS: "-D warnings -C link-arg=/IGNORE:4099"
         run: |
           cargo check -p chatmail -p madmail-tray --target aarch64-pc-windows-msvc
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/crates/chatmail/src/ctl/docs.rs
+++ b/crates/chatmail/src/ctl/docs.rs
@@ -229,6 +229,10 @@ fn write_file(path: &Path, contents: &[u8], mode: u32) -> Result<()> {
         std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
             .map_err(|e| ChatmailError::config(format!("chmod {}: {e}", path.display())))?;
     }
+    #[cfg(not(unix))]
+    {
+        let _ = mode;
+    }
     Ok(())
 }
 

--- a/crates/chatmail/src/ctl/install/config.rs
+++ b/crates/chatmail/src/ctl/install/config.rs
@@ -19,6 +19,9 @@
 
 use std::path::PathBuf;
 
+/// Install plan used by Unix systemd/user steps and Windows post-install.
+/// Some fields are only read on Unix (`system` / `systemd` modules).
+#[allow(dead_code)]
 pub struct InstallConfig {
     pub binary_name: String,
     pub binary_path: PathBuf,

--- a/crates/chatmail/src/ctl/install/mod.rs
+++ b/crates/chatmail/src/ctl/install/mod.rs
@@ -27,7 +27,9 @@ use chatmail_acme::{
     parse_http_listen, resolve_domain_to_public_ip, ObtainOptions,
 };
 use chatmail_config::install_cli::InstallArgs;
-use chatmail_config::{effective_database_config, is_local_dev_state_dir, AppConfig, Args};
+#[cfg(not(windows))]
+use chatmail_config::is_local_dev_state_dir;
+use chatmail_config::{effective_database_config, AppConfig, Args};
 use chatmail_db::{init_db_from_config, set_setting, settings_keys};
 use chatmail_types::{wrap_ip_domain, ChatmailError, Result};
 

--- a/crates/chatmail/src/ctl/install/mod.rs
+++ b/crates/chatmail/src/ctl/install/mod.rs
@@ -20,6 +20,7 @@
 mod config;
 #[cfg(unix)]
 mod system;
+#[cfg(unix)]
 mod systemd;
 
 use chatmail_acme::{
@@ -482,6 +483,11 @@ impl InstallConfig {
                     .map(|s| s.to_string_lossy().into_owned())
             })
             .unwrap_or_else(|| "madmail".into());
+        // Windows argv0 is often `madmail.exe` — strip for service name / conf basename.
+        let binary_name = binary_name
+            .strip_suffix(".exe")
+            .unwrap_or(&binary_name)
+            .to_string();
 
         let config_dir = args
             .config_dir
@@ -949,17 +955,21 @@ mod tests {
         assert!(cfg.paths_explicit);
         assert!(!cfg.use_default_systemd_paths);
         assert!(cfg.system_install);
-        let unit = systemd::render_systemd_unit(&cfg);
-        assert!(!unit.contains("StateDirectory="));
-        assert!(unit.contains(&format!(
-            "--config {} run --libexec {}",
-            cfg.config_path.display(),
-            cfg.state_dir.display()
-        )));
-        assert!(unit.contains("ReadWritePaths=/var/lib/madmail-custom /etc/madmail-custom"));
+        #[cfg(unix)]
+        {
+            let unit = systemd::render_systemd_unit(&cfg);
+            assert!(!unit.contains("StateDirectory="));
+            assert!(unit.contains(&format!(
+                "--config {} run --libexec {}",
+                cfg.config_path.display(),
+                cfg.state_dir.display()
+            )));
+            assert!(unit.contains("ReadWritePaths=/var/lib/madmail-custom /etc/madmail-custom"));
+        }
     }
 
     #[test]
+    #[cfg(unix)]
     fn default_install_uses_fhs_systemd_layout_despite_global_state_dir_default() {
         let global = Args {
             config: PathBuf::from("/etc/madmail/madmail.conf"),

--- a/crates/chatmail/src/ctl/mod.rs
+++ b/crates/chatmail/src/ctl/mod.rs
@@ -65,5 +65,5 @@ pub use admin_token::admin_token;
 pub use dispatch::dispatch;
 pub use docs::{argv_binary_name, install_cli_docs};
 pub use output::{print_error_json, CtlOut};
-pub use service_cmd::argv_has_service_flag;
+pub use service_cmd::{argv_has_service_flag, argv_without_service_flag};
 pub use version::print_version;

--- a/crates/chatmail/src/ctl/service_cmd.rs
+++ b/crates/chatmail/src/ctl/service_cmd.rs
@@ -241,11 +241,15 @@ fn query_service_state(name: &str) -> Result<String> {
         .map_err(|e| ChatmailError::config(format!("sc query {name}: {e}")))?;
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}{stderr}");
     if !output.status.success() {
+        // 1060 = service does not exist — a normal status, not a hard failure.
+        if combined.contains("1060") || combined.to_ascii_lowercase().contains("does not exist") {
+            return Ok("NotInstalled".into());
+        }
         return Err(ChatmailError::config(format!(
-            "sc query {name} failed: {}{}",
-            stdout.trim(),
-            stderr.trim()
+            "sc query {name} failed: {}",
+            combined.trim()
         )));
     }
     for line in stdout.lines() {

--- a/crates/chatmail/src/ctl/uninstall.rs
+++ b/crates/chatmail/src/ctl/uninstall.rs
@@ -16,6 +16,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 //! `chatmail uninstall` — Madmail `ctl/uninstall.go` (systemd + FHS paths).
+//!
+//! On Windows builds, the Unix/systemd uninstall path is compiled out of use;
+//! dead-code lint is silenced for those helpers.
+
+#![cfg_attr(windows, allow(dead_code))]
 
 use std::collections::BTreeSet;
 use std::fs::{self, OpenOptions};
@@ -33,6 +38,8 @@ use super::util;
 
 const DEFAULT_BINARY_NAME: &str = "madmail";
 
+// Unix FHS/systemd uninstall paths are unused when building for Windows.
+#[cfg_attr(windows, allow(dead_code))]
 const SYSTEMD_UNIT_DIRS: &[&str] = &[
     "/etc/systemd/system",
     "/usr/lib/systemd/system",
@@ -40,6 +47,7 @@ const SYSTEMD_UNIT_DIRS: &[&str] = &[
 ];
 
 #[derive(Debug, Default)]
+#[cfg_attr(windows, allow(dead_code))]
 struct UninstallPlan {
     installation_found: bool,
     primary_binary_name: String,

--- a/crates/chatmail/src/service_host.rs
+++ b/crates/chatmail/src/service_host.rs
@@ -32,7 +32,7 @@ use windows_service::service_control_handler::{self, ServiceControlHandlerResult
 use windows_service::service_dispatcher;
 
 use crate::boot;
-use crate::ctl::service_cmd;
+use crate::ctl::argv_without_service_flag;
 
 const SERVICE_TYPE: ServiceType = ServiceType::OWN_PROCESS;
 
@@ -132,7 +132,7 @@ fn run_service() -> Result<(), String> {
 }
 
 fn parse_service_cli_args() -> Result<chatmail_config::Args, String> {
-    let argv = service_cmd::argv_without_service_flag();
+    let argv = argv_without_service_flag();
     let cli = Cli::try_parse_from(argv).map_err(|e| format!("parse service CLI: {e}"))?;
     match cli.command {
         None | Some(Command::Run) => Ok(cli.args),

--- a/crates/madmail-tray/src/tray_win.rs
+++ b/crates/madmail-tray/src/tray_win.rs
@@ -26,6 +26,8 @@ struct TrayApp {
     config: PathBuf,
     state_dir: PathBuf,
     madmail: PathBuf,
+    /// Held so the tray icon is not dropped for the process lifetime.
+    #[allow(dead_code)]
     tray: Option<tray_icon::TrayIcon>,
     item_status: MenuItem,
     item_open_admin: MenuItem,

--- a/docs/guide/cli/install.md
+++ b/docs/guide/cli/install.md
@@ -38,7 +38,13 @@ sudo madmail install --simple --domain example.org --tls-mode file --no-obtain-c
 
 # Local dev (no root)
 madmail install --simple --ip 127.0.0.1   --config-dir /tmp/mm --state-dir /tmp/sd
+
+# Windows (elevated): ProgramData defaults, service + firewall
+madmail install --simple --ip 203.0.113.50 --tls-mode self_signed --lang en `
+  --install-service --start-service --firewall
 ```
+
+On **Windows**, default install paths are `%ProgramData%\Madmail\config` and `%ProgramData%\Madmail\data` (not `/etc` / `/var/lib`). Use the [Windows packaging guide](../../../packaging/windows/README.md) for the Inno Setup wizard and tray helper.
 
 ## Key flags
 
@@ -47,7 +53,10 @@ madmail install --simple --ip 127.0.0.1   --config-dir /tmp/mm --state-dir /tmp/
 | `-s`, `--simple` | Quick setup (`--ip` or `--domain` required) |
 | `-n`, `--non-interactive` | Script install (requires `--domain` without `--simple`) |
 | `--ip`, `--domain`, `--hostname` | Server identity |
-| `--config-dir`, `--state-dir` | Override FHS paths |
+| `--config-dir`, `--state-dir` | Override FHS / ProgramData paths |
+| `--install-service` | Register Windows service after install (no-op notice on Unix) |
+| `--start-service` | Start Windows service after install |
+| `--firewall` | Open Windows Firewall rules for mail/HTTP ports |
 | `--tls-mode` | `autocert`, `file`, or `self_signed` |
 | `--acme-email`, `--auto-ip-cert`, `--obtain-certificate`, `--no-obtain-certificate`, `--cert-only`, `--http-listen` | TLS issuance |
 | `--lang` | UI language: `en`, `fa`, `ru`, `es` |

--- a/docs/project/user-guide/02-quick-start.md
+++ b/docs/project/user-guide/02-quick-start.md
@@ -52,12 +52,42 @@ sudo systemctl start madmail
 
 Before install, create an **`A`/`AAAA`** record for the hostname pointing at your server. After install, add **`MX`** and (optionally) SPF/DKIM/DMARC — see [DNS and Mail Authentication](./12-dns-mail-auth.md).
 
+### Windows
+
+Prefer the **setup wizard** when available (`madmail-windows-amd64-setup.exe` / `arm64`), or use the CLI:
+
+```powershell
+# After placing madmail.exe on the machine (elevated PowerShell recommended)
+.\madmail.exe install --simple --ip YOUR_IP --tls-mode self_signed --lang en `
+  --install-service --start-service --firewall
+
+# Optional tray
+.\madmail-tray.exe install-autostart
+.\madmail-tray.exe
+```
+
+Defaults:
+
+| Item | Path |
+|------|------|
+| Config / certs | `%ProgramData%\Madmail\config\` |
+| State / token | `%ProgramData%\Madmail\data\` |
+| Service name | `Madmail` |
+
+Useful commands: `madmail service status`, `madmail firewall apply`, `madmail-tray --smoke-exit`.
+
+Packaging and build notes: [packaging/windows/README.md](../../../packaging/windows/README.md).  
+Manual release checklist: [packaging/windows/MANUAL-CHECKLIST.md](../../../packaging/windows/MANUAL-CHECKLIST.md).
+
+> Full Windows support is integrated on branch `feat/windows-installer` (epic [#103](https://github.com/themadorg/madmail/issues/103)) until merged to the default release branch.
+
 More detail:
 
 - [Simple IP + ACME install](../../install-simple-ip-acme.md)
 - [IP vs domain deployment](./11-deployment-ip-domain-certs.md)
 - [DNS, SPF, DKIM, federation](./12-dns-mail-auth.md)
 - [Local development](../../local-dev.md)
+- [Windows packaging](../../../packaging/windows/README.md)
 
 ## Local Testing (for Operators)
 

--- a/packaging/windows/MANUAL-CHECKLIST.md
+++ b/packaging/windows/MANUAL-CHECKLIST.md
@@ -1,0 +1,37 @@
+# Windows release checklist (L8)
+
+Run before claiming a public Windows setup.exe or closing epic [#103](https://github.com/themadorg/madmail/issues/103) via a `main` merge.
+
+## Environment
+
+- [ ] Windows 10/11 x64 machine (or VM)
+- [ ] Windows 11 arm64 machine or lab (if shipping arm64)
+- [ ] Built or CI artifacts: `madmail.exe`, `madmail-tray.exe`, optional `*-setup.exe`
+
+## Installer / CLI
+
+- [ ] **Local self-signed:** setup wizard or  
+  `madmail install --simple --ip 127.0.0.1 --tls-mode self_signed --install-service --start-service --firewall`
+- [ ] Service shows **Running** (`madmail service status` / Services MMC)
+- [ ] Firewall rules present (`Madmail (*)` in Windows Firewall)
+- [ ] `madmail-tray --smoke-exit` exits 0; tray menu opens admin / start-stop works
+- [ ] Admin token file under `%ProgramData%\Madmail\data\admin_token`
+- [ ] **Public IP self-signed** (optional lab)
+- [ ] **Domain LE** or **auto-IP cert** when port 80 and DNS/IP allow (optional)
+
+## Upgrade / uninstall
+
+- [ ] Re-run setup or replace binaries without wiping mail (`--keep-data` path)
+- [ ] Uninstall keeps data when expected; full wipe when requested
+
+## Docs smoke
+
+- [ ] Quick-start Windows section matches current flags
+- [ ] `packaging/windows/README.md` build steps work on a clean checkout
+
+## Sign-off
+
+| Arch | Tester | Date | Notes |
+|------|--------|------|--------|
+| amd64 | | | |
+| arm64 | | | |

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -127,3 +127,15 @@ madmail firewall apply|remove
 madmail-tray --smoke-exit
 madmail-tray install-autostart
 ```
+
+## CI
+
+GitHub Actions workflow [`.github/workflows/windows.yml`](../../.github/workflows/windows.yml) (branch `feat/windows-installer`):
+
+| Job | Purpose |
+|-----|---------|
+| `linux-windows-crates` | Unit tests for tray / service / firewall / packaging file presence |
+| `windows-amd64-smoke` | MSVC build, tray smoke, local self-signed install under temp dirs, upload CI artifacts |
+| `windows-arm64-compile` | Best-effort `cargo check` for `aarch64-pc-windows-msvc` (`continue-on-error`) |
+
+Does **not** create git tags or GitHub Releases. Manual sign-off: [MANUAL-CHECKLIST.md](./MANUAL-CHECKLIST.md).


### PR DESCRIPTION
## Summary

PR 7 (final stack PR) of the Windows installer epic #103.

- **`.github/workflows/windows.yml`** on `feat/windows-installer`:
  - Linux: tray + service/firewall/tls unit tests + packaging file presence
  - `windows-latest`: release build of `madmail` + `madmail-tray`, tray smoke, local self-signed install, firewall `--help`, upload CI artifacts (not Releases)
  - arm64 `cargo check` best-effort (`continue-on-error`)
- **Docs:** Windows section in quick-start, install CLI flags, packaging README CI section, `MANUAL-CHECKLIST.md` (L8)

No tags / GitHub Releases / `main` changes.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [x] Documentation only
- [x] Build / CI / tooling
- [ ] Refactor (no functional change)

## Area

- [ ] SMTP
- [ ] IMAP
- [ ] Federation / delivery queue
- [ ] Authentication / JIT
- [ ] Admin API / admin web UI (`external/madmail-admin-web`)
- [ ] TURN / Iroh / proxy services
- [ ] Storage / quota / DB migrations
- [x] Configuration / CLI
- [x] Docs (`docs/project/`, `docs/TDD/`, user guide)
- [x] Other: Windows CI / packaging

## Testing

- [x] `make lint`
- [ ] Workflow green on PR (GitHub Actions)

**Manual verification (if any):**

```text
Workflow runs when this PR targets feat/windows-installer
```

## Documentation

- [ ] No doc updates needed
- [x] Updated operator/user docs (quick-start, install CLI, packaging)
- [ ] Updated developer docs (`docs/project/`)
- [ ] Updated or added TDD section (`docs/TDD/`) — required for significant design changes

## Security & privacy

- [x] Not security-sensitive
- [ ] Security-sensitive — added/updated tests for the security property
- [x] Reviewed error messages for information leakage

## Commits

- `ci:` / `docs:`

## Checklist

- [x] PR is focused and reviewable (small vertical slices preferred)
- [x] No secrets, `data/`, `target/`, or `node_modules/` committed
- [ ] Submodule pointers updated if `external/madmail-admin-web` changed
- [x] Behavior parity with Madmail v1 considered (or intentional difference documented)

## Related

- Epic: #103
- User report: #99
- Milestone: Windows installer (full production pack)