### PR TITLE
ci(windows): build Inno setup.exe on GitHub Actions

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -207,7 +207,8 @@ jobs:
         run: |
           & .\packaging\windows\build-setup.ps1 -Arch amd64
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          $setup = "build\madmail-windows-amd64-setup.exe"
+          # Resolve against workspace root (build-setup used to leave cwd under packaging/windows).
+          $setup = Join-Path $env:GITHUB_WORKSPACE "build\madmail-windows-amd64-setup.exe"
           if (-not (Test-Path $setup)) { throw "missing $setup" }
           Get-Item $setup | Format-List FullName, Length, LastWriteTime
 
@@ -215,5 +216,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: madmail-windows-amd64-setup
-          path: build/madmail-windows-amd64-setup.exe
+          path: ${{ github.workspace }}/build/madmail-windows-amd64-setup.exe
           retention-days: 14

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -157,3 +157,63 @@ jobs:
         run: |
           cargo check -p chatmail -p madmail-tray --target aarch64-pc-windows-msvc
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+  # Inno Setup installer (amd64) — reuses smoke-built exes; CI artifact only (not a GitHub Release).
+  windows-amd64-setup:
+    name: Windows amd64 Inno setup
+    runs-on: windows-latest
+    needs: windows-amd64-smoke
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download madmail + tray binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: madmail-windows-amd64-ci
+          path: ci-bin
+
+      - name: Stage build/ names expected by Madmail.iss
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path build | Out-Null
+          $madmail = Get-ChildItem -Path ci-bin -Recurse -Filter madmail.exe | Select-Object -First 1
+          if (-not $madmail) { throw "madmail.exe not found under ci-bin" }
+          Copy-Item -Force $madmail.FullName build\madmail-windows-amd64.exe
+          Write-Host "staged $($madmail.FullName) -> build\madmail-windows-amd64.exe"
+          $tray = Get-ChildItem -Path ci-bin -Recurse -Filter madmail-tray.exe -ErrorAction SilentlyContinue | Select-Object -First 1
+          if ($tray) {
+            Copy-Item -Force $tray.FullName build\madmail-tray-windows-amd64.exe
+            Write-Host "staged $($tray.FullName) -> build\madmail-tray-windows-amd64.exe"
+          } else {
+            Write-Host "madmail-tray.exe not in artifact; setup will omit tray (skipifsourcedoesntexist)"
+          }
+          Get-ChildItem build | Format-Table Name, Length
+
+      - name: Install Inno Setup 6
+        shell: pwsh
+        run: |
+          choco install innosetup -y --no-progress
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $iscc = @(
+            "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe",
+            "$env:ProgramFiles\Inno Setup 6\ISCC.exe"
+          ) | Where-Object { Test-Path $_ } | Select-Object -First 1
+          if (-not $iscc) { throw "ISCC.exe not found after choco install innosetup" }
+          Write-Host "ISCC: $iscc"
+          & $iscc /? 2>&1 | Select-Object -First 5
+
+      - name: Compile setup.exe
+        shell: pwsh
+        run: |
+          & .\packaging\windows\build-setup.ps1 -Arch amd64
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $setup = "build\madmail-windows-amd64-setup.exe"
+          if (-not (Test-Path $setup)) { throw "missing $setup" }
+          Get-Item $setup | Format-List FullName, Length, LastWriteTime
+
+      - name: Upload setup installer (ephemeral CI artifact, not a Release)
+        uses: actions/upload-artifact@v4
+        with:
+          name: madmail-windows-amd64-setup
+          path: build/madmail-windows-amd64-setup.exe
+          retention-days: 14

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2719,15 +2719,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "is-docker"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2736,16 +2727,6 @@ dependencies = [
  "hermit-abi",
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "is-wsl"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
-dependencies = [
- "is-docker",
- "once_cell",
 ]
 
 [[package]]
@@ -3015,7 +2996,6 @@ version = "2.17.3"
 dependencies = [
  "chatmail-config",
  "clap",
- "open",
  "serde_json",
  "tempfile",
  "tray-icon",
@@ -3732,16 +3712,6 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "open"
-version = "5.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b3d059e795d52b8a72fef45658620edd4d9c359b338564aa14391ffa511ed5"
-dependencies = [
- "is-wsl",
- "libc",
-]
 
 [[package]]
 name = "openssl"

--- a/crates/chatmail/src/ctl/service_cmd.rs
+++ b/crates/chatmail/src/ctl/service_cmd.rs
@@ -276,8 +276,7 @@ fn delete_service(_name: &str) -> Result<()> {
 
 #[cfg(windows)]
 fn query_service_state(name: &str) -> Result<String> {
-    let output = Command::new("sc")
-        .args(["query", name])
+    let output = sc_command(&["query", name])
         .output()
         .map_err(|e| ChatmailError::config(format!("sc query {name}: {e}")))?;
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -314,8 +313,7 @@ fn query_service_state(_name: &str) -> Result<String> {
 }
 
 fn run_sc(args: &[&str], action: &str) -> Result<()> {
-    let output = Command::new("sc")
-        .args(args)
+    let output = sc_command(args)
         .output()
         .map_err(|e| ChatmailError::config(format!("sc {action}: {e}")))?;
     if output.status.success() {
@@ -329,6 +327,29 @@ fn run_sc(args: &[&str], action: &str) -> Result<()> {
         stdout.trim(),
         stderr.trim()
     )))
+}
+
+/// Build an `sc.exe` command.
+///
+/// Windows `sc` option syntax is `key= value` (space after `=`). Rust's default
+/// `Command` quoting wraps those tokens as `"start= auto"`, which `sc` rejects
+/// with exit 1639 (`ERROR: Invalid start= field`). On Windows every argument is
+/// therefore appended with [`CommandExt::raw_arg`] so the process command line
+/// keeps unquoted `start= auto`, `binPath= "…"`, `reset= 86400`, etc.
+fn sc_command(args: &[&str]) -> Command {
+    let mut cmd = Command::new("sc");
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        for a in args {
+            cmd.raw_arg(a);
+        }
+    }
+    #[cfg(not(windows))]
+    {
+        cmd.args(args);
+    }
+    cmd
 }
 
 #[cfg(test)]
@@ -347,6 +368,28 @@ mod tests {
         assert!(p.contains("run"), "{p}");
         assert!(p.contains("--libexec"), "{p}");
         assert!(p.contains("madmail.exe"), "{p}");
+    }
+
+    /// Document the sc option tokens that must not be Command-quoted on Windows.
+    #[test]
+    fn sc_create_option_tokens_use_space_after_equals() {
+        let bin = service_bin_path(
+            Path::new(r"C:\Program Files\Madmail\madmail.exe"),
+            Path::new(r"C:\ProgramData\Madmail\config\madmail.conf"),
+            Path::new(r"C:\ProgramData\Madmail\data"),
+        );
+        let create_args = [
+            "create",
+            "Madmail",
+            &format!("binPath= {bin}"),
+            "start= auto",
+            "DisplayName= Madmail",
+        ];
+        assert!(create_args[2].starts_with("binPath= "));
+        assert_eq!(create_args[3], "start= auto");
+        assert_eq!(create_args[4], "DisplayName= Madmail");
+        // These must go through sc_command → raw_arg on Windows (see run_sc docs).
+        let _ = sc_command(&create_args);
     }
 
     #[test]

--- a/crates/chatmail/src/ctl/service_cmd.rs
+++ b/crates/chatmail/src/ctl/service_cmd.rs
@@ -353,13 +353,12 @@ fn run_sc(args: &[&str], action: &str) -> Result<()> {
     )))
 }
 
