### PR TITLE
docs: Windows operator HTML www_dir and install gaps

### DIFF
--- a/docs/guide/cli/html-export.md
+++ b/docs/guide/cli/html-export.md
@@ -25,11 +25,23 @@ madmail html-export <DEST_DIR>
 
 ## Example
 
+### Linux
+
 ```bash
-madmail html-export /opt/madmail-www-backup
+sudo madmail html-export /var/lib/madmail/www
 ```
 
-Edit exported files, then point the server at them with [`html-serve`](html-serve.md).
+### Windows
+
+```powershell
+$cfg = "$env:ProgramData\Madmail\config\madmail.conf"
+$st  = "$env:ProgramData\Madmail\data"
+$www = "$env:ProgramData\Madmail\www"
+New-Item -ItemType Directory -Force -Path $www | Out-Null
+& "C:\Program Files\Madmail\madmail.exe" --config $cfg --state-dir $st html-export $www
+```
+
+Edit exported files, then point the server at them with [`html-serve`](html-serve.md). Full walkthrough: [Customizing HTML pages](../../project/user-guide/17-customizing-html-pages.md).
 
 ## JSON output (`--json`)
 

--- a/docs/guide/cli/html-migrate.md
+++ b/docs/guide/cli/html-migrate.md
@@ -65,10 +65,19 @@ madmail html-migrate --yes
 
 ```bash
 # Interactive (recommended once after Go → v2)
-sudo madmail --config /etc/maddy/maddy.conf html-migrate
+sudo madmail --config /etc/madmail/madmail.conf html-migrate
 
 # Scripted
-sudo madmail --config /etc/maddy/maddy.conf html-migrate --yes
+sudo madmail --config /etc/madmail/madmail.conf html-migrate --yes
+```
+
+Windows (custom `www_dir` under ProgramData):
+
+```powershell
+& "C:\Program Files\Madmail\madmail.exe" `
+  --config "$env:ProgramData\Madmail\config\madmail.conf" `
+  --state-dir "$env:ProgramData\Madmail\data" `
+  html-migrate --yes
 ```
 
 ## Notes

--- a/docs/guide/cli/html-serve.md
+++ b/docs/guide/cli/html-serve.md
@@ -25,19 +25,31 @@ madmail html-serve <WWW_DIR>
 
 ## Example
 
-```bash
-madmail html-serve /opt/custom-www
-madmail html-serve embedded
-madmail reload
-```
-
-After changing settings stored in the database, run:
+### Linux
 
 ```bash
