### PR TITLE
fix(windows): TURN media firewall ports + installer option

### DIFF
--- a/crates/chatmail-config/src/cli.rs
+++ b/crates/chatmail-config/src/cli.rs
@@ -673,7 +673,7 @@ pub const FIREWALL_RULE_PREFIX: &str = "Madmail";
 pub enum FirewallCommand {
     /// Create named inbound allow rules for mail/HTTP ports.
     Apply {
-        /// Also open TURN (UDP/TCP 3478).
+        /// Also open TURN: UDP/TCP 3478 (control) and UDP 49152–65535 (media relay).
         #[arg(long)]
         turn: bool,
         /// Also open Shadowsocks (TCP 8388).

--- a/crates/chatmail-config/src/install_cli.rs
+++ b/crates/chatmail-config/src/install_cli.rs
@@ -74,6 +74,11 @@ pub struct InstallArgs {
     #[arg(long)]
     pub enable_iroh: bool,
 
+    /// Disable embedded TURN for Delta Chat audio/video calls (default: TURN is enabled).
+    /// When set, install omits TURN from config and Windows firewall skips TURN ports.
+    #[arg(long = "no-turn")]
+    pub no_turn: bool,
+
     #[arg(long)]
     pub turn_off_tls: bool,
 

--- a/crates/chatmail/src/ctl/firewall_cmd.rs
+++ b/crates/chatmail/src/ctl/firewall_cmd.rs
@@ -15,8 +15,9 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-//! `madmail firewall` — Windows Firewall inbound rules for mail/HTTP listeners.
+//! `madmail firewall` — Windows Firewall inbound rules for mail/HTTP/TURN listeners.
 
+use chatmail_config::turn_relay_ports::{DEFAULT_TURN_RELAY_PORT_MAX, DEFAULT_TURN_RELAY_PORT_MIN};
 use chatmail_config::{Args, FirewallCommand, FIREWALL_RULE_PREFIX};
 use chatmail_types::{ChatmailError, Result};
 
@@ -33,6 +34,9 @@ const CORE_RULES: &[(&str, &str, u16)] = &[
     ("HTTPS", "TCP", 443),
 ];
 
+/// Default TURN control plane (matches install `turn_port` / IMAP METADATA).
+const DEFAULT_TURN_CONTROL_PORT: u16 = 3478;
+
 pub async fn firewall(args: &Args, cmd: &FirewallCommand) -> Result<()> {
     match cmd {
         FirewallCommand::Apply { turn, ss, iroh } => apply(args, *turn, *ss, *iroh),
@@ -47,36 +51,45 @@ pub async fn firewall(args: &Args, cmd: &FirewallCommand) -> Result<()> {
 #[cfg(windows)]
 pub fn ensure_http01_inbound() -> Result<()> {
     // Same display name as full apply — idempotent via delete+add in add_rule.
-    add_rule(&rule_name("HTTP"), "TCP", 80)?;
+    add_rule(&rule_name("HTTP"), "TCP", "80")?;
     Ok(())
 }
 
 /// Open standard Madmail ports (and optional TURN / SS / Iroh).
+///
+/// When `turn` is set, opens TURN **control** (UDP/TCP 3478) and the default
+/// **media relay** UDP range (49152–65535). Control alone is not enough for
+/// Delta Chat audio/video once ICE uses relayed candidates.
 pub fn apply_rules(turn: bool, ss: bool, iroh: bool) -> Result<Vec<String>> {
     require_windows()?;
     let mut names = Vec::new();
     for (label, proto, port) in CORE_RULES {
         let name = rule_name(label);
-        add_rule(&name, proto, *port)?;
+        add_rule(&name, proto, &port.to_string())?;
         names.push(name);
     }
     if turn {
         let name = rule_name("TURN");
-        add_rule(&name, "UDP", 3478)?;
-        names.push(name.clone());
+        add_rule(&name, "UDP", &DEFAULT_TURN_CONTROL_PORT.to_string())?;
+        names.push(name);
         // TCP TURN as well (config often binds both).
         let name_tcp = rule_name("TURN-TCP");
-        add_rule(&name_tcp, "TCP", 3478)?;
+        add_rule(&name_tcp, "TCP", &DEFAULT_TURN_CONTROL_PORT.to_string())?;
         names.push(name_tcp);
+        // Media relay allocations (RFC 8656 dynamic range / madmail defaults).
+        let name_relay = rule_name("TURN-relay");
+        let range = format!("{DEFAULT_TURN_RELAY_PORT_MIN}-{DEFAULT_TURN_RELAY_PORT_MAX}");
+        add_rule(&name_relay, "UDP", &range)?;
+        names.push(name_relay);
     }
     if ss {
         let name = rule_name("Shadowsocks");
-        add_rule(&name, "TCP", 8388)?;
+        add_rule(&name, "TCP", "8388")?;
         names.push(name);
     }
     if iroh {
         let name = rule_name("Iroh");
-        add_rule(&name, "TCP", 3340)?;
+        add_rule(&name, "TCP", "3340")?;
         names.push(name);
     }
     Ok(names)
@@ -144,8 +157,9 @@ fn require_windows() -> Result<()> {
     }
 }
 
+/// `port_spec` is a single port (`"3478"`) or inclusive range (`"49152-65535"`).
 #[cfg(windows)]
-fn add_rule(name: &str, protocol: &str, port: u16) -> Result<()> {
+fn add_rule(name: &str, protocol: &str, port_spec: &str) -> Result<()> {
     use std::process::Command;
     // Idempotent: delete existing same-name rule first.
     let _ = delete_rule(name);
@@ -159,7 +173,7 @@ fn add_rule(name: &str, protocol: &str, port: u16) -> Result<()> {
             "dir=in",
             "action=allow",
             &format!("protocol={protocol}"),
-            &format!("localport={port}"),
+            &format!("localport={port_spec}"),
             "profile=any",
             "enable=yes",
         ])
@@ -175,7 +189,7 @@ fn add_rule(name: &str, protocol: &str, port: u16) -> Result<()> {
 }
 
 #[cfg(not(windows))]
-fn add_rule(_name: &str, _protocol: &str, _port: u16) -> Result<()> {
+fn add_rule(_name: &str, _protocol: &str, _port_spec: &str) -> Result<()> {
     require_windows()
 }
 
@@ -254,6 +268,13 @@ mod tests {
         for p in [25u16, 143, 587, 465, 993, 80, 443] {
             assert!(ports.contains(&p), "missing port {p}");
         }
+    }
+
+    #[test]
+    fn turn_defaults_match_docs() {
+        assert_eq!(DEFAULT_TURN_CONTROL_PORT, 3478);
+        assert_eq!(DEFAULT_TURN_RELAY_PORT_MIN, 49152);
+        assert_eq!(DEFAULT_TURN_RELAY_PORT_MAX, 65535);
     }
 
     #[tokio::test]

--- a/crates/chatmail/src/ctl/install/mod.rs
+++ b/crates/chatmail/src/ctl/install/mod.rs
@@ -665,7 +665,8 @@ impl InstallConfig {
         };
 
         let enable_ss = args.enable_ss || args.simple;
-        let enable_turn = true;
+        // TURN defaults on (Delta Chat calls); `--no-turn` opts out (installer checkbox).
+        let enable_turn = !args.no_turn;
         let language = validate_language_code(&args.lang)?;
         let enable_chatmail = args.enable_chatmail || args.simple || args.domain.is_some();
 
@@ -831,6 +832,7 @@ mod tests {
             enable_chatmail: false,
             enable_ss: false,
             enable_iroh: false,
+            no_turn: false,
             turn_off_tls: false,
             dry_run: false,
             skip_systemd: false,
@@ -933,6 +935,7 @@ mod tests {
             enable_chatmail: false,
             enable_ss: false,
             enable_iroh: false,
+            no_turn: false,
             turn_off_tls: false,
             dry_run: false,
             skip_systemd: false,
@@ -984,6 +987,7 @@ mod tests {
             enable_chatmail: false,
             enable_ss: false,
             enable_iroh: false,
+            no_turn: false,
             turn_off_tls: false,
             dry_run: false,
             skip_systemd: false,
@@ -1040,6 +1044,7 @@ mod tests {
             enable_chatmail: false,
             enable_ss: false,
             enable_iroh: false,
+            no_turn: false,
             turn_off_tls: false,
             dry_run: false,
             skip_systemd: false,
@@ -1087,6 +1092,7 @@ mod tests {
                 enable_chatmail: false,
                 enable_ss: false,
                 enable_iroh: false,
+                no_turn: false,
                 turn_off_tls: false,
                 dry_run: false,
                 skip_systemd: false,
@@ -1132,6 +1138,7 @@ mod tests {
             enable_chatmail: false,
             enable_ss: false,
             enable_iroh: false,
+            no_turn: false,
             turn_off_tls: false,
             dry_run: false,
             skip_systemd: false,
@@ -1185,6 +1192,7 @@ mod tests {
                 enable_chatmail: false,
                 enable_ss: false,
                 enable_iroh: false,
+                no_turn: false,
                 turn_off_tls: false,
                 dry_run: false,
                 skip_systemd: false,
@@ -1224,6 +1232,7 @@ mod tests {
                 enable_chatmail: false,
                 enable_ss: false,
                 enable_iroh: false,
+                no_turn: false,
                 turn_off_tls: false,
                 dry_run: false,
                 skip_systemd: false,
@@ -1271,6 +1280,7 @@ mod tests {
                 enable_chatmail: false,
                 enable_ss: false,
                 enable_iroh: false,
+                no_turn: false,
                 turn_off_tls: false,
                 dry_run: false,
                 skip_systemd: false,
@@ -1288,6 +1298,54 @@ mod tests {
             }
         };
         assert!(InstallConfig::from_args(&global, &args).is_err());
+    }
+
+    #[test]
+    fn no_turn_disables_turn_in_install_config() {
+        let global = Args {
+            config: PathBuf::from("/etc/madmail/madmail.conf"),
+            state_dir: PathBuf::from("./data"),
+            boot_once: false,
+            json: false,
+        };
+        let args = InstallArgs {
+            no_turn: true,
+            ..InstallArgs {
+                non_interactive: false,
+                simple: true,
+                domain: None,
+                hostname: None,
+                ip: Some(EXAMPLE_PUBLIC_IP.into()),
+                config_dir: None,
+                state_dir: None,
+                tls_mode: None,
+                cert_path: None,
+                key_path: None,
+                acme_email: None,
+                enable_chatmail: false,
+                enable_ss: false,
+                enable_iroh: false,
+                no_turn: false,
+                turn_off_tls: false,
+                dry_run: false,
+                skip_systemd: false,
+                skip_user: false,
+                install_service: false,
+                start_service: false,
+                firewall: false,
+                binary_path: None,
+                obtain_certificate: false,
+                no_obtain_certificate: true,
+                cert_only: false,
+                http_listen: "0.0.0.0:80".into(),
+                auto_ip_cert: false,
+                lang: "en".into(),
+            }
+        };
+        let cfg = InstallConfig::from_args(&global, &args).unwrap();
+        assert!(!cfg.enable_turn);
+        let conf = render_maddy_conf(&cfg);
+        assert!(!conf.contains("turn_enable yes"), "{conf}");
     }
 
     #[test]
@@ -1313,6 +1371,7 @@ mod tests {
             enable_chatmail: false,
             enable_ss: false,
             enable_iroh: true,
+            no_turn: false,
             turn_off_tls: false,
             dry_run: false,
             skip_systemd: false,

--- a/docs/guide/cli/install.md
+++ b/docs/guide/cli/install.md
@@ -58,7 +58,8 @@ On **Windows**, default install paths are `%ProgramData%\Madmail\config` and `%P
 | `--config-dir`, `--state-dir` | Override FHS / ProgramData paths |
 | `--install-service` | Register Windows service after install (no-op notice on Unix) |
 | `--start-service` | Start Windows service after install |
-| `--firewall` | Open Windows Firewall rules for mail/HTTP ports |
+| `--firewall` | Open Windows Firewall rules for mail/HTTP (+ TURN when enabled) |
+| `--no-turn` | Disable embedded TURN (Delta Chat audio/video); default is TURN **on** |
 | `--tls-mode` | `autocert`, `file`, or `self_signed` |
 | `--acme-email`, `--auto-ip-cert`, `--obtain-certificate`, `--no-obtain-certificate`, `--cert-only`, `--http-listen` | TLS issuance |
 | `--lang` | UI language: `en`, `fa`, `ru`, `es` |

--- a/packaging/windows/MANUAL-CHECKLIST.md
+++ b/packaging/windows/MANUAL-CHECKLIST.md
@@ -15,7 +15,8 @@ CI: merges to **`main`** run lint/smoke/arm64; published **GitHub Releases** run
 - [ ] **Local self-signed:** setup wizard or  
   `madmail install --simple --ip 127.0.0.1 --tls-mode self_signed --install-service --start-service --firewall`
 - [ ] Service shows **Running** (`madmail service status` / Services MMC)
-- [ ] Firewall rules present (`Madmail (*)` in Windows Firewall)
+- [ ] Firewall rules present (`Madmail (*)` in Windows Firewall), including **TURN** (UDP/TCP 3478) and **TURN-relay** (UDP 49152–65535) when TURN is enabled
+- [ ] Delta Chat audio/video can connect (same LAN or WAN) when TURN is enabled
 - [ ] `madmail-tray --smoke-exit` exits 0; tray start/stop service and “copy admin token” work
 - [ ] Admin token file under `%ProgramData%\Madmail\data\admin_token` (use CLI / `POST /api/admin` — Windows builds do not embed the admin-web SPA)
 - [ ] Service install does **not** fail with sc exit **1639** (uses Win32 CreateService, not quoted `sc start=`)

--- a/packaging/windows/Madmail.iss
+++ b/packaging/windows/Madmail.iss
@@ -219,6 +219,9 @@ begin
 
   if FeaturePage.Values[0] then
     Args := Args + ' --enable-ss';
+  { TURN default on in install; pass --no-turn when operator disables calls. }
+  if not FeaturePage.Values[1] then
+    Args := Args + ' --no-turn';
   { Iroh omitted: Windows builds do not ship iroh-relay.exe yet; enabling it makes
     the service fail at boot with "iroh-relay: program not found". Re-add when packaged. }
 
@@ -384,10 +387,13 @@ begin
 
   FeaturePage := CreateInputOptionPage(LangPage.ID,
     'Optional features', 'Enable additional services in the generated config',
+    'TURN is required for reliable Delta Chat audio/video when P2P fails. ' +
     'You can change these later via config / CLI.',
     False, False);
   FeaturePage.Add('Shadowsocks proxy');
+  FeaturePage.Add('TURN for Delta Chat audio/video calls (UDP 3478 + media ports)');
   FeaturePage.Values[0] := True;
+  FeaturePage.Values[1] := True;
 
   DnsPage := CreateOutputMsgPage(wpSelectTasks,
     'DNS checklist', 'Domain deployment reminders',

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -44,7 +44,7 @@ iscc /DArch=arm64 packaging\windows\Madmail.iss
 3. **Identity** — IP or hostname  
 4. **TLS** — self-signed or Let's Encrypt  
 5. ACME email (if LE)  
-6. Language + optional Shadowsocks (Iroh omitted until `iroh-relay.exe` is packaged)  
+6. Language + optional Shadowsocks / TURN for calls (Iroh omitted until `iroh-relay.exe` is packaged)  
 7. Install directory + tasks (firewall, start service, tray autostart)  
 8. DNS checklist (domain mode)  
 9. Post-install: `madmail install … --install-service [--start-service] [--firewall]`  
@@ -173,8 +173,17 @@ Do not open `/api/admin` in a browser (GET → **405**).
 ### Installer options (wizard)
 
 - **Shadowsocks** — optional (default on).
+- **TURN** (Delta Chat audio/video) — optional (default **on**). Opens UDP/TCP **3478** and UDP **49152–65535** when the firewall task is selected. Uncheck and pass CLI `--no-turn` to disable call relay.
 - **Iroh** — **not** offered (no `iroh-relay.exe` on Windows yet; enabling it breaks service boot).
 - Prefer **self-signed** in the lab if port **80** / ACME is not ready; **Let's Encrypt** (public IP or domain) needs inbound TCP 80 during install.
+
+After install, verify TURN firewall rules if calls fail:
+
+```powershell
+Get-NetFirewallRule -DisplayName "Madmail*TURN*" | Format-Table DisplayName, Enabled
+# Manual repair (elevated), if needed:
+# madmail firewall apply --turn
+```
 
 ## CI
 


### PR DESCRIPTION
## Summary

Fixes Delta Chat **audio/video** failures on Windows installer builds (#116) and adds a wizard option to enable/disable TURN.

### Root cause
`madmail firewall apply --turn` (and install `--firewall` when TURN is on) only opened **UDP/TCP 3478**. Call media uses the default TURN **relay UDP range 49152–65535**, which stayed blocked by Windows Firewall. Text/attachments (IMAP/SMTP) were unaffected — matching the report vs Linux.

### Changes
- Open **Madmail (TURN-relay)** UDP `49152-65535` when TURN firewall rules are applied
- Install: **`--no-turn`** disables TURN in generated config and skips TURN firewall ports (default remains TURN on)
- Inno optional features: **TURN for Delta Chat audio/video** (default checked); unchecked → `--no-turn`
- Docs: packaging README, install CLI flags, manual checklist

### Workaround (until this ships)
```powershell
netsh advfirewall firewall add rule name="Madmail (TURN-relay)" dir=in action=allow protocol=UDP localport=49152-65535 profile=any
```

Fixes #116

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Build / CI / tooling
- [ ] Refactor (no functional change)

## Area

- [ ] SMTP
- [ ] IMAP
- [ ] Federation / delivery queue
- [ ] Authentication / JIT
- [ ] Admin API / admin web UI (`external/madmail-admin-web`)
- [x] TURN / Iroh / proxy services
- [ ] Storage / quota / DB migrations
- [x] Configuration / CLI
- [x] Docs (`docs/project/`, `docs/TDD/`, user guide)
- [x] Other: Windows packaging / firewall

## Testing

- [x] `cargo fmt --all -- --check` (via `make lint`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (or targeted crate/tests: install + firewall_cmd + chatmail-config lib + tray + service_cmd)
- [ ] Manual / E2E verification (describe below)

**Manual verification (if any):**

```text
Linux: make lint; unit tests for install (incl. no_turn), firewall_cmd, chatmail-config.
Windows host A/V call after reinstall not run in this environment.
Recommend: Win10/Server 2022 install with firewall + TURN checked, then Delta Chat call on LAN.
```

## Documentation

- [ ] No doc updates needed
- [x] Updated operator/user docs (`docs/project/user-guide/`, install guides)
- [ ] Updated developer docs (`docs/project/`)
- [ ] Updated or added TDD section (`docs/TDD/`) — required for significant design changes

Also: `packaging/windows/README.md`, `MANUAL-CHECKLIST.md`, `docs/guide/cli/install.md`.

## Security & privacy

- [x] Not security-sensitive
- [ ] Security-sensitive — added/updated tests for the security property
- [ ] Reviewed error messages for information leakage

Opens additional UDP ports when TURN is enabled (required for calls).

## Commits

- `fix:` bug fix + feature

## Checklist

- [x] PR is focused and reviewable (small vertical slices preferred)
- [x] No secrets, `data/`, `target/`, or `node_modules/` committed
- [x] Submodule pointers updated if `external/madmail-admin-web` changed
- [x] Behavior parity with Madmail v1 considered (or intentional difference documented)