-/// Build an `sc.exe` command.
+/// Build an `sc.exe` command (used for start/stop/delete/query).
 ///
-/// Windows `sc` option syntax is `key= value` (space after `=`). Rust's default
-/// `Command` quoting wraps those tokens as `"start= auto"`, which `sc` rejects
-/// with exit 1639 (`ERROR: Invalid start= field`). On Windows every argument is
-/// therefore appended with [`CommandExt::raw_arg`] so the process command line
-/// keeps unquoted `start= auto`, `binPath= "…"`, `reset= 86400`, etc.
+/// Service **create/config** uses the Win32 API ([`create_or_update_service`]) so
+/// we never depend on `sc` option quoting. Remaining `sc` calls still use
+/// [`CommandExt::raw_arg`] on Windows: if a future caller passes `key= value`
+/// tokens, Rust's default quoting must not wrap them as `"start= auto"` (exit 1639).
 fn sc_command(args: &[&str]) -> Command {
     let mut cmd = Command::new("sc");
     #[cfg(windows)]
@@ -394,26 +393,21 @@ mod tests {
         assert!(p.contains("madmail.exe"), "{p}");
     }
 
-    /// Document the sc option tokens that must not be Command-quoted on Windows.
     #[test]
-    fn sc_create_option_tokens_use_space_after_equals() {
+    fn service_bin_path_is_suitable_for_scm_image_path() {
         let bin = service_bin_path(
             Path::new(r"C:\Program Files\Madmail\madmail.exe"),
             Path::new(r"C:\ProgramData\Madmail\config\madmail.conf"),
             Path::new(r"C:\ProgramData\Madmail\data"),
         );
-        let create_args = [
-            "create",
-            "Madmail",
-            &format!("binPath= {bin}"),
-            "start= auto",
-            "DisplayName= Madmail",
-        ];
-        assert!(create_args[2].starts_with("binPath= "));
-        assert_eq!(create_args[3], "start= auto");
-        assert_eq!(create_args[4], "DisplayName= Madmail");
-        // These must go through sc_command → raw_arg on Windows (see run_sc docs).
-        let _ = sc_command(&create_args);
+        // CreateService uses exe + argv; ImagePath-style string still used for display/logging.
+        assert!(bin.starts_with('"'), "{bin}");
+        assert!(bin.contains("--service"), "{bin}");
+        assert!(bin.contains("--config"), "{bin}");
+        assert!(bin.contains("run"), "{bin}");
+        assert!(bin.contains("--libexec"), "{bin}");
+        // sc start/stop/delete still go through sc_command (raw_arg on Windows).
+        let _ = sc_command(&["query", "Madmail"]);
     }
 
     #[test]

--- a/crates/chatmail/src/ctl/service_cmd.rs
+++ b/crates/chatmail/src/ctl/service_cmd.rs
@@ -54,13 +54,10 @@ fn require_windows() -> Result<()> {
 fn install(args: &Args, name: &str, start_after: bool) -> Result<()> {
     require_windows()?;
     let out = CtlOut::from_args(args, "service");
-    let exe = std::env::current_exe().map_err(|e| {
-        ChatmailError::config(format!(
-            "resolve current executable for service binPath: {e}"
-        ))
-    })?;
+    // Prefer sibling/Program Files madmail.exe — never register madmail-tray as the service.
+    let exe = resolve_service_executable()?;
     let bin_path = service_bin_path(&exe, &args.config, &args.state_dir);
-    create_service(name, &bin_path)?;
+    create_or_update_service(name, &bin_path)?;
     set_service_description(name, "Madmail chatmail / mail server")?;
     set_service_recovery(name)?;
     if !out.is_json() {
@@ -83,6 +80,31 @@ fn install(args: &Args, name: &str, start_after: bool) -> Result<()> {
         }))?;
     }
     Ok(())
+}
+
+/// Binary that the SCM must launch (always `madmail.exe`, never the tray).
+fn resolve_service_executable() -> Result<std::path::PathBuf> {
+    let current = std::env::current_exe().map_err(|e| {
+        ChatmailError::config(format!(
+            "resolve current executable for service binPath: {e}"
+        ))
+    })?;
+    let name = current
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    if name == "madmail.exe" || name == "madmail" {
+        return Ok(current);
+    }
+    if let Some(dir) = current.parent() {
+        let sibling = dir.join("madmail.exe");
+        if sibling.is_file() {
+            return Ok(sibling);
+        }
+    }
+    // Last resort: still use current (may be wrong if tray-only install).
+    Ok(current)
 }
 
 fn uninstall(args: &Args, name: &str) -> Result<()> {
@@ -172,9 +194,9 @@ pub fn argv_without_service_flag() -> Vec<std::ffi::OsString> {
 }
 
 #[cfg(windows)]
-fn create_service(name: &str, bin_path: &str) -> Result<()> {
+fn create_or_update_service(name: &str, bin_path: &str) -> Result<()> {
     // sc requires a space after `=` tokens.
-    run_sc(
+    match run_sc(
         &[
             "create",
             name,
@@ -183,11 +205,30 @@ fn create_service(name: &str, bin_path: &str) -> Result<()> {
             "DisplayName= Madmail",
         ],
         &format!("create service {name}"),
-    )
+    ) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let msg = e.to_string();
+            // 1073 = The specified service already exists.
+            if msg.contains("1073") || msg.to_ascii_lowercase().contains("already exists") {
+                run_sc(
+                    &[
+                        "config",
+                        name,
+                        &format!("binPath= {bin_path}"),
+                        "start= auto",
+                    ],
+                    &format!("update service {name} binPath"),
+                )?;
+                return Ok(());
+            }
+            Err(e)
+        }
+    }
 }
 
 #[cfg(not(windows))]
-fn create_service(_name: &str, _bin_path: &str) -> Result<()> {
+fn create_or_update_service(_name: &str, _bin_path: &str) -> Result<()> {
     require_windows()
 }
 

--- a/crates/chatmail/src/ctl/service_cmd.rs
+++ b/crates/chatmail/src/ctl/service_cmd.rs
@@ -57,9 +57,7 @@ fn install(args: &Args, name: &str, start_after: bool) -> Result<()> {
     // Prefer sibling/Program Files madmail.exe — never register madmail-tray as the service.
     let exe = resolve_service_executable()?;
     let bin_path = service_bin_path(&exe, &args.config, &args.state_dir);
-    create_or_update_service(name, &bin_path)?;
-    set_service_description(name, "Madmail chatmail / mail server")?;
-    set_service_recovery(name)?;
+    create_or_update_service(name, &exe, &args.config, &args.state_dir)?;
     if !out.is_json() {
         println!("✓ Registered Windows service {name}");
         println!("  binPath: {bin_path}");
@@ -193,75 +191,101 @@ pub fn argv_without_service_flag() -> Vec<std::ffi::OsString> {
     std::env::args_os().filter(|a| a != SERVICE_FLAG).collect()
 }
 
+/// Register or update the Madmail SCM service via the Win32 service APIs.
+///
+/// Prefer this over shelling out to `sc.exe`: Rust's default `Command` quoting
+/// turns `start= auto` into `"start= auto"`, which `sc` rejects with exit 1639.
 #[cfg(windows)]
-fn create_or_update_service(name: &str, bin_path: &str) -> Result<()> {
-    // sc requires a space after `=` tokens.
-    match run_sc(
-        &[
-            "create",
-            name,
-            &format!("binPath= {bin_path}"),
-            "start= auto",
-            "DisplayName= Madmail",
+fn create_or_update_service(name: &str, exe: &Path, config: &Path, state_dir: &Path) -> Result<()> {
+    use std::ffi::OsString;
+    use std::time::Duration;
+
+    use windows_service::service::{
+        ServiceAccess, ServiceAction, ServiceActionType, ServiceErrorControl,
+        ServiceFailureActions, ServiceFailureResetPeriod, ServiceInfo, ServiceStartType,
+        ServiceType,
+    };
+    use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
+
+    let manager_access = ServiceManagerAccess::CONNECT | ServiceManagerAccess::CREATE_SERVICE;
+    let manager = ServiceManager::local_computer(None::<&str>, manager_access)
+        .map_err(|e| ChatmailError::config(format!("OpenSCManager (need elevated admin): {e}")))?;
+
+    let service_info = ServiceInfo {
+        name: OsString::from(name),
+        display_name: OsString::from("Madmail"),
+        service_type: ServiceType::OWN_PROCESS,
+        start_type: ServiceStartType::AutoStart,
+        error_control: ServiceErrorControl::Normal,
+        executable_path: exe.to_path_buf(),
+        launch_arguments: vec![
+            OsString::from(SERVICE_FLAG),
+            OsString::from("--config"),
+            config.as_os_str().to_os_string(),
+            OsString::from("run"),
+            OsString::from("--libexec"),
+            state_dir.as_os_str().to_os_string(),
         ],
-        &format!("create service {name}"),
-    ) {
-        Ok(()) => Ok(()),
-        Err(e) => {
-            let msg = e.to_string();
-            // 1073 = The specified service already exists.
-            if msg.contains("1073") || msg.to_ascii_lowercase().contains("already exists") {
-                run_sc(
-                    &[
-                        "config",
-                        name,
-                        &format!("binPath= {bin_path}"),
-                        "start= auto",
-                    ],
-                    &format!("update service {name} binPath"),
-                )?;
-                return Ok(());
-            }
-            Err(e)
+        dependencies: vec![],
+        account_name: None, // LocalSystem
+        account_password: None,
+    };
+
+    let service_access = ServiceAccess::QUERY_CONFIG
+        | ServiceAccess::CHANGE_CONFIG
+        | ServiceAccess::START
+        | ServiceAccess::DELETE;
+
+    // 1073 = ERROR_SERVICE_EXISTS
+    let service = match manager.create_service(&service_info, service_access) {
+        Ok(svc) => svc,
+        Err(windows_service::Error::Winapi(io)) if io.raw_os_error() == Some(1073) => {
+            let svc = manager
+                .open_service(name, service_access)
+                .map_err(|e| ChatmailError::config(format!("open existing service {name}: {e}")))?;
+            svc.change_config(&service_info)
+                .map_err(|e| ChatmailError::config(format!("update service {name} config: {e}")))?;
+            svc
         }
-    }
+        Err(e) => {
+            return Err(ChatmailError::config(format!("create service {name}: {e}")));
+        }
+    };
+
+    // Best-effort metadata; registration already succeeded.
+    let _ = service.set_description("Madmail chatmail / mail server");
+    let failure_actions = ServiceFailureActions {
+        reset_period: ServiceFailureResetPeriod::After(Duration::from_secs(86_400)),
+        reboot_msg: None,
+        command: None,
+        actions: Some(vec![
+            ServiceAction {
+                action_type: ServiceActionType::Restart,
+                delay: Duration::from_millis(5_000),
+            },
+            ServiceAction {
+                action_type: ServiceActionType::Restart,
+                delay: Duration::from_millis(5_000),
+            },
+            ServiceAction {
+                action_type: ServiceActionType::Restart,
+                delay: Duration::from_millis(5_000),
+            },
+        ]),
+    };
+    let _ = service.update_failure_actions(failure_actions);
+
+    Ok(())
 }
 
 #[cfg(not(windows))]
-fn create_or_update_service(_name: &str, _bin_path: &str) -> Result<()> {
+fn create_or_update_service(
+    _name: &str,
+    _exe: &Path,
+    _config: &Path,
+    _state_dir: &Path,
+) -> Result<()> {
     require_windows()
-}
-
-#[cfg(windows)]
-fn set_service_description(name: &str, description: &str) -> Result<()> {
-    run_sc(
-        &["description", name, description],
-        &format!("set description for {name}"),
-    )
-}
-
-#[cfg(not(windows))]
-fn set_service_description(_name: &str, _description: &str) -> Result<()> {
-    Ok(())
-}
-
-#[cfg(windows)]
-fn set_service_recovery(name: &str) -> Result<()> {
-    // Restart on failure: 5s, 5s, 5s; reset fail count after 1 day.
-    run_sc(
-        &[
-            "failure",
-            name,
-            "reset= 86400",
-            "actions= restart/5000/restart/5000/restart/5000",
-        ],
-        &format!("set recovery for {name}"),
-    )
-}
-
-#[cfg(not(windows))]
-fn set_service_recovery(_name: &str) -> Result<()> {
-    Ok(())
 }
 
 #[cfg(windows)]

--- a/crates/madmail-tray/Cargo.toml
+++ b/crates/madmail-tray/Cargo.toml
@@ -18,7 +18,6 @@ serde_json = { workspace = true }
 [target.'cfg(windows)'.dependencies]
 tray-icon = "0.19"
 winit = { version = "0.30", default-features = false, features = ["rwh_06"] }
-open = "5"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/madmail-tray/src/main.rs
+++ b/crates/madmail-tray/src/main.rs
@@ -25,7 +25,7 @@ use clap::{Parser, Subcommand};
 #[derive(Debug, Parser)]
 #[command(
     name = "madmail-tray",
-    about = "Madmail tray helper — status, admin, service control"
+    about = "Madmail tray helper — status, token, service control"
 )]
 struct Cli {
     /// Configuration file (default: %ProgramData%\\Madmail\\config\\madmail.conf on Windows).
@@ -52,8 +52,6 @@ struct Cli {
 enum Commands {
     /// Print service / path status and exit.
     Status,
-    /// Open the admin UI in the default browser.
-    OpenAdmin,
     /// Print the admin token if present.
     Token,
     /// Start the Madmail service (`madmail service start`).
@@ -84,14 +82,6 @@ fn main() {
         Some(Commands::Status) => {
             let r = ops::smoke_report(&config, &state_dir, &service_name);
             ops::print_smoke_report(&r);
-        }
-        Some(Commands::OpenAdmin) => {
-            let url = paths::admin_url(&config);
-            if let Err(e) = ops::open_url(&url) {
-                eprintln!("Error: {e}");
-                std::process::exit(1);
-            }
-            println!("Opened {url}");
         }
         Some(Commands::Token) => match paths::read_admin_token(&state_dir) {
             Some(t) => println!("{t}"),
@@ -143,7 +133,7 @@ fn main() {
             {
                 eprintln!(
                     "Interactive tray UI is Windows-only.\n\
-                     Use: madmail-tray --smoke-exit | status | open-admin | token\n\
+                     Use: madmail-tray --smoke-exit | status | token\n\
                      Or run on Windows for the system tray."
                 );
                 std::process::exit(2);

--- a/crates/madmail-tray/src/ops.rs
+++ b/crates/madmail-tray/src/ops.rs
@@ -13,6 +13,9 @@ use crate::paths;
 pub enum ServiceState {
     Running,
     Stopped,
+    /// Windows SCM: service name not registered (sc error 1060).
+    #[cfg_attr(not(windows), allow(dead_code))]
+    NotInstalled,
     Unknown(String),
     Unavailable,
 }
@@ -22,6 +25,7 @@ impl ServiceState {
         match self {
             ServiceState::Running => "Running",
             ServiceState::Stopped => "Stopped",
+            ServiceState::NotInstalled => "NotInstalled",
             ServiceState::Unknown(s) => s.as_str(),
             ServiceState::Unavailable => "Unavailable",
         }
@@ -53,7 +57,20 @@ pub fn query_service_state(service_name: &str) -> ServiceState {
                 }
                 ServiceState::Unknown("UNKNOWN".into())
             }
-            Ok(_) => ServiceState::Stopped,
+            Ok(o) => {
+                let combined = format!(
+                    "{}{}",
+                    String::from_utf8_lossy(&o.stdout),
+                    String::from_utf8_lossy(&o.stderr)
+                );
+                if combined.contains("1060")
+                    || combined.to_ascii_lowercase().contains("does not exist")
+                {
+                    ServiceState::NotInstalled
+                } else {
+                    ServiceState::Stopped
+                }
+            }
             Err(_) => ServiceState::Unavailable,
         }
     }
@@ -77,27 +94,61 @@ pub fn query_service_state(service_name: &str) -> ServiceState {
     }
 }
 
+/// Run `madmail service <action>`. On Windows, if the service is not installed and
+/// `action` is `start`, register it first (`service install --start`).
 pub fn run_madmail_service(
     madmail: &Path,
     config: &Path,
     state_dir: &Path,
     action: &str,
 ) -> Result<(), String> {
-    let status = Command::new(madmail)
-        .args([
-            "--config",
-            &config.display().to_string(),
-            "--state-dir",
-            &state_dir.display().to_string(),
-            "service",
-            action,
-        ])
-        .status()
-        .map_err(|e| format!("spawn madmail: {e}"))?;
+    #[cfg(windows)]
+    {
+        if action == "start" {
+            match query_service_state("Madmail") {
+                ServiceState::NotInstalled => {
+                    return run_madmail_args(
+                        madmail,
+                        config,
+                        state_dir,
+                        &["service", "install", "--start"],
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
+    run_madmail_args(madmail, config, state_dir, &["service", action])
+}
+
+fn run_madmail_args(
+    madmail: &Path,
+    config: &Path,
+    state_dir: &Path,
+    extra: &[&str],
+) -> Result<(), String> {
+    let mut cmd = Command::new(madmail);
+    cmd.arg("--config")
+        .arg(config)
+        .arg("--state-dir")
+        .arg(state_dir)
+        .args(extra);
+    // Avoid flashing a console window when launched from the tray.
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    let status = cmd.status().map_err(|e| format!("spawn madmail: {e}"))?;
     if status.success() {
         Ok(())
     } else {
-        Err(format!("madmail service {action} exit {:?}", status.code()))
+        Err(format!(
+            "madmail {} exit {:?}",
+            extra.join(" "),
+            status.code()
+        ))
     }
 }
 

--- a/crates/madmail-tray/src/ops.rs
+++ b/crates/madmail-tray/src/ops.rs
@@ -172,21 +172,6 @@ pub fn open_path(path: &Path) -> Result<(), String> {
     }
 }
 
-pub fn open_url(url: &str) -> Result<(), String> {
-    #[cfg(windows)]
-    {
-        open::that(url).map_err(|e| format!("open url: {e}"))
-    }
-    #[cfg(not(windows))]
-    {
-        Command::new("xdg-open")
-            .arg(url)
-            .spawn()
-            .map_err(|e| format!("xdg-open: {e}"))?;
-        Ok(())
-    }
-}
-
 /// Snapshot used by `--smoke-exit` and tray status label.
 #[derive(Debug)]
 pub struct SmokeReport {
@@ -208,7 +193,7 @@ pub fn smoke_report(config: &Path, state_dir: &Path, service_name: &str) -> Smok
         state_exists: state_dir.is_dir(),
         token_present: paths::read_admin_token(state_dir).is_some(),
         service: query_service_state(service_name),
-        admin_url: paths::admin_url(config),
+        admin_url: paths::admin_api_url(config),
         madmail: paths::madmail_binary().display().to_string(),
     }
 }

--- a/crates/madmail-tray/src/paths.rs
+++ b/crates/madmail-tray/src/paths.rs
@@ -60,8 +60,11 @@ pub fn read_admin_token(state_dir: &Path) -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
-/// Best-effort admin URL from config hostname, else localhost HTTP.
-pub fn admin_url(config_path: &Path) -> String {
+/// Admin **API** base URL (`POST` only — not a browser page). From config hostname, else localhost.
+///
+/// Kept for status/smoke reporting. There is no tray “open admin UI” while the SPA is not
+/// embedded in Windows builds; operators use the CLI + `POST /api/admin` with the token.
+pub fn admin_api_url(config_path: &Path) -> String {
     if config_path.is_file() {
         if let Ok(cfg) = chatmail_config::load_config(config_path) {
             let host = cfg
@@ -98,8 +101,9 @@ mod tests {
     }
 
     #[test]
-    fn admin_url_defaults() {
-        let u = admin_url(Path::new("/nonexistent/madmail.conf"));
+    fn admin_api_url_defaults() {
+        let u = admin_api_url(Path::new("/nonexistent/madmail.conf"));
         assert!(u.contains("127.0.0.1"), "{u}");
+        assert!(u.ends_with("/api/admin"), "{u}");
     }
 }

--- a/crates/madmail-tray/src/tray_win.rs
+++ b/crates/madmail-tray/src/tray_win.rs
@@ -45,8 +45,10 @@ impl TrayApp {
         let label = format!("Status: {}", st.as_str());
         self.item_status.set_text(label);
         let running = matches!(st, ServiceState::Running);
+        // Allow Start when stopped or not yet registered (install --start).
         self.item_start.set_enabled(!running);
-        self.item_stop.set_enabled(running);
+        self.item_stop
+            .set_enabled(running || matches!(st, ServiceState::Stopped));
     }
 
     fn handle_menu(&mut self, id: &tray_icon::menu::MenuId) {

--- a/crates/madmail-tray/src/tray_win.rs
+++ b/crates/madmail-tray/src/tray_win.rs
@@ -30,7 +30,6 @@ struct TrayApp {
     #[allow(dead_code)]
     tray: Option<tray_icon::TrayIcon>,
     item_status: MenuItem,
-    item_open_admin: MenuItem,
     item_copy_token: MenuItem,
     item_start: MenuItem,
     item_stop: MenuItem,
@@ -54,11 +53,6 @@ impl TrayApp {
     fn handle_menu(&mut self, id: &tray_icon::menu::MenuId) {
         if id == self.item_status.id() {
             self.refresh_status();
-        } else if id == self.item_open_admin.id() {
-            let url = paths::admin_url(&self.config);
-            if let Err(e) = ops::open_url(&url) {
-                eprintln!("open admin: {e}");
-            }
         } else if id == self.item_copy_token.id() {
             if let Some(tok) = paths::read_admin_token(&self.state_dir) {
                 // Best-effort: print and try clip.exe
@@ -134,7 +128,6 @@ fn default_icon() -> Icon {
 pub fn run(config: PathBuf, state_dir: PathBuf) -> Result<(), String> {
     let madmail = paths::madmail_binary();
     let item_status = MenuItem::new("Status: …", true, None);
-    let item_open_admin = MenuItem::new("Open admin UI", true, None);
     let item_copy_token = MenuItem::new("Show / copy admin token", true, None);
     let item_start = MenuItem::new("Start service", true, None);
     let item_stop = MenuItem::new("Stop service", true, None);
@@ -145,8 +138,6 @@ pub fn run(config: PathBuf, state_dir: PathBuf) -> Result<(), String> {
     menu.append(&item_status)
         .map_err(|e| format!("menu: {e}"))?;
     menu.append(&PredefinedMenuItem::separator())
-        .map_err(|e| format!("menu: {e}"))?;
-    menu.append(&item_open_admin)
         .map_err(|e| format!("menu: {e}"))?;
     menu.append(&item_copy_token)
         .map_err(|e| format!("menu: {e}"))?;
@@ -173,7 +164,6 @@ pub fn run(config: PathBuf, state_dir: PathBuf) -> Result<(), String> {
         madmail,
         tray: Some(tray),
         item_status,
-        item_open_admin,
         item_copy_token,
         item_start,
         item_stop,

--- a/docs/project/user-guide/02-quick-start.md
+++ b/docs/project/user-guide/02-quick-start.md
@@ -74,7 +74,9 @@ Defaults:
 | State / token | `%ProgramData%\Madmail\data\` |
 | Service name | `Madmail` |
 
-Useful commands: `madmail service status`, `madmail firewall apply`, `madmail-tray --smoke-exit`.
+Useful commands: `madmail service status`, `madmail admin-token`, `madmail firewall apply`, `madmail-tray --smoke-exit`.
+
+Admin: use the **CLI** and **`POST /api/admin`** with the bearer token. Current Windows packages do **not** embed the admin-web SPA at `/admin` (browser GET on `/api/admin` returns **405**).
 
 Packaging and build notes: [packaging/windows/README.md](../../../packaging/windows/README.md).  
 Manual release checklist: [packaging/windows/MANUAL-CHECKLIST.md](../../../packaging/windows/MANUAL-CHECKLIST.md).

--- a/packaging/windows/MANUAL-CHECKLIST.md
+++ b/packaging/windows/MANUAL-CHECKLIST.md
@@ -14,8 +14,9 @@ Run before claiming a public Windows setup.exe or closing epic [#103](https://gi
   `madmail install --simple --ip 127.0.0.1 --tls-mode self_signed --install-service --start-service --firewall`
 - [ ] Service shows **Running** (`madmail service status` / Services MMC)
 - [ ] Firewall rules present (`Madmail (*)` in Windows Firewall)
-- [ ] `madmail-tray --smoke-exit` exits 0; tray menu opens admin / start-stop works
-- [ ] Admin token file under `%ProgramData%\Madmail\data\admin_token`
+- [ ] `madmail-tray --smoke-exit` exits 0; tray start/stop service and “copy admin token” work
+- [ ] Admin token file under `%ProgramData%\Madmail\data\admin_token` (use CLI / `POST /api/admin` — Windows builds do not embed the admin-web SPA)
+- [ ] Service install does **not** fail with sc exit **1639** (uses Win32 CreateService, not quoted `sc start=`)
 - [ ] **Full mail path** (or `vagrant` E2E): create two users, SMTP 587 → IMAP 143 both directions — see [vagrant/README.md](./vagrant/README.md)
 - [ ] **Public IP self-signed** (optional lab)
 - [ ] **Domain LE** or **auto-IP cert** when port 80 and DNS/IP allow (optional)

--- a/packaging/windows/Madmail.iss
+++ b/packaging/windows/Madmail.iss
@@ -59,6 +59,12 @@ ArchitecturesInstallIn64BitMode=x64compatible
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
 
+[Dirs]
+Name: "{commonappdata}\Madmail"
+Name: "{commonappdata}\Madmail\config"
+Name: "{commonappdata}\Madmail\data"
+Name: "{commonappdata}\Madmail\config\certs"
+
 [Tasks]
 Name: "desktopicon"; Description: "Create a &desktop shortcut for Madmail tray"; GroupDescription: "Additional icons:"; Flags: unchecked
 Name: "autostart"; Description: "Start &tray when I log in"; GroupDescription: "Startup:"; Flags: checkedonce
@@ -78,9 +84,9 @@ Name: "{group}\Uninstall Madmail"; Filename: "{uninstallexe}"
 Name: "{autodesktop}\Madmail Tray"; Filename: "{app}\{#MyTrayExeName}"; Tasks: desktopicon; Check: TrayPresent
 
 [Run]
-; Configure server (self-signed / LE based on wizard), register service, optional firewall
-Filename: "{app}\{#MyAppExeName}"; \
-  Parameters: "{code:InstallCliArgs}"; \
+; Log configure step to ProgramData\Madmail\install.log (failures were invisible with bare runhidden).
+Filename: "{cmd}"; \
+  Parameters: "/C """"{app}\{#MyAppExeName}"" {code:InstallCliArgs} > ""{commonappdata}\Madmail\install.log"" 2>&1"""; \
   StatusMsg: "Configuring Madmail (TLS, service)…"; \
   Flags: runhidden waituntilterminated
 ; Tray autostart
@@ -345,20 +351,44 @@ begin
 end;
 
 procedure CurStepChanged(CurStep: TSetupStep);
+var
+  LogPath: String;
+  ResultCode: Integer;
 begin
   if CurStep = ssPostInstall then
   begin
+    LogPath := ExpandConstant('{commonappdata}\Madmail\install.log');
     FinishedMsg :=
       'Madmail is installed under:'#13#10 +
       '  App:   ' + ExpandConstant('{app}') + #13#10 +
       '  Config: ' + ConfigDir + #13#10 +
       '  State:  ' + StateDir + #13#10#13#10 +
       'Service name: {#MyServiceName}'#13#10 +
-      'Admin token file: ' + StateDir + '\admin_token'#13#10#13#10 +
+      'Admin token file: ' + StateDir + '\admin_token'#13#10 +
+      'Install log: ' + LogPath + #13#10#13#10 +
+      'If the service is missing, open an elevated cmd and run:'#13#10 +
+      '  "' + ExpandConstant('{app}\{#MyAppExeName}') + '" --config "' + ConfigDir + '\madmail.conf" --state-dir "' + StateDir + '" service install --start'#13#10#13#10 +
       'Useful commands:'#13#10 +
       '  madmail service status'#13#10 +
       '  madmail admin-token'#13#10 +
       '  madmail-tray --smoke-exit';
+
+    { Verify SCM registration; offer repair if configure step failed silently. }
+    if Exec(ExpandConstant('{cmd}'),
+      '/C sc query {#MyServiceName} >nul 2>&1',
+      '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+    begin
+      if ResultCode <> 0 then
+      begin
+        MsgBox(
+          'Madmail files were installed, but the Windows service "{#MyServiceName}" is not registered.'#13#10#13#10 +
+          'This often happens if antivirus blocked the configure step, or the installer was not elevated.'#13#10#13#10 +
+          'See log: ' + LogPath + #13#10#13#10 +
+          'Repair (elevated Command Prompt):'#13#10 +
+          '"' + ExpandConstant('{app}\{#MyAppExeName}') + '" --config "' + ConfigDir + '\madmail.conf" --state-dir "' + StateDir + '" service install --start',
+          mbError, MB_OK);
+      end;
+    end;
   end;
 end;
 

--- a/packaging/windows/Madmail.iss
+++ b/packaging/windows/Madmail.iss
@@ -216,8 +216,8 @@ begin
 
   if FeaturePage.Values[0] then
     Args := Args + ' --enable-ss';
-  if FeaturePage.Values[1] then
-    Args := Args + ' --enable-iroh';
+  { Iroh omitted: Windows builds do not ship iroh-relay.exe yet; enabling it makes
+    the service fail at boot with "iroh-relay: program not found". Re-add when packaged. }
 
   Args := Args + ' --install-service';
   if WizardIsTaskSelected('startservice') then
@@ -322,9 +322,7 @@ begin
     'You can change these later via config / CLI.',
     False, False);
   FeaturePage.Add('Shadowsocks proxy');
-  FeaturePage.Add('Iroh relay discovery');
   FeaturePage.Values[0] := True;
-  FeaturePage.Values[1] := False;
 
   DnsPage := CreateOutputMsgPage(wpSelectTasks,
     'DNS checklist', 'Domain deployment reminders',

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -141,6 +141,28 @@ GitHub Actions workflow [`.github/workflows/windows.yml`](../../.github/workflow
 
 Does **not** create git tags or GitHub Releases. Download the setup from the Actions run artifacts (`madmail-windows-amd64-setup`). Manual sign-off: [MANUAL-CHECKLIST.md](./MANUAL-CHECKLIST.md).
 
+### Windows Defender / SmartScreen
+
+Unsigned CI-built `setup.exe` / `madmail.exe` are often flagged as **Trojan:Win32/Bearfoos** (or similar ML heuristics). That is a **false positive** for this project until Authenticode signing is added.
+
+Workarounds for lab VMs:
+
+1. **Defender exclusion** for `C:\Program Files\Madmail` and `%ProgramData%\Madmail` (and your Downloads folder while installing).
+2. Restore the file from Protection history if quarantined mid-install.
+3. Prefer copying **`madmail.exe`** from CI and running elevated `madmail install …` if setup.exe is blocked.
+4. Long-term: sign release binaries (Authenticode).
+
+If the tray says the service does not exist (error 1060), register it manually (elevated):
+
+```powershell
+& "C:\Program Files\Madmail\madmail.exe" `
+  --config "$env:ProgramData\Madmail\config\madmail.conf" `
+  --state-dir "$env:ProgramData\Madmail\data" `
+  service install --start
+```
+
+Configure log (when installed via setup): `%ProgramData%\Madmail\install.log`.
+
 ## Local full E2E (Vagrant + libvirt)
 
 Optional **release testing** on a Windows VM (not a GHA replacement): install, service, firewall, and **full mail path** (create users, SMTP submit, IMAP receive both directions).

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -44,7 +44,7 @@ iscc /DArch=arm64 packaging\windows\Madmail.iss
 3. **Identity** — IP or hostname  
 4. **TLS** — self-signed or Let's Encrypt  
 5. ACME email (if LE)  
-6. Language + optional Shadowsocks / Iroh  
+6. Language + optional Shadowsocks (Iroh omitted until `iroh-relay.exe` is packaged)  
 7. Install directory + tasks (firewall, start service, tray autostart)  
 8. DNS checklist (domain mode)  
 9. Post-install: `madmail install … --install-service [--start-service] [--firewall]`  

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -124,9 +124,28 @@ Until arm64 CI runners or cargo-xwin are available, **compile-only** checks and 
 madmail install --simple --ip … --install-service --start-service --firewall
 madmail service install|start|stop|status
 madmail firewall apply|remove
+madmail admin-token
 madmail-tray --smoke-exit
+madmail-tray status | token
 madmail-tray install-autostart
 ```
+
+### Admin API vs admin web UI
+
+| Surface | Windows packaging status |
+|---------|--------------------------|
+| `POST /api/admin` + bearer token | Supported (service running) |
+| Embedded SPA at `/admin` | **Not** shipped in current Windows CI builds (stub / disabled) |
+| Tray “Open admin UI” | **Removed** — no SPA; use token + CLI/API |
+
+Token file: `%ProgramData%\Madmail\data\admin_token`.  
+Do not open `/api/admin` in a browser (GET → **405**).
+
+### Installer options (wizard)
+
+- **Shadowsocks** — optional (default on).
+- **Iroh** — **not** offered (no `iroh-relay.exe` on Windows yet; enabling it breaks service boot).
+- Prefer **self-signed** in the lab if port **80** / ACME is not ready; **Let's Encrypt** (public IP or domain) needs inbound TCP 80 during install.
 
 ## CI
 

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -136,9 +136,10 @@ GitHub Actions workflow [`.github/workflows/windows.yml`](../../.github/workflow
 |-----|---------|
 | `linux-windows-crates` | Unit tests for tray / service / firewall / packaging file presence |
 | `windows-amd64-smoke` | MSVC build, tray smoke, service status, local self-signed install, upload CI artifacts |
+| `windows-amd64-setup` | Inno Setup (`choco install innosetup`) → `madmail-windows-amd64-setup.exe` artifact |
 | `windows-arm64-compile` | `cargo check` for `aarch64-pc-windows-msvc` (server + tray) |
 
-Does **not** create git tags or GitHub Releases. Manual sign-off: [MANUAL-CHECKLIST.md](./MANUAL-CHECKLIST.md).
+Does **not** create git tags or GitHub Releases. Download the setup from the Actions run artifacts (`madmail-windows-amd64-setup`). Manual sign-off: [MANUAL-CHECKLIST.md](./MANUAL-CHECKLIST.md).
 
 ## Local full E2E (Vagrant + libvirt)
 

--- a/packaging/windows/build-setup.ps1
+++ b/packaging/windows/build-setup.ps1
@@ -62,15 +62,19 @@ function Build-One([string]$A) {
 }
 
 New-Item -ItemType Directory -Force -Path $Build | Out-Null
-Set-Location $Here
-
-switch ($Arch) {
-    "amd64" { Build-One "amd64" }
-    "arm64" { Build-One "arm64" }
-    "all" {
-        Build-One "amd64"
-        Build-One "arm64"
+# Do not leave the caller's cwd changed (GHA steps share the process with &).
+Push-Location $Here
+try {
+    switch ($Arch) {
+        "amd64" { Build-One "amd64" }
+        "arm64" { Build-One "arm64" }
+        "all" {
+            Build-One "amd64"
+            Build-One "arm64"
+        }
     }
+} finally {
+    Pop-Location
 }
 
 Write-Host "==> done"


### PR DESCRIPTION
## Summary

Ship a CI-built **Inno Setup** `setup.exe` and harden the Windows install/runtime path so Contabo-style VMs can finish install without known footguns.

### CI
- Job **`windows-amd64-setup`**: after `windows-amd64-smoke`, stage binaries, `choco install innosetup`, `build-setup.ps1`, upload `madmail-windows-amd64-setup.exe` (artifact only — **not** a GitHub Release)
- `build-setup.ps1`: Push/Pop-Location so GHA cwd stays at workspace root

### Installer / ops
- Configure step logs to `%ProgramData%\Madmail\install.log`; post-install warns if SCM service missing + repair command
- ProgramData dirs created by Inno
- **Iroh** option removed from wizard (no `iroh-relay.exe` on Windows)
- Defender / 1060 service repair notes in `packaging/windows/README.md`

### Service + tray
- **`service install`**: Win32 `CreateService` / `ChangeServiceConfig` (avoids `sc` exit **1639** Invalid `start=` field)
- Prefer sibling `madmail.exe` as binPath (never tray)
- Tray: auto `service install --start` when NotInstalled; no console flash; **removed** “Open admin UI” (no embedded SPA; GET `/api/admin` is 405)
- Docs: README, MANUAL-CHECKLIST, quick-start Windows section aligned

## Type of change

- [x] Bug fix
- [x] Feature / enhancement
- [x] Build / CI / tooling
- [x] Documentation

## Area

- [x] Other: Windows packaging / service / tray

## Testing

- [x] `make fmt` / `make lint` (local)
- [x] `cargo test -p chatmail --lib ctl::service_cmd` / `cargo test -p madmail-tray`
- [ ] Workflow green on PR (Windows runners)
- [x] Manual Contabo: LE HTTP-01 OK; service after Win32 fix path; Iroh disable required for old wizard

## Related

- Epic: #103
- Milestone: Windows installer (full production pack)
- Base: `feat/windows-installer`