-madmail reload
+sudo madmail html-serve /var/lib/madmail/www
+sudo madmail html-serve embedded
+sudo madmail reload
+# or: sudo systemctl restart madmail
 ```
 
-to apply listener and HTTP route changes without a full process restart.
+### Windows
+
+```powershell
+$cfg = "$env:ProgramData\Madmail\config\madmail.conf"
+$st  = "$env:ProgramData\Madmail\data"
+$www = "$env:ProgramData\Madmail\www"
+
+& "C:\Program Files\Madmail\madmail.exe" --config $cfg --state-dir $st html-serve $www
+# Revert to built-in pages:
+# & "C:\Program Files\Madmail\madmail.exe" --config $cfg --state-dir $st html-serve embedded
+Restart-Service Madmail
+```
+
+After changing settings stored in the database, run `madmail reload` and/or restart the service to remount HTTP routes.
+
+Operator walkthrough (export → edit → serve): [Customizing HTML pages](../../project/user-guide/17-customizing-html-pages.md).
 
 ## JSON output (`--json`)
 

--- a/docs/guide/cli/install.md
+++ b/docs/guide/cli/install.md
@@ -44,7 +44,9 @@ madmail install --simple --ip 203.0.113.50 --tls-mode self_signed --lang en `
   --install-service --start-service --firewall
 ```
 
-On **Windows**, default install paths are `%ProgramData%\Madmail\config` and `%ProgramData%\Madmail\data` (not `/etc` / `/var/lib`). Use the [Windows packaging guide](../../../packaging/windows/README.md) for the Inno Setup wizard and tray helper.
+On **Windows**, default install paths are `%ProgramData%\Madmail\config` and `%ProgramData%\Madmail\data` (not `/etc` / `/var/lib`). Prefer the [Windows packaging guide](../../../packaging/windows/README.md) for the Inno Setup wizard, tray helper, UAC/SmartScreen notes, and service layout.
+
+**Let's Encrypt on Windows:** open **inbound TCP 80** (Windows Firewall + provider panel) before HTTP-01. Install opens a Madmail HTTP firewall rule when possible, but cloud firewalls still matter. For a lab finish without LE, use `--tls-mode self_signed --no-obtain-certificate`.
 
 ## Key flags
 

--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -42,6 +42,18 @@ Port **80** must be free during install when autocert issuance runs (default for
 
 **Before install (domain):** create an **`A` or `AAAA`** record for the hostname pointing at this machine. See [DNS and Mail Authentication](../project/user-guide/12-dns-mail-auth.md) for the full checklist (MX, SPF, DKIM, DMARC, federation).
 
+### Windows (Inno or CLI)
+
+Prefer **`madmail-windows-amd64-setup.exe`** from [GitHub Releases](https://github.com/themadorg/madmail/releases) (unsigned — UAC / SmartScreen notes in the packaging guide). Or elevated CLI:
+
+```powershell
+& "C:\Program Files\Madmail\madmail.exe" install `
+  --simple --ip 203.0.113.50 --tls-mode self_signed --lang en `
+  --install-service --start-service --firewall
+```
+
+Defaults: `%ProgramData%\Madmail\config` and `%ProgramData%\Madmail\data`, service name **`Madmail`**. Details: [Windows packaging](../packaging/windows/README.md), [Quick Start — Windows](../project/user-guide/02-quick-start.md).
+
 ### Local / dev — custom paths (no root)
 
 ```bash

--- a/docs/install-simple-ip-acme.md
+++ b/docs/install-simple-ip-acme.md
@@ -4,12 +4,29 @@ Use this flow when the mail server is reached by **public IP** (typical Delta Ch
 
 ## Command
 
+### Linux
+
 Run as **root** on the server (or via `sudo`):
 
 ```bash
 sudo madmail install --simple --ip 203.0.113.50 --auto-ip-cert \
   --acme-email you@example.com
 ```
+
+### Windows
+
+Elevated PowerShell (or the Inno wizard with **Public IP** + **Let's Encrypt**):
+
+```powershell
+& "C:\Program Files\Madmail\madmail.exe" install `
+  --simple --ip 203.0.113.50 --auto-ip-cert `
+  --acme-email you@example.com --lang en `
+  --config-dir "$env:ProgramData\Madmail\config" `
+  --state-dir "$env:ProgramData\Madmail\data" `
+  --install-service --start-service --firewall
+```
+
+Ensure **inbound TCP 80** is allowed (Windows Firewall + cloud/provider firewall). Install opens the Madmail HTTP rule when it can; LE still needs reachability from the public internet.
 
 Replace:
 
@@ -26,15 +43,16 @@ Replace:
 |------|---------|
 | `--enable-chatmail` | Turn on Chatmail blocks in the generated config |
 | `--enable-ss` | Include Shadowsocks proxy blocks |
-| `--skip-systemd` | Config + certs only, no `madmail.service` |
-| `--skip-user` | Do not create the `madmail` system user |
+| `--install-service` / `--start-service` / `--firewall` | **Windows:** register/start SCM service and open firewall ports |
+| `--skip-systemd` | Config + certs only, no `madmail.service` (**Linux**) |
+| `--skip-user` | Do not create the `madmail` system user (**Linux**) |
 | `--dry-run` | Print planned paths without writing files |
 | `--no-obtain-certificate` | Skip issuance during install (unusual with `--auto-ip-cert`) |
 | `--lang` | Website / UI language for the public pages and docs (`en`, `fa`, `ru`, `es`). Seeds the `LANGUAGE` setting. |
 
 ## What this does
 
-1. **System layout** — Installs `madmail` to `/usr/local/bin/madmail`, writes `/etc/madmail/madmail.conf`, state under `/var/lib/madmail`, enables a `madmail.service` systemd unit (unless `--skip-systemd`).
+1. **System layout** — **Linux:** installs `madmail` to `/usr/local/bin/madmail`, writes `/etc/madmail/madmail.conf`, state under `/var/lib/madmail`, enables a `madmail.service` systemd unit (unless `--skip-systemd`). **Windows:** uses `%ProgramData%\Madmail\{config,data}` and the `Madmail` Windows service when `--install-service` is set (see [Windows packaging](../packaging/windows/README.md)).
 2. **TLS mode** — Sets `autocert` (not self-signed). With `--auto-ip-cert`, `turn_off_tls` stays **off** so IMAP/SMTP submission use TLS with the issued cert.
 3. **Certificate** — Obtains a Let's Encrypt **short-lived IP certificate** (profile `shortlived`, ~6-day lifetime) with **HTTP-01** on `0.0.0.0:80`.
 4. **Storage** — Writes PEMs to:

--- a/docs/project/user-guide/02-quick-start.md
+++ b/docs/project/user-guide/02-quick-start.md
@@ -80,6 +80,8 @@ Useful commands: `madmail service status`, `madmail admin-token`, `madmail firew
 
 Admin: use the **CLI** and **`POST /api/admin`** with the bearer token. Current Windows packages do **not** embed the admin-web SPA at `/admin` (browser GET on `/api/admin` returns **405**).
 
+**Custom public HTML** (`/`, `/new`, `/docs/`, …): export defaults to `%ProgramData%\Madmail\www`, run `html-serve`, restart the service — see [Customizing HTML pages](./17-customizing-html-pages.md#windows).
+
 Packaging and build notes: [packaging/windows/README.md](../../../packaging/windows/README.md).  
 Manual release checklist: [packaging/windows/MANUAL-CHECKLIST.md](../../../packaging/windows/MANUAL-CHECKLIST.md).  
 Epic: [#103](https://github.com/themadorg/madmail/issues/103).
@@ -89,6 +91,7 @@ More detail:
 - [Simple IP + ACME install](../../install-simple-ip-acme.md)
 - [IP vs domain deployment](./11-deployment-ip-domain-certs.md)
 - [DNS, SPF, DKIM, federation](./12-dns-mail-auth.md)
+- [Customizing HTML pages](./17-customizing-html-pages.md)
 - [Local development](../../local-dev.md)
 - [Windows packaging](../../../packaging/windows/README.md)
 

--- a/docs/project/user-guide/07-admin-and-cli.md
+++ b/docs/project/user-guide/07-admin-and-cli.md
@@ -13,21 +13,21 @@ One particularly useful CLI command for production servers is `madmail upgrade` 
 
 ## The Web Admin Dashboard
 
-This is the graphical way to manage the server.
+This is the graphical way to manage the server **when the admin SPA is embedded and enabled**.
 
 ### Accessing It
 
-In the official releases and normal installations, the Admin Web Interface is **included directly in the `madmail` binary**.
-
-It is served at:
+On **Linux** release builds that include the admin-web SPA (e.g. `make build-with-admin-web` / many official packages), the dashboard is served from the same binary at:
 
 ```
 https://your-server/admin/
 ```
 
-(or a custom path you configure).
+(or a custom path you configure). Enable with `madmail admin-web enable` if the path returns 404.
 
-You log in with the **admin token** — a long random string stored in the `admin_token` file on the server (or the one shown during `madmail install`).
+**Windows** CI/Release packages currently **do not** embed the admin SPA. Opening `/admin` will not give you a dashboard, and browser **GET** on `/api/admin` returns **405** (that endpoint is **POST-only** JSON). Use the **CLI** and the admin token instead (see [Quick Start — Windows](./02-quick-start.md)).
+
+You log in (or call the API) with the **admin token** — a long random string in the `admin_token` file on the server (Linux: often under `/var/lib/madmail/`; Windows: `%ProgramData%\Madmail\data\admin_token`).
 
 ### What You Can Do in the Web Interface
 
@@ -207,19 +207,37 @@ madmail html-serve /path/to/custom/www   # serve custom HTML instead of built-in
 madmail html-export /backup/www    # export the default web files
 ```
 
+**Windows** (paths and service differ; use elevated PowerShell):
+
+```powershell
+$m = "C:\Program Files\Madmail\madmail.exe"
+$cfg = "--config"; $c = "$env:ProgramData\Madmail\config\madmail.conf"
+$st = "--state-dir"; $s = "$env:ProgramData\Madmail\data"
+
+& $m $cfg $c $st $s admin-token
+& $m $cfg $c $st $s service status
+& $m $cfg $c $st $s html-export "$env:ProgramData\Madmail\www"
+& $m $cfg $c $st $s html-serve "$env:ProgramData\Madmail\www"
+Restart-Service Madmail
+```
+
+Custom public pages: [Customizing HTML pages](./17-customizing-html-pages.md).  
+Installer / Defender / UAC: [Windows packaging](../../../packaging/windows/README.md).
+
 ### Tips
 
 - Almost every command supports `--help` (e.g. `madmail accounts --help` or `madmail registration-tokens create --help`).
-- Many operations are easier in the web admin dashboard. Use the CLI when you need scripting or only have terminal access.
-- After changing ports, paths, or certain settings, a `madmail reload` (or full restart) is often required.
+- On **Linux**, many operators use the **admin web dashboard** when it is enabled and embedded. On **Windows** release builds the admin SPA is typically **not** embedded — use the **CLI** and `POST /api/admin` with the admin token (see [Quick Start — Windows](./02-quick-start.md)).
+- After changing ports, paths, or certain settings, a `madmail reload` (or full restart / `Restart-Service Madmail`) is often required.
 
 For the complete list of subcommands and flags, run `madmail --help`.
 
 ### CLI vs Web Interface
 
-- Use the **web interface** for exploration and occasional tasks.
-- Use the **CLI** for scripting, automation, or when you only have SSH access.
-- Both expose the same admin API. The web UI is a browser frontend; the CLI calls the same resources directly or via equivalent DB operations.
+- Use the **public website** (`/`, `/new`, `/docs/`) for end users; customize it with `www_dir` / `html-serve`.
+- Use the **admin SPA** (`/admin`) when your build includes it and it is enabled — not always available on Windows packages.
+- Use the **CLI** for scripting, automation, SSH/RDP-only access, and when the admin SPA is unavailable.
+- The admin SPA (when present) and CLI both talk to the same admin API / DB settings.
 
 ## The Admin API (How Everything Works)
 

--- a/docs/project/user-guide/10-troubleshooting.md
+++ b/docs/project/user-guide/10-troubleshooting.md
@@ -114,9 +114,20 @@ The safest way is almost always:
 
 ```bash
 madmail reload
+# Windows: Restart-Service Madmail  (or madmail … reload then restart if needed)
 ```
 
 If that doesn’t pick up the change, a full restart is the next step.
+
+## Windows-Specific Issues
+
+| Symptom | Likely cause | What to try |
+|---------|----------------|-------------|
+| SmartScreen / Defender flags setup | Unsigned CI/Release PE (false positive) | [Defender / UAC guide](../../../packaging/windows/README.md#windows-defender-smartscreen-and-uac) |
+| Service missing after setup | Install stopped early (e.g. Let's Encrypt) | Read `%ProgramData%\Madmail\install.log`; finish with self-signed or fix TCP 80 |
+| LE HTTP-01 Invalid | Firewall / reachability (port free ≠ LE can connect) | Open inbound **TCP 80** host + cloud; re-test from the internet |
+| `/admin` blank or 404 | SPA not embedded / not enabled | Use CLI + token; see [Admin & CLI](./07-admin-and-cli.md) |
+| Custom HTML not showing | `www_dir` not set or service not restarted | [Customizing HTML](./17-customizing-html-pages.md#windows) |
 
 ## Getting More Information
 
@@ -125,10 +136,20 @@ When something is really not working, these commands are your friends:
 ```bash
 madmail status                 # basic health
 madmail logs                   # if your system uses journalctl or similar
-sqlite3 /var/lib/maddy/chatmail.db "SELECT * FROM settings;"
+sqlite3 /var/lib/madmail/chatmail.db "SELECT * FROM settings;"   # Linux default path
 ```
 
-Also check the admin web interface **Status** page — it often shows exactly which ports are actually listening.
+Windows:
+
+```powershell
+& "C:\Program Files\Madmail\madmail.exe" `
+  --config "$env:ProgramData\Madmail\config\madmail.conf" `
+  --state-dir "$env:ProgramData\Madmail\data" status
+Get-Content "$env:ProgramData\Madmail\install.log" -ErrorAction SilentlyContinue
+Get-Service Madmail
+```
+
+Also check the admin web interface **Status** page when the SPA is available — it often shows which ports are listening.
 
 ## When in Doubt
 

--- a/docs/project/user-guide/12-advanced-deployment.md
+++ b/docs/project/user-guide/12-advanced-deployment.md
@@ -6,8 +6,9 @@ This page indexes advanced operator topics. Each has its own guide.
 |-------|-------|
 | Endpoint rewrite (push-push / domain redirection) | [15-endpoint-rewrite.md](./15-endpoint-rewrite.md) |
 | Exchangers (push-pull, pull-pull intermediaries) | [16-exchangers.md](./16-exchangers.md) |
-| Customizing public HTML pages and web UI | [17-customizing-html-pages.md](./17-customizing-html-pages.md) |
+| Customizing public HTML pages and web UI (Linux + Windows) | [17-customizing-html-pages.md](./17-customizing-html-pages.md) |
 | DNS, SPF, DKIM, DMARC, federation reachability | [12-dns-mail-auth.md](./12-dns-mail-auth.md) |
+| Windows installer, service, tray, Defender/UAC | [packaging/windows/README.md](../../../packaging/windows/README.md) |
 | Stealth / Shadowsocks | [What is Chatmail?](./01-what-is-chatmail.md) (Shadowsocks feature) and [Admin & CLI](./07-admin-and-cli.md) |
 
 For standard public relays, start with [Quick Start](./02-quick-start.md) and [DNS and Mail Authentication](./12-dns-mail-auth.md).

--- a/docs/project/user-guide/17-customizing-html-pages.md
+++ b/docs/project/user-guide/17-customizing-html-pages.md
@@ -22,42 +22,88 @@ This means you only need to provide the files you want to change — everything 
 
 ### Setting a Custom WWW Directory
 
-Add the following to your configuration file:
+**Linux** — add to the config (path example):
 
 ```toml
-www_dir = "/var/lib/maddy/www"
+www_dir = "/var/lib/madmail/www"
 ```
 
 Or use the CLI:
 
 ```bash
-madmail html-serve /var/lib/maddy/www
+# Linux
+sudo madmail html-serve /var/lib/madmail/www
+
+# Windows (elevated PowerShell; ProgramData layout)
+& "C:\Program Files\Madmail\madmail.exe" `
+  --config "$env:ProgramData\Madmail\config\madmail.conf" `
+  --state-dir "$env:ProgramData\Madmail\data" `
+  html-serve "$env:ProgramData\Madmail\www"
 ```
 
 To go back to the built-in (embedded) files:
 
 ```bash
 madmail html-serve embedded
+# Windows: same command with --config / --state-dir as above
 ```
 
-Then reload the server:
+Then apply the config:
 
 ```bash
-madmail reload
+# Linux
+sudo madmail reload
+# or: sudo systemctl reload madmail / restart madmail
+
+# Windows
+Restart-Service Madmail
+# or: madmail … reload  (then restart service if routes did not remount)
 ```
 
-Make sure the directory is readable by the user the `madmail` service runs as (usually the `madmail` system user).
+Make sure the directory is readable by the account the service runs as:
+
+| Platform | Typical service account | Notes |
+|----------|-------------------------|--------|
+| Linux | `madmail` system user | `chown` / permissions on `www_dir` |
+| Windows | **LocalSystem** (default SCM service) | Paths under `%ProgramData%\Madmail\` are fine; if you put `www` elsewhere, grant **Read** + traverse |
 
 ## Getting Started with Customization
 
-A typical starting workflow is:
+### Linux
 
-1. Create your `www_dir` (for example `/var/lib/maddy/www`).
-2. Copy the default files you want to customize from the server's built-in assets.
-3. Edit the copied files.
-4. Reload the server and test.
+1. Create a directory (e.g. `/var/lib/madmail/www`).
+2. Export defaults: `sudo madmail html-export /var/lib/madmail/www`
+3. Edit the files you care about.
+4. `sudo madmail html-serve /var/lib/madmail/www` then `sudo madmail reload` (or restart the unit).
 
-Many operators start by copying the entire default web tree and then gradually replacing individual files as needed.
+### Windows
+
+1. Create `%ProgramData%\Madmail\www` (or another path LocalSystem can read).
+2. Export defaults (elevated):
+
+```powershell
+$cfg = "$env:ProgramData\Madmail\config\madmail.conf"
+$st  = "$env:ProgramData\Madmail\data"
+$www = "$env:ProgramData\Madmail\www"
+New-Item -ItemType Directory -Force -Path $www | Out-Null
+& "C:\Program Files\Madmail\madmail.exe" --config $cfg --state-dir $st html-export $www
+& "C:\Program Files\Madmail\madmail.exe" --config $cfg --state-dir $st html-serve $www
+Restart-Service Madmail
+```
+
+3. Edit files under `$www`, hard-refresh the browser (Ctrl+Shift+R).
+4. Revert: `html-serve embedded` + restart the service.
+
+Many operators export the **entire** default tree once, then replace individual files over time. Missing files still fall back to the embedded defaults.
+
+### Suggested Windows layout
+
+```text
+%ProgramData%\Madmail\
+  config\madmail.conf     ← www_dir set by html-serve
+  www\                    ← editable HTML/CSS/JS
+  data\                   ← mail DB, admin_token (do not put secrets in www\)
+```
 
 ## What You Can Customize
 
@@ -92,15 +138,9 @@ This built-in guide matches the running server version and lists which files you
 
 ## Updating After Changes
 
-In most cases you only need to run:
+After **content** edits under an existing `www_dir`, the server re-reads HTML from disk; a full restart is rarely required. After **`html-serve`** (changing the path or switching to `embedded`), run **`madmail reload`** and/or restart the service (`systemctl restart madmail` / `Restart-Service Madmail`).
 
-```bash
-madmail reload
-```
-
-after changing files in your `www_dir`. A full restart is rarely required for HTML changes.
-
-Users may need to do a hard refresh (Ctrl+Shift+R or Cmd+Shift+R) in their browser to see updated static assets.
+Users may need a hard refresh (Ctrl+Shift+R or Cmd+Shift+R) in the browser to see updated static assets.
 
 ## Go Madmail → madmail-v2 (template syntax)
 

--- a/docs/what-is-missing.md
+++ b/docs/what-is-missing.md
@@ -81,7 +81,7 @@ Madmail parity for operator-owned www trees (`ctl/html.go`):
 
 **Default site (no `www_dir`):** HTML templates and all static files are served from **embedded RAM** in the binary (`rust_embed`) — preloaded at startup, no disk I/O.
 
-**Operator override:** `html-export` → edit files → `html-serve /path/to/www` → `systemctl restart madmail` (once, to set `www_dir`). After that, files are read from disk on each request (live reload; `Cache-Control: no-cache`). `html-serve embedded` clears `www_dir` and restores the RAM default.
+**Operator override:** `html-export` → edit files → `html-serve /path/to/www` → restart/reload once (Linux: `systemctl restart madmail`; Windows: `Restart-Service Madmail`) to set `www_dir`. After that, files are read from disk on each request (live reload; `Cache-Control: no-cache`). `html-serve embedded` clears `www_dir` and restores the RAM default. Windows paths: see [17-customizing-html-pages.md](project/user-guide/17-customizing-html-pages.md#windows).
 
 **Manually verified:** export count, config `www_dir`, journal line `www: serving HTML from external directory`, custom homepage + static file over HTTP/HTTPS, revert to embedded.
 

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -136,6 +136,7 @@ Until arm64 CI runners or cargo-xwin are available, **compile-only** checks and 
 | Tray | `C:\Program Files\Madmail\madmail-tray.exe` |
 | Config | `%ProgramData%\Madmail\config\` |
 | State | `%ProgramData%\Madmail\data\` |
+| Custom public HTML (optional) | `%ProgramData%\Madmail\www\` (`www_dir` via `html-serve`) |
 | Service | `Madmail` |
 
 ## Related CLI
@@ -145,10 +146,18 @@ madmail install --simple --ip … --install-service --start-service --firewall
 madmail service install|start|stop|status
 madmail firewall apply|remove
 madmail admin-token
+madmail html-export %ProgramData%\Madmail\www
+madmail html-serve %ProgramData%\Madmail\www
 madmail-tray --smoke-exit
 madmail-tray status | token
 madmail-tray install-autostart
 ```
+
+### Custom public HTML pages
+
+Same as Linux: `www_dir` + `html-export` / `html-serve`. On Windows, put the tree under ProgramData (LocalSystem can read it), then restart the service.
+
+Full steps: [Customizing HTML pages](../../docs/project/user-guide/17-customizing-html-pages.md#windows).
 
 ### Admin API vs admin web UI
 


### PR DESCRIPTION
## Summary

Operator docs catch-up after the Windows installer landed on `main` (epic #103).

Documents how to customize public HTML on **Windows** (`html-export` / `html-serve` under `%ProgramData%\Madmail\www`), clarifies that the admin SPA is often not embedded in Windows packages, and fills related install / LE / troubleshooting / packaging cross-links.

Related: #103

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [x] Documentation only
- [ ] Build / CI / tooling
- [ ] Refactor (no functional change)

## Area

- [ ] SMTP
- [ ] IMAP
- [ ] Federation / delivery queue
- [ ] Authentication / JIT
- [ ] Admin API / admin web UI (`external/madmail-admin-web`)
- [ ] TURN / Iroh / proxy services
- [ ] Storage / quota / DB migrations
- [ ] Configuration / CLI
- [x] Docs (`docs/project/`, `docs/TDD/`, user guide)
- [x] Other: Windows packaging README cross-links

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace` (or targeted crate/tests: <!-- list if subset -->)
- [x] Manual / E2E verification (describe below)

**Manual verification (if any):**

```text
Doc review only — markdown updates, no code changes.
Checked internal links and Windows ProgramData / CLI examples for consistency
with packaging/windows/README.md and current install/service layout.
```

## Documentation

- [ ] No doc updates needed
- [x] Updated operator/user docs (`docs/project/user-guide/`, install guides)
- [x] Updated developer docs (`docs/project/`)
- [ ] Updated or added TDD section (`docs/TDD/`) — required for significant design changes

Also updated:

- `docs/guide/cli/{html-export,html-serve,html-migrate,install}.md`
- `docs/guide/install.md`, `docs/install-simple-ip-acme.md`
- `docs/what-is-missing.md`
- `packaging/windows/README.md` (www layout + html-export/serve)

## Security & privacy

- [x] Not security-sensitive
- [ ] Security-sensitive — added/updated tests for the security property
- [ ] Reviewed error messages for information leakage

## Commits

- `docs:` documentation

## Checklist

- [x] PR is focused and reviewable (small vertical slices preferred)
- [x] No secrets, `data/`, `target/`, or `node_modules/` committed
- [x] Submodule pointers updated if `external/madmail-admin-web` changed
- [x] Behavior parity with Madmail v1 considered (or intentional difference documented)