### PR TITLE
fix(cli): preflight and rollback madmail update on ABI mismatch

### DIFF
--- a/crates/chatmail/src/upgrade.rs
+++ b/crates/chatmail/src/upgrade.rs
@@ -815,7 +815,9 @@ pub fn perform_upgrade(new_bin_path: &Path, args: &Args) -> Result<()> {
         // Live binary should still be the old one if rename failed; try to keep services up.
         eprintln!("▶️ Starting services after failed replace...");
         let _ = systemctl_succeeded(&["start", &service]);
-        return Err(ChatmailError::config(format!("failed to replace binary: {e}")));
+        return Err(ChatmailError::config(format!(
+            "failed to replace binary: {e}"
+        )));
     }
 
     // Belt-and-suspenders: re-smoke the installed path (catches corrupt write).

--- a/crates/chatmail/src/upgrade.rs
+++ b/crates/chatmail/src/upgrade.rs
@@ -467,6 +467,7 @@ fn download_url_response(
 /// `perform_upgrade` directly).
 fn handle_update_url(url: &str, args: &Args, accept_unsafe_https: bool) -> Result<()> {
     check_supported_url_archive(url)?;
+    warn_if_default_linux_asset(url);
 
     let (download_path, mut tmp_file) = create_private_temp_file("madmail-update")?;
 
@@ -563,7 +564,196 @@ fn run_systemctl(args: &[&str]) {
     let _ = Command::new("systemctl").args(args).status();
 }
 
-/// Upgrade in place: verify signature, stop service, replace executable, start service.
+fn systemctl_succeeded(args: &[&str]) -> bool {
+    Command::new("systemctl")
+        .args(args)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Sibling backup path for the live binary (`/usr/local/bin/madmail` → `…/madmail.prev`).
+fn backup_path_for(current: &Path) -> PathBuf {
+    let mut name = current.as_os_str().to_owned();
+    name.push(".prev");
+    PathBuf::from(name)
+}
+
+/// Hint shown when a binary fails to run (wrong release variant / older glibc).
+const VARIANT_HINT: &str = "\
+If you see GLIBC_*. not found (or the loader refuses to start the binary), this host needs a \
+different release asset than the default glibc build:\n\
+  • madmail-linux-amd64-legacy.tar.gz  — older distros (e.g. Ubuntu 22.04)\n\
+  • madmail-linux-amd64-musl.tar.gz    — static-ish musl alternative\n\
+  • …-arm64-legacy / …-arm64-musl     — same for arm64\n\
+Download from https://github.com/themadorg/madmail/releases and re-run update with that URL.";
+
+/// Soft warning when the download URL looks like a default (non-legacy, non-musl) Linux asset.
+fn warn_if_default_linux_asset(url: &str) {
+    let path = url_path(url).to_ascii_lowercase();
+    if !path.contains("madmail-linux-") {
+        return;
+    }
+    if path.contains("-legacy") || path.contains("-musl") {
+        return;
+    }
+    if !(path.contains("amd64") || path.contains("arm64") || path.contains("aarch64")) {
+        return;
+    }
+    eprintln!(
+        "ℹ️ Default Linux build selected. Hosts with older system glibc need a *-legacy \
+         (or *-musl) asset from GitHub Releases. A host preflight runs before the live \
+         binary is replaced; an incompatible build aborts the upgrade safely."
+    );
+}
+
+/// Ensure the candidate binary can actually execute on this host (`madmail version`).
+///
+/// Catches wrong-variant installs (default glibc build on older distros) **before**
+/// services are stopped or the live binary is replaced. Signature verification must
+/// already have passed — we only exec trusted, signed bytes.
+fn preflight_new_binary(new_bin: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        // Owner rwx so we can exec a temp extract (mode may still be 0600).
+        fs::set_permissions(new_bin, fs::Permissions::from_mode(0o700)).map_err(|e| {
+            ChatmailError::config(format!(
+                "failed to set executable bit on {}: {e}",
+                new_bin.display()
+            ))
+        })?;
+    }
+
+    eprintln!("🧪 Preflight: running new binary (`version`) on this host...");
+
+    let output = match Command::new(new_bin).arg("version").output() {
+        Ok(o) => o,
+        Err(e) => {
+            return Err(ChatmailError::config(format!(
+                "new binary failed to execute (loader/ABI incompatibility?): {e}\n\
+                 The live binary was NOT replaced.\n{VARIANT_HINT}"
+            )));
+        }
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let detail = if !stderr.trim().is_empty() {
+            stderr.trim().to_string()
+        } else if !stdout.trim().is_empty() {
+            stdout.trim().to_string()
+        } else {
+            format!("exit status {}", output.status)
+        };
+        return Err(ChatmailError::config(format!(
+            "new binary failed host preflight (`madmail version`):\n{detail}\n\n\
+             The live binary was NOT replaced.\n{VARIANT_HINT}"
+        )));
+    }
+
+    let ver = String::from_utf8_lossy(&output.stdout);
+    let first = ver
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .unwrap_or("ok");
+    eprintln!("✅ Preflight OK ({first})");
+    Ok(())
+}
+
+/// Copy the live binary to `*.prev` so a failed upgrade can be rolled back.
+fn backup_current_binary(current: &Path) -> Result<PathBuf> {
+    let backup = backup_path_for(current);
+    eprintln!("💾 Backing up current binary to {}...", backup.display());
+    fs::copy(current, &backup).map_err(|e| {
+        ChatmailError::config(format!(
+            "failed to back up current binary to {}: {e}",
+            backup.display()
+        ))
+    })?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        // Prefer the live mode; fall back to 0755 so the backup stays runnable.
+        let mode = fs::metadata(current)
+            .ok()
+            .map(|m| m.permissions().mode())
+            .unwrap_or(0o755);
+        let _ = fs::set_permissions(&backup, fs::Permissions::from_mode(mode));
+    }
+    Ok(backup)
+}
+
+/// Restore `backup` over `current` (used when the new binary fails smoke/start).
+fn restore_backup(backup: &Path, current: &Path) -> Result<()> {
+    eprintln!(
+        "↩️ Restoring previous binary from {} → {}...",
+        backup.display(),
+        current.display()
+    );
+    // Write via a temp sibling then rename so a partial copy cannot leave a
+    // half-written executable at the install path.
+    let parent = current
+        .parent()
+        .ok_or_else(|| ChatmailError::config("executable has no parent directory"))?;
+    let tmp = parent.join(format!(".chatmail-rollback-{}", std::process::id()));
+    fs::copy(backup, &tmp).map_err(|e| {
+        ChatmailError::config(format!(
+            "failed to stage rollback binary from {}: {e}",
+            backup.display()
+        ))
+    })?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&tmp, fs::Permissions::from_mode(0o755))?;
+    }
+    fs::rename(&tmp, current).map_err(|e| {
+        let _ = fs::remove_file(&tmp);
+        ChatmailError::config(format!(
+            "failed to restore previous binary to {}: {e}",
+            current.display()
+        ))
+    })?;
+    Ok(())
+}
+
+/// After install: if the new binary cannot run, restore `backup` and restart services.
+fn rollback_on_broken_install(
+    real_bin_path: &Path,
+    backup: &Path,
+    service: &str,
+    reason: &str,
+) -> Result<()> {
+    eprintln!("⚠️ {reason}");
+    restore_backup(backup, real_bin_path)?;
+    eprintln!("▶️ Restarting services with the restored binary...");
+    if !systemctl_succeeded(&["start", service]) {
+        eprintln!(
+            "⚠️ Warning: failed to start {service} after rollback; try: systemctl start {service}"
+        );
+    }
+    let iroh_unit = PathBuf::from("/etc/systemd/system/iroh-relay.service");
+    if iroh_unit.is_file() && !systemctl_succeeded(&["start", "iroh-relay.service"]) {
+        eprintln!(
+            "⚠️ Warning: failed to start iroh-relay.service after rollback; try: systemctl start iroh-relay.service"
+        );
+    }
+    Err(ChatmailError::config(format!(
+        "upgrade rolled back: {reason}\n\
+         Previous binary restored from {}.\n{VARIANT_HINT}",
+        backup.display()
+    )))
+}
+
+/// Upgrade in place: verify signature, preflight, backup, stop service, replace, start.
+///
+/// Safety (issue #114):
+/// - Host preflight (`new_bin version`) runs **before** services stop / binary replace.
+/// - Live binary is copied to `*.prev` before replace.
+/// - If the installed binary fails a post-replace smoke check, restore `*.prev` and restart.
 pub fn perform_upgrade(new_bin_path: &Path, args: &Args) -> Result<()> {
     eprintln!("🔍 Verifying digital signature...");
     match verify_signature(new_bin_path)? {
@@ -574,6 +764,9 @@ pub fn perform_upgrade(new_bin_path: &Path, args: &Args) -> Result<()> {
             ));
         }
     }
+
+    // Abort early (services still up, live binary untouched) if this host cannot run it.
+    preflight_new_binary(new_bin_path)?;
 
     let current_bin = std::env::current_exe()
         .map_err(|e| ChatmailError::config(format!("failed to get current executable: {e}")))?;
@@ -587,6 +780,9 @@ pub fn perform_upgrade(new_bin_path: &Path, args: &Args) -> Result<()> {
             "upgrade must be run as root (sudo) to manage services and replace the binary",
         ));
     }
+
+    // Keep a runnable previous binary so a post-replace failure can recover in-band.
+    let backup = backup_current_binary(&real_bin_path)?;
 
     let service = systemd_service_name();
     eprintln!("⏹️ Stopping services...");
@@ -614,41 +810,77 @@ pub fn perform_upgrade(new_bin_path: &Path, args: &Args) -> Result<()> {
         fs::set_permissions(&tmp_path, fs::Permissions::from_mode(0o755))?;
     }
 
-    fs::rename(&tmp_path, &real_bin_path).map_err(|e| {
+    if let Err(e) = fs::rename(&tmp_path, &real_bin_path) {
         let _ = fs::remove_file(&tmp_path);
-        ChatmailError::config(format!("failed to replace binary: {e}"))
-    })?;
+        // Live binary should still be the old one if rename failed; try to keep services up.
+        eprintln!("▶️ Starting services after failed replace...");
+        let _ = systemctl_succeeded(&["start", &service]);
+        return Err(ChatmailError::config(format!("failed to replace binary: {e}")));
+    }
+
+    // Belt-and-suspenders: re-smoke the installed path (catches corrupt write).
+    if let Err(e) = preflight_new_binary(&real_bin_path) {
+        return rollback_on_broken_install(
+            &real_bin_path,
+            &backup,
+            &service,
+            &format!("installed binary failed smoke check: {e}"),
+        );
+    }
 
     // Run post-upgrade hooks from the *new* binary so first upgrades that ship
     // html-migrate still work (this process is still the old code).
     run_post_upgrade_www_migrate(&real_bin_path, args);
 
     eprintln!("▶️ Starting services...");
-    if !Command::new("systemctl")
-        .args(["start", &service])
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
-    {
-        eprintln!("⚠️ Warning: failed to start {service}; try: systemctl start {service}");
+    let started = systemctl_succeeded(&["start", &service]);
+    if !started {
+        // Service unit failed — only roll back if the binary itself is broken.
+        // Config/port issues must not undo a good ABI-compatible upgrade.
+        if preflight_new_binary(&real_bin_path).is_err() {
+            return rollback_on_broken_install(
+                &real_bin_path,
+                &backup,
+                &service,
+                &format!(
+                    "failed to start {service} and installed binary no longer passes smoke check"
+                ),
+            );
+        }
+        eprintln!(
+            "⚠️ Warning: failed to start {service}; the new binary passed smoke checks. \
+             Try: systemctl start {service}  (and inspect journalctl -u {service}). \
+             Previous binary kept at {}.",
+            backup.display()
+        );
+    } else {
+        // Catch crash-loops where systemctl start returns success then the unit dies.
+        thread::sleep(Duration::from_secs(1));
+        if !systemctl_succeeded(&["is-active", "--quiet", &service])
+            && preflight_new_binary(&real_bin_path).is_err()
+        {
+            return rollback_on_broken_install(
+                &real_bin_path,
+                &backup,
+                &service,
+                &format!("{service} is not active and installed binary fails smoke check"),
+            );
+        }
     }
 
     let iroh_unit = PathBuf::from("/etc/systemd/system/iroh-relay.service");
-    if iroh_unit.is_file()
-        && !Command::new("systemctl")
-            .args(["start", "iroh-relay.service"])
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false)
-    {
+    if iroh_unit.is_file() && !systemctl_succeeded(&["start", "iroh-relay.service"]) {
         eprintln!(
-                "⚠️ Warning: failed to start iroh-relay.service; try: systemctl start iroh-relay.service"
-            );
+            "⚠️ Warning: failed to start iroh-relay.service; try: systemctl start iroh-relay.service"
+        );
     }
 
     refresh_cli_docs_after_upgrade();
 
-    eprintln!("🎉 Upgrade complete.");
+    eprintln!(
+        "🎉 Upgrade complete. (previous binary kept at {} for manual rollback if needed)",
+        backup.display()
+    );
     Ok(())
 }
 
@@ -777,6 +1009,71 @@ mod tests {
         assert!(is_download_url("http://127.0.0.1:8080/bin"));
         assert!(!is_download_url("/tmp/madmail-signed"));
         assert!(!is_download_url("./madmail"));
+    }
+
+    #[test]
+    fn backup_path_for_appends_prev() {
+        assert_eq!(
+            backup_path_for(Path::new("/usr/local/bin/madmail")),
+            PathBuf::from("/usr/local/bin/madmail.prev")
+        );
+        assert_eq!(
+            backup_path_for(Path::new("C:\\Program Files\\Madmail\\madmail.exe")),
+            PathBuf::from("C:\\Program Files\\Madmail\\madmail.exe.prev")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn preflight_accepts_script_that_prints_version() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dir.path().join("fake-madmail");
+        fs::write(&bin, b"#!/bin/sh\necho 'madmail 9.9.9-test'\n").unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();
+        preflight_new_binary(&bin).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn preflight_rejects_binary_that_exits_nonzero() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dir.path().join("broken-madmail");
+        fs::write(
+            &bin,
+            b"#!/bin/sh\necho \"version 'GLIBC_2.39' not found\" >&2\nexit 127\n",
+        )
+        .unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();
+        let err = preflight_new_binary(&bin).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("preflight") || msg.contains("GLIBC"),
+            "got: {msg}"
+        );
+        assert!(
+            msg.contains("legacy") || msg.contains("NOT replaced"),
+            "expected recovery/variant hint, got: {msg}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn backup_and_restore_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let current = dir.path().join("madmail");
+        fs::write(&current, b"old-binary-bytes").unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&current, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let backup = backup_current_binary(&current).unwrap();
+        assert!(backup.ends_with("madmail.prev"));
+        assert_eq!(fs::read(&backup).unwrap(), b"old-binary-bytes");
+
+        fs::write(&current, b"new-broken-bytes").unwrap();
+        restore_backup(&backup, &current).unwrap();
+        assert_eq!(fs::read(&current).unwrap(), b"old-binary-bytes");
     }
 
     #[test]
@@ -1005,6 +1302,10 @@ mod tests {
 
     /// When the official signing key is available, prove signed `madmail` inside
     /// `.tar.gz` passes verification (the full traditional check) after extract.
+    ///
+    /// Payload is a tiny shell script that implements `version` so host preflight
+    /// (issue #114) also succeeds; trailing signature bytes are fine because the
+    /// script `exit 0`s before the interpreter would see them.
     #[test]
     fn signed_madmail_inside_tar_gz_passes_verify_after_extract() {
         let Some(key_path) = official_private_key_path() else {
@@ -1013,18 +1314,24 @@ mod tests {
         };
         let dir = tempfile::tempdir().unwrap();
         let payload = dir.path().join("madmail");
-        // Small fake binary body (not a real ELF); signature is what matters.
         fs::write(
             &payload,
-            b"MADMAIL_TEST_PAYLOAD_FOR_SIGNATURE_CHECK_0123456789",
+            b"#!/bin/sh\nif [ \"$1\" = version ]; then echo madmail-test-signed 0.0.0; fi\nexit 0\n",
         )
         .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&payload, fs::Permissions::from_mode(0o755)).unwrap();
+        }
         sign_with_official_key(&payload, &key_path);
 
         assert!(
             verify_signature(&payload).unwrap(),
             "signed payload must verify before packaging"
         );
+        // Preflight must accept this signed runnable payload (not just signature).
+        preflight_new_binary(&payload).unwrap();
 
         let archive = dir.path().join("madmail-linux-amd64.tar.gz");
         let bytes = fs::read(&payload).unwrap();
@@ -1040,17 +1347,50 @@ mod tests {
             "extracted madmail must pass the traditional signature check"
         );
 
-        // Full URL pipeline: download .tar.gz → extract → perform_upgrade verify.
+        // Full URL pipeline: download .tar.gz → extract → perform_upgrade verify + preflight.
         let body = fs::read(&archive).unwrap();
         let (url, server) = serve_once(body);
         let err = upgrade_command(&url, &test_args(), false).unwrap_err();
         let msg = err.to_string();
-        // Signature OK; non-root should fail before replace (or root-only env).
+        // Signature + preflight OK; non-root should fail before replace (or root-only env).
         assert!(
             msg.contains("must be run as root") || msg.contains("Upgrade complete"),
-            "expected post-signature traditional path, got: {msg}"
+            "expected post-signature/preflight traditional path, got: {msg}"
         );
         server.join().unwrap();
+    }
+
+    /// Signed but non-executable payload must fail preflight *before* root/replace
+    /// (the whole point of issue #114 — never brick on a bad variant).
+    #[test]
+    fn signed_non_executable_fails_preflight_not_root_check() {
+        let Some(key_path) = official_private_key_path() else {
+            eprintln!("skip: official private key not found");
+            return;
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let payload = dir.path().join("madmail");
+        fs::write(
+            &payload,
+            b"MADMAIL_NOT_AN_ELF_JUST_BYTES_FOR_SIGNATURE_ONLY_0123456789",
+        )
+        .unwrap();
+        sign_with_official_key(&payload, &key_path);
+        assert!(verify_signature(&payload).unwrap());
+
+        let err = perform_upgrade(&payload, &test_args()).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("preflight")
+                || msg.contains("failed to execute")
+                || msg.contains("NOT replaced")
+                || msg.contains("legacy"),
+            "expected preflight abort, got: {msg}"
+        );
+        assert!(
+            !msg.contains("must be run as root"),
+            "must not reach root check after failed preflight: {msg}"
+        );
     }
 
     fn official_private_key_path() -> Option<PathBuf> {

--- a/docs/guide/cli/update.md
+++ b/docs/guide/cli/update.md
@@ -32,12 +32,18 @@ madmail update <PATH_OR_URL> [--accept-unsafe-https]
 
 ```bash
 madmail update /tmp/madmail-signed
-madmail update https://relay.example/releases/madmail
-madmail update --accept-unsafe-https https://self-signed.example/madmail
+
+# Default amd64 (newer glibc)
 madmail update https://github.com/themadorg/madmail/releases/latest/download/madmail-linux-amd64.tar.gz
+
+# Older distros — use the matching variant you installed with
+madmail update https://github.com/themadorg/madmail/releases/latest/download/madmail-linux-amd64-legacy.tar.gz
+madmail update https://github.com/themadorg/madmail/releases/latest/download/madmail-linux-amd64-musl.tar.gz
+
+madmail update --accept-unsafe-https https://self-signed.example/madmail
 ```
 
-See [upgrade](upgrade.md) for full behavior (TLS policy, archive extract, signature verify, systemd stop/replace/start, custom www template migration).
+See [upgrade](upgrade.md) for full behavior: TLS policy, archive extract, signature verify, **host preflight**, **`*.prev` backup/rollback**, Linux release variants, systemd stop/replace/start, custom www template migration.
 
 ## JSON output (`--json`)
 

--- a/docs/guide/cli/upgrade.md
+++ b/docs/guide/cli/upgrade.md
@@ -33,18 +33,43 @@ madmail upgrade <PATH_OR_URL> [--accept-unsafe-https]
 1. Downloads the file if a URL is given. **HTTPS verifies TLS certificates by default.** Self-signed/untrusted certs require `--accept-unsafe-https` or an interactive yes. `http://` is unchanged.
 2. If the URL ends in `.tar.gz` or `.tgz`, extracts the `madmail` binary from the archive first.
 3. Verifies an **Ed25519 signature** in the last 64 bytes of the binary.
-4. Stops the systemd service (and iroh-relay when present).
-5. Replaces the current executable.
-6. **Custom www templates:** runs the new binary’s [`html-migrate`](html-migrate.md) against `--config`. If `www_dir` points at a custom site that still uses Go `html/template` syntax and/or legacy `/qr?data=` QR image URLs, you are prompted to convert (Minijinja + client-side QR; backups as `*.go-template.bak` / `main.js.qr-compat.bak`). Decline or non-interactive sessions leave files unchanged; re-run `madmail html-migrate --yes` later if needed.
-7. Restarts the systemd service when applicable and refreshes man/completions.
+4. **Host preflight:** runs the new binary with `version` on this machine. If it cannot execute (wrong glibc / loader error), the upgrade **aborts** — services stay up and the live binary is not touched.
+5. Copies the current executable to a sibling `*.prev` backup (e.g. `/usr/local/bin/madmail.prev`).
+6. Stops the systemd service (and iroh-relay when present).
+7. Replaces the current executable.
+8. Re-runs the smoke check on the installed path; on failure, **restores `*.prev`**, restarts services, and errors out.
+9. **Custom www templates:** runs the new binary’s [`html-migrate`](html-migrate.md) against `--config`. If `www_dir` points at a custom site that still uses Go `html/template` syntax and/or legacy `/qr?data=` QR image URLs, you are prompted to convert (Minijinja + client-side QR; backups as `*.go-template.bak` / `main.js.qr-compat.bak`). Decline or non-interactive sessions leave files unchanged; re-run `madmail html-migrate --yes` later if needed.
+10. Restarts the systemd service when applicable and refreshes man/completions. A previous working binary remains at `*.prev` for manual rollback if needed.
+
+## Linux release variants
+
+Official GitHub Releases ship more than one Linux build per architecture. **The default asset is not universal:**
+
+| Asset (example) | When to use it |
+|-----------------|----------------|
+| `madmail-linux-amd64.tar.gz` | Default glibc build (newer distros) |
+| `madmail-linux-amd64-legacy.tar.gz` | Older glibc (e.g. Ubuntu 22.04 / hosts that report `GLIBC_2.38` / `GLIBC_2.39` not found) |
+| `madmail-linux-amd64-musl.tar.gz` | musl / static-ish alternative |
+| `…-arm64…` / `…-arm64-legacy…` / `…-arm64-musl…` | Same matrix for arm64 |
+
+If you originally installed `*-legacy` or `*-musl`, keep using that variant in `update` / `upgrade` URLs. Pointing a legacy host at the default tarball used to overwrite a working binary and brick the install; preflight + `*.prev` rollback prevent that.
 
 ## Examples
 
 ```bash
+# Local signed binary
 madmail upgrade /tmp/madmail-signed
-madmail upgrade https://relay.example/releases/madmail
-madmail upgrade --accept-unsafe-https https://self-signed.example/madmail
+
+# Default amd64 (newer glibc hosts)
 madmail upgrade https://github.com/themadorg/madmail/releases/latest/download/madmail-linux-amd64.tar.gz
+
+# Older distros / hosts that need the legacy build
+madmail upgrade https://github.com/themadorg/madmail/releases/latest/download/madmail-linux-amd64-legacy.tar.gz
+
+# musl alternative
+madmail upgrade https://github.com/themadorg/madmail/releases/latest/download/madmail-linux-amd64-musl.tar.gz
+
+madmail upgrade --accept-unsafe-https https://self-signed.example/madmail
 ```
 
 ## Notes
@@ -54,6 +79,7 @@ madmail upgrade https://github.com/themadorg/madmail/releases/latest/download/ma
 - `--accept-unsafe-https` only relaxes **HTTPS transport** certificate checks (self-signed peers); it never weakens Ed25519 signature verification.
 - Non-interactive / `--json` sessions cannot prompt; pass `--accept-unsafe-https` explicitly when needed.
 - Requires appropriate permissions to replace `/usr/local/bin/madmail`.
+- After a successful upgrade, `madmail.prev` next to the install path is the previous binary (manual rollback: `sudo cp /usr/local/bin/madmail.prev /usr/local/bin/madmail && sudo systemctl start madmail`).
 
 ## JSON output (`--json`)
 

--- a/docs/man/madmail.1
+++ b/docs/man/madmail.1
@@ -82,6 +82,10 @@ preserve selected artifacts.\&
 .RS 4
 Replace this executable from a signed local file or URL
 (raw binary or .tar.gz / .tgz archive).\&
+Runs a host preflight (\fBversion\fR) before stopping services; keeps a
+\fB*.prev\fR backup and rolls back if the new binary cannot run.\&
+Use the same Linux release variant you installed (\fB*-legacy\fR / \fB*-musl\fR
+when required — the default \fBamd64\fR build is not universal).\&
 After replace, may prompt to migrate custom \fBwww_dir\fR (Go templates
 to Minijinja and legacy \fB/qr\fR to client-side QR; see \fBhtml-migrate\fR).\&
 .PP

--- a/docs/man/madmail.1.scd
+++ b/docs/man/madmail.1.scd
@@ -68,6 +68,10 @@ Extended documentation:
 *upgrade*, *update*
 	Replace this executable from a signed local file or URL
 	(raw binary or .tar.gz / .tgz archive).
+	Runs a host preflight (*version*) before stopping services; keeps a
+	*.prev* backup and rolls back if the new binary cannot run.
+	Use the same Linux release variant you installed (*\-legacy* / *\-musl*
+	when required — the default *amd64* build is not universal).
 	After replace, may prompt to convert custom *www_dir* Go templates
 	to Minijinja (see *html\-migrate*).
 

--- a/docs/project/user-guide/02-quick-start.md
+++ b/docs/project/user-guide/02-quick-start.md
@@ -112,9 +112,16 @@ To obtain a ready-to-use binary without compiling:
 1. Go to the releases page:  
    **https://github.com/themadorg/madmail/releases**
 
-2. Download the latest release for your architecture (usually `madmail-linux-amd64` or similar).
+2. Download the latest release for your architecture. Releases ship several Linux variants:
 
-   Example with `wget`:
+   | Asset | Use when |
+   |-------|----------|
+   | `madmail-linux-amd64` / `.tar.gz` | Default glibc build (newer distros) |
+   | `madmail-linux-amd64-legacy` / `.tar.gz` | Older glibc (e.g. Ubuntu 22.04; `GLIBC_2.38+` errors) |
+   | `madmail-linux-amd64-musl` / `.tar.gz` | musl alternative |
+   | arm64 equivalents (`…-arm64…`, `…-legacy…`, `…-musl…`) | Same matrix for arm64 |
+
+   Example with `wget` (default amd64):
 
    ```bash
    wget https://github.com/themadorg/madmail/releases/download/vX.Y.Z/madmail-linux-amd64
@@ -122,14 +129,17 @@ To obtain a ready-to-use binary without compiling:
    sudo mv madmail-linux-amd64 /usr/local/bin/madmail
    ```
 
-   The binaries in the official releases are the same ones produced by this project.
+   The binaries in the official releases are the same ones produced by this project. Pick the variant that runs on your host and **keep using that same variant** for later updates.
 
 ## Secure Upgrades with `madmail upgrade`
 
 Once you have `madmail` installed, future updates can be done securely with the built-in upgrade command:
 
 ```bash
-sudo madmail upgrade <path-or-url>
+# Use the same variant you installed (default / legacy / musl)
+sudo madmail upgrade https://github.com/themadorg/madmail/releases/latest/download/madmail-linux-amd64.tar.gz
+# older glibc hosts:
+# sudo madmail upgrade https://github.com/themadorg/madmail/releases/latest/download/madmail-linux-amd64-legacy.tar.gz
 ```
 
 ### How it works
@@ -139,10 +149,12 @@ sudo madmail upgrade <path-or-url>
   2. If the URL is a `.tar.gz` / `.tgz` release archive, extracts the binary first.
   3. **Verifies the digital signature** (Ed25519) that is appended to the release binary.
   4. If the signature is invalid or missing, the upgrade is **aborted** — the binary is never installed. This protects against compromised or tampered releases.
-  5. Stops the `madmail.service` (and iroh-relay if present).
-  6. Atomically replaces the running binary.
-  7. May prompt to convert custom `www_dir` Go templates to Minijinja and fix legacy `/qr?data=` QR (`html-migrate`).
-  8. Restarts the service(s).
+  5. **Host preflight:** runs the new binary (`version`) before touching the live install. Wrong-variant / glibc mismatches abort safely (service stays up).
+  6. Copies the current binary to `madmail.prev` next to the install path.
+  7. Stops the `madmail.service` (and iroh-relay if present).
+  8. Atomically replaces the running binary; on post-install smoke failure, restores `*.prev` and restarts.
+  9. May prompt to convert custom `www_dir` Go templates to Minijinja and fix legacy `/qr?data=` QR (`html-migrate`).
+  10. Restarts the service(s).
 
 This is the supported way to update a production server with signature verification.
 

--- a/tests/deltachat-test/scenarios/test_10_upgrade_mechanism.py
+++ b/tests/deltachat-test/scenarios/test_10_upgrade_mechanism.py
@@ -92,6 +92,30 @@ def run_test(madmail_bin, private_key_path, test_dir):
         print(f"Stderr: {result.stderr}")
         raise Exception("Failure: Signed binary verification failed!")
 
+    # Issue #114: signed but non-executable dummy must fail host preflight and
+    # must NOT replace the live binary (no brick).
+    if (
+        "preflight" in signed_out.lower()
+        or "failed to execute" in signed_out.lower()
+        or "NOT replaced" in signed_out
+    ):
+        print("✓ Success: Signed non-runnable binary aborted at preflight (live intact)")
+        if not os.path.isfile(madmail_under_test):
+            raise Exception("Live binary missing after preflight abort")
+        # File should still be the original under-test copy (not the dummy).
+        with open(madmail_under_test, "rb") as f:
+            live_head = f.read(16)
+        with open(madmail_bin, "rb") as f:
+            orig_head = f.read(16)
+        if live_head != orig_head:
+            raise Exception(
+                "Security Failure: live binary was replaced after preflight abort"
+            )
+    else:
+        # Older binaries without preflight still reach root/replace; tolerate.
+        print(
+            "  note: no preflight abort text (binary may predate issue #114 fix)"
+        )
     # Use a fresh copy for the URL step (the prior binary may still be mapped).
     madmail_for_url = os.path.join(test_dir, "madmail_for_url")
     shutil.copy2(madmail_bin, madmail_for_url)

--- a/tests/upgrade-safety.sh
+++ b/tests/upgrade-safety.sh
@@ -1,0 +1,562 @@
+#!/usr/bin/env bash
+# Container / host harness for madmail update safety (issue #114).
+#
+# Scenarios:
+#   G) live binary `version` works
+#   A) unsigned binary rejected; live binary untouched; no *.prev
+#   B) signed wrong-arch (arm64) fails preflight; live untouched
+#   H) default amd64 asset on older glibc fails preflight; live untouched  (#114)
+#   C) compatible signed upgrade succeeds; creates *.prev with prior bytes
+#   E) re-upgrade after success still works (regression)
+#   D) .tar.gz URL extract + upgrade succeeds
+#   F) default-asset URL prints variant warning; live untouched on failed download
+#
+# Usage (repo root, after `cargo build -p chatmail --release`):
+#   ./tests/upgrade-safety.sh              # host (partial) + docker matrix
+#   ./tests/upgrade-safety.sh --docker-only
+#   ./tests/upgrade-safety.sh --host-only  # used inside containers
+#
+# Env:
+#   MADMAIL_BIN      path to built madmail (default: target/release/madmail)
+#   RELEASE_TAG      GitHub release tag (default: latest via gh, or v2.18.2)
+#   UPGRADE_ASSET    asset name for success path (auto: default or legacy)
+#   FORCE_LEGACY=1   always use *-legacy for success scenarios
+#   KEEP_WORKDIR=1   keep work dir
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+MADMAIL_BIN="${MADMAIL_BIN:-$ROOT/target/release/madmail}"
+WORKDIR="${WORKDIR:-$(mktemp -d /tmp/madmail-upgrade-safety.XXXXXX)}"
+RELEASE_TAG="${RELEASE_TAG:-}"
+REPO="${REPO:-themadorg/madmail}"
+PASS=0
+FAIL=0
+SKIP=0
+
+# All diagnostics go to stderr so command substitutions (e.g. pick_success_asset)
+# only capture the intended return value on stdout.
+red() { printf '\033[31m%s\033[0m\n' "$*" >&2; }
+green() { printf '\033[32m%s\033[0m\n' "$*" >&2; }
+yellow() { printf '\033[33m%s\033[0m\n' "$*" >&2; }
+info() { printf '→ %s\n' "$*" >&2; }
+
+cleanup() {
+  if [[ "${KEEP_WORKDIR:-0}" == "1" ]]; then
+    yellow "KEEP_WORKDIR=1 — left $WORKDIR"
+  else
+    rm -rf "$WORKDIR"
+  fi
+}
+trap cleanup EXIT
+
+assert_ok() {
+  local name="$1"
+  shift
+  info "TEST: $name"
+  # Use `|| rc=$?` so nested helpers that toggle `set -e` cannot abort the harness
+  # when a scenario returns non-zero (e.g. skip=2).
+  local rc=0
+  "$@" || rc=$?
+  if [[ "$rc" -eq 0 ]]; then
+    green "  PASS: $name"
+    PASS=$((PASS + 1))
+  elif [[ "$rc" -eq 2 ]]; then
+    yellow "  SKIP: $name"
+    SKIP=$((SKIP + 1))
+  else
+    red "  FAIL: $name (rc=$rc)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local hay="$1" needle="$2"
+  [[ "$hay" == *"$needle"* ]]
+}
+
+sha() { sha256sum "$1" | awk '{print $1}'; }
+
+need_bin() {
+  if [[ ! -x "$MADMAIL_BIN" ]]; then
+    red "madmail binary not found/executable: $MADMAIL_BIN"
+    red "Build with: cargo build -p chatmail --release"
+    exit 2
+  fi
+}
+
+resolve_tag() {
+  if [[ -n "$RELEASE_TAG" ]]; then
+    echo "$RELEASE_TAG"
+    return
+  fi
+  if command -v gh >/dev/null 2>&1; then
+    gh release view --repo "$REPO" --json tagName --jq .tagName
+  else
+    echo "v2.18.2"
+  fi
+}
+
+download_asset() {
+  local tag="$1" name="$2" dest="$3"
+  mkdir -p "$(dirname "$dest")"
+  if [[ -f "$dest" && -s "$dest" ]] && file "$dest" 2>/dev/null | grep -qiE 'ELF|gzip compressed'; then
+    return 0
+  fi
+  local url="https://github.com/${REPO}/releases/download/${tag}/${name}"
+  info "Downloading $name ($tag)..."
+  local tmp="${dest}.part"
+  rm -f "$tmp" "$dest"
+  curl -fsSL --retry 3 --retry-delay 1 -o "$tmp" "$url"
+  mv -f "$tmp" "$dest"
+  chmod +x "$dest" || true
+  if ! file "$dest" 2>/dev/null | grep -qiE 'ELF|gzip compressed'; then
+    red "downloaded $name does not look like a binary/archive"
+    file "$dest" || true
+    return 1
+  fi
+}
+
+host_can_run() {
+  local bin="$1"
+  # Do not toggle set -e globally (breaks callers under `set -e`).
+  if "$bin" version >/dev/null 2>&1; then
+    return 0
+  fi
+  return 1
+}
+
+# Pick a success-path asset: prefer default if it runs here, else legacy.
+pick_success_asset() {
+  local tag="$1"
+  if [[ -n "${UPGRADE_ASSET:-}" ]]; then
+    echo "$UPGRADE_ASSET"
+    return
+  fi
+  if [[ "${FORCE_LEGACY:-0}" == "1" ]]; then
+    echo "madmail-linux-amd64-legacy"
+    return
+  fi
+  mkdir -p "$WORKDIR/assets"
+  local tmp="$WORKDIR/assets/madmail-linux-amd64"
+  if ! download_asset "$tag" "madmail-linux-amd64" "$tmp"; then
+    # Fall back if probe download fails (network blip).
+    echo "madmail-linux-amd64-legacy"
+    return
+  fi
+  if host_can_run "$tmp"; then
+    echo "madmail-linux-amd64"
+  else
+    echo "madmail-linux-amd64-legacy"
+  fi
+}
+
+setup_install() {
+  INSTALL_DIR="$WORKDIR/install"
+  mkdir -p "$INSTALL_DIR" "$WORKDIR/assets" "$WORKDIR/http"
+  cp -f "$MADMAIL_BIN" "$INSTALL_DIR/madmail"
+  chmod 755 "$INSTALL_DIR/madmail"
+  LIVE="$INSTALL_DIR/madmail"
+  LIVE_SHA_BEFORE="$(sha "$LIVE")"
+}
+
+run_upgrade() {
+  local path_or_url="$1"
+  shift || true
+  RC=0
+  OUT="$("$LIVE" upgrade "$path_or_url" "$@" 2>&1)" || RC=$?
+}
+
+# ─── scenarios ──────────────────────────────────────────────────────────────
+
+scenario_G_live_version() {
+  setup_install
+  local ver
+  ver="$("$LIVE" version 2>&1)" || return 1
+  echo "  version: $ver"
+  return 0
+}
+
+scenario_A_unsigned() {
+  setup_install
+  local dummy="$WORKDIR/assets/unsigned.bin"
+  printf 'NOT A SIGNED MADMAIL BINARY %s' "$(head -c 64 /dev/urandom | base64 -w0 2>/dev/null || head -c 64 /dev/urandom | base64)" >"$dummy"
+  run_upgrade "$dummy"
+  assert_contains "$OUT" "INVALID SIGNATURE" || {
+    echo "$OUT" | tail -20
+    return 1
+  }
+  [[ "$RC" -ne 0 ]] || return 1
+  [[ "$(sha "$LIVE")" == "$LIVE_SHA_BEFORE" ]] || {
+    echo "live binary was modified after unsigned upgrade attempt"
+    return 1
+  }
+  [[ ! -e "${LIVE}.prev" ]] || {
+    echo "unexpected .prev after failed unsigned upgrade"
+    return 1
+  }
+  return 0
+}
+
+scenario_B_wrong_arch() {
+  setup_install
+  local tag="$1"
+  local arm="$WORKDIR/assets/madmail-linux-arm64"
+  download_asset "$tag" "madmail-linux-arm64" "$arm"
+  if file "$arm" | grep -qiE 'x86-64|x86_64'; then
+    return 2
+  fi
+  run_upgrade "$arm"
+  [[ "$(sha "$LIVE")" == "$LIVE_SHA_BEFORE" ]] || {
+    echo "BRICK RISK: live binary changed after wrong-arch upgrade"
+    echo "$OUT" | tail -40
+    return 1
+  }
+  if ! echo "$OUT" | grep -qiE 'preflight|failed to execute|exec format|cannot execute|NOT replaced|legacy'; then
+    echo "expected preflight/loader abort, got:"
+    echo "$OUT" | tail -40
+    return 1
+  fi
+  [[ "$RC" -ne 0 ]] || return 1
+  "$LIVE" version >/dev/null
+  return 0
+}
+
+# Issue #114 core: default glibc build on host that cannot run it.
+scenario_H_default_rejected_on_old_glibc() {
+  setup_install
+  local tag="$1"
+  local def="$WORKDIR/assets/madmail-linux-amd64"
+  download_asset "$tag" "madmail-linux-amd64" "$def"
+  if host_can_run "$def"; then
+    yellow "  host can run default amd64 — scenario is N/A here (covered on bookworm)"
+    return 2
+  fi
+  run_upgrade "$def"
+  [[ "$(sha "$LIVE")" == "$LIVE_SHA_BEFORE" ]] || {
+    echo "BRICK RISK: live binary overwritten by incompatible default build"
+    echo "$OUT" | tail -50
+    return 1
+  }
+  [[ ! -e "${LIVE}.prev" ]] || {
+    # Backup is only taken after preflight; must not exist on preflight fail.
+    echo "unexpected .prev after preflight failure (backup should not run)"
+    return 1
+  }
+  if ! echo "$OUT" | grep -qiE 'preflight|GLIBC|failed to execute|NOT replaced|legacy'; then
+    echo "expected preflight/GLIBC abort, got:"
+    echo "$OUT" | tail -40
+    return 1
+  fi
+  [[ "$RC" -ne 0 ]] || return 1
+  # Live still executable
+  "$LIVE" version >/dev/null
+  green "  (default asset correctly refused; live binary still runs)"
+  return 0
+}
+
+scenario_C_success_prev() {
+  setup_install
+  local tag="$1"
+  local asset="$2"
+  local good="$WORKDIR/assets/$asset"
+  download_asset "$tag" "$asset" "$good"
+  if ! host_can_run "$good"; then
+    yellow "  cannot run $asset on this host"
+    return 2
+  fi
+  if [[ "$(id -u)" -ne 0 ]]; then
+    yellow "  need root to replace binary"
+    return 2
+  fi
+  run_upgrade "$good"
+  if [[ "$RC" -ne 0 ]]; then
+    echo "$OUT" | tail -50
+    return 1
+  fi
+  assert_contains "$OUT" "Signature verification successful" || {
+    echo "$OUT" | tail -30
+    return 1
+  }
+  if ! echo "$OUT" | grep -qE 'Preflight OK|Preflight'; then
+    echo "missing preflight success line"
+    echo "$OUT" | tail -30
+    return 1
+  fi
+  assert_contains "$OUT" "Upgrade complete" || return 1
+  [[ -f "${LIVE}.prev" ]] || {
+    echo "missing ${LIVE}.prev after successful upgrade"
+    return 1
+  }
+  [[ "$(sha "${LIVE}.prev")" == "$LIVE_SHA_BEFORE" ]] || {
+    echo ".prev is not the previous live binary"
+    return 1
+  }
+  [[ "$(sha "$LIVE")" != "$LIVE_SHA_BEFORE" ]] || {
+    echo "live binary unchanged after successful upgrade"
+    return 1
+  }
+  "$LIVE" version >/dev/null
+  echo "$asset" >"$WORKDIR/last_success_asset"
+  return 0
+}
+
+scenario_E_reupgrade() {
+  if [[ "$(id -u)" -ne 0 ]]; then
+    return 2
+  fi
+  INSTALL_DIR="$WORKDIR/install"
+  LIVE="$INSTALL_DIR/madmail"
+  if [[ ! -f "$WORKDIR/last_success_asset" ]]; then
+    return 2
+  fi
+  local asset
+  asset="$(cat "$WORKDIR/last_success_asset")"
+  local good="$WORKDIR/assets/$asset"
+  [[ -x "$good" ]] || return 2
+
+  # After scenario C, $LIVE is a published release binary (without this branch's
+  # code). Re-seed the under-test build so we keep exercising the fixed path.
+  cp -f "$MADMAIL_BIN" "$LIVE"
+  chmod 755 "$LIVE"
+  local before
+  before="$(sha "$LIVE")"
+  run_upgrade "$good"
+  if [[ "$RC" -ne 0 ]]; then
+    echo "$OUT" | tail -40
+    return 1
+  fi
+  assert_contains "$OUT" "Upgrade complete" || return 1
+  if [[ ! -f "${LIVE}.prev" ]]; then
+    echo "missing ${LIVE}.prev after re-upgrade"
+    return 1
+  fi
+  local prev_sha
+  prev_sha="$(sha "${LIVE}.prev" 2>/dev/null || echo missing)"
+  if [[ "$prev_sha" != "$before" ]]; then
+    echo "re-upgrade did not snapshot previous live into .prev (prev=$prev_sha before=$before)"
+    return 1
+  fi
+  "$LIVE" version >/dev/null
+  return 0
+}
+
+scenario_D_tarball() {
+  if [[ "$(id -u)" -ne 0 ]]; then
+    return 2
+  fi
+  setup_install
+  local tag="$1"
+  local asset="$2" # e.g. madmail-linux-amd64-legacy.tar.gz
+  local tgz_name="$asset"
+  local tgz="$WORKDIR/http/$tgz_name"
+  download_asset "$tag" "$tgz_name" "$tgz"
+
+  local port
+  port="$(python3 - <<'PY'
+import socket
+s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()
+PY
+)"
+  (
+    cd "$WORKDIR/http"
+    python3 -m http.server "$port" --bind 127.0.0.1 >/dev/null 2>&1
+  ) &
+  local http_pid=$!
+  sleep 0.4
+  local url="http://127.0.0.1:${port}/${tgz_name}"
+  RC=0
+  OUT="$("$LIVE" update "$url" 2>&1)" || RC=$?
+  kill "$http_pid" 2>/dev/null || true
+  wait "$http_pid" 2>/dev/null || true
+
+  if [[ "$RC" -ne 0 ]]; then
+    echo "$OUT" | tail -50
+    return 1
+  fi
+  if ! echo "$OUT" | grep -qiE 'Extracting madmail binary from archive|Extracting'; then
+    echo "$OUT" | tail -30
+    return 1
+  fi
+  assert_contains "$OUT" "Signature verification successful" || return 1
+  assert_contains "$OUT" "Upgrade complete" || return 1
+  [[ -f "${LIVE}.prev" ]] || return 1
+  "$LIVE" version >/dev/null
+  return 0
+}
+
+scenario_F_default_url_warning() {
+  setup_install
+  local port
+  port="$(python3 - <<'PY'
+import socket
+s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()
+PY
+)"
+  mkdir -p "$WORKDIR/empty_http"
+  (
+    cd "$WORKDIR/empty_http"
+    python3 -m http.server "$port" --bind 127.0.0.1 >/dev/null 2>&1
+  ) &
+  local http_pid=$!
+  sleep 0.3
+  local url="http://127.0.0.1:${port}/madmail-linux-amd64.tar.gz"
+  RC=0
+  OUT="$("$LIVE" update "$url" 2>&1)" || RC=$?
+  kill "$http_pid" 2>/dev/null || true
+  wait "$http_pid" 2>/dev/null || true
+  if ! echo "$OUT" | grep -qiE 'Default Linux build|legacy|\*-legacy'; then
+    echo "$OUT" | tail -25
+    return 1
+  fi
+  [[ "$(sha "$LIVE")" == "$LIVE_SHA_BEFORE" ]] || return 1
+  return 0
+}
+
+run_host_scenarios() {
+  need_bin
+  local tag
+  tag="$(resolve_tag)"
+  info "Release tag: $tag"
+  info "Workdir: $WORKDIR"
+  info "Binary: $MADMAIL_BIN ($(file -b "$MADMAIL_BIN" 2>/dev/null || echo '?'))"
+  info "uid=$(id -u) glibc=$(ldd --version 2>&1 | head -1)"
+
+  local success_asset
+  success_asset="$(pick_success_asset "$tag")"
+  info "Success-path asset: $success_asset"
+  local tgz_asset="${success_asset}.tar.gz"
+
+  assert_ok "G: live binary version works" scenario_G_live_version
+  assert_ok "A: unsigned rejected, live untouched" scenario_A_unsigned
+  assert_ok "B: wrong-arch signed fails preflight" scenario_B_wrong_arch "$tag"
+  assert_ok "H: default amd64 rejected when host cannot run it (#114)" scenario_H_default_rejected_on_old_glibc "$tag"
+  assert_ok "C: success + *.prev ($success_asset)" scenario_C_success_prev "$tag" "$success_asset"
+  assert_ok "E: re-upgrade still works" scenario_E_reupgrade
+  assert_ok "D: tar.gz URL upgrade ($tgz_asset)" scenario_D_tarball "$tag" "$tgz_asset"
+  assert_ok "F: default asset URL warns about variants" scenario_F_default_url_warning
+}
+
+run_one_docker() {
+  local img="$1"
+  local label="$2"
+  local force_legacy="${3:-0}"
+  local bin_on_host="${4:-$MADMAIL_BIN}"
+  if [[ ! -x "$bin_on_host" ]]; then
+    red "binary for $label not found: $bin_on_host"
+    return 1
+  fi
+  local tag
+  tag="$(resolve_tag)"
+  info "Pulling $img ($label)..."
+  docker pull -q "$img" >/dev/null
+
+  info "Container matrix: $label ($img) FORCE_LEGACY=$force_legacy bin=$bin_on_host"
+  # Verify the under-test binary actually runs in this image (else G fails noisily).
+  if ! docker run --rm -v "$bin_on_host:/binaries/madmail:ro" "$img" /binaries/madmail version >/dev/null 2>&1; then
+    red "under-test binary cannot run inside $img — rebuild with matching glibc"
+    docker run --rm -v "$bin_on_host:/binaries/madmail:ro" "$img" \
+      bash -c '/binaries/madmail version' 2>&1 | tail -5 || true
+    return 1
+  fi
+
+  docker run --rm \
+    -v "$ROOT:/src:ro" \
+    -v "$bin_on_host:/binaries/madmail:ro" \
+    -e MADMAIL_BIN=/binaries/madmail \
+    -e RELEASE_TAG="$tag" \
+    -e FORCE_LEGACY="$force_legacy" \
+    -e KEEP_WORKDIR=0 \
+    -e WORKDIR=/tmp/upgrade-safety \
+    "$img" \
+    bash -c '
+      set -euo pipefail
+      export DEBIAN_FRONTEND=noninteractive
+      apt-get update -qq
+      apt-get install -y -qq curl ca-certificates file python3 >/dev/null
+      mkdir -p /tmp/upgrade-safety
+      bash /src/tests/upgrade-safety.sh --host-only
+    '
+}
+
+ensure_bookworm_bin() {
+  local out="$ROOT/target/bookworm-release/release/madmail"
+  if [[ -x "$out" ]] && "$out" version >/dev/null 2>&1; then
+    # Prefer a bookworm-built binary if present; still verify it runs in bookworm below.
+    echo "$out"
+    return
+  fi
+  if [[ -x "$out" ]]; then
+    echo "$out"
+    return
+  fi
+  info "Building fixed madmail against bookworm glibc (for #114 old-distro matrix)..."
+  mkdir -p "$ROOT/target/bookworm-release"
+  docker pull -q rust:1-bookworm >/dev/null
+  docker run --rm \
+    -v "$ROOT:/src:rw" \
+    -v madmail-cargo-registry:/usr/local/cargo/registry \
+    -v madmail-cargo-git:/usr/local/cargo/git \
+    -e CARGO_TARGET_DIR=/src/target/bookworm-release \
+    -w /src \
+    rust:1-bookworm \
+    cargo build -p chatmail --release
+  if [[ ! -x "$out" ]]; then
+    red "bookworm build failed: missing $out"
+    return 1
+  fi
+  echo "$out"
+}
+
+run_docker_matrix() {
+  local rc=0
+  local bookworm_bin
+  bookworm_bin="$(ensure_bookworm_bin)" || return 1
+
+  # Bookworm (glibc 2.36): default release needs 2.39 → scenario H; success via legacy.
+  run_one_docker "debian:bookworm-slim" "bookworm/old-glibc" 1 "$bookworm_bin" || rc=1
+  echo
+  # Newer base: default amd64 should pass preflight (success via default asset).
+  # Host release build is fine on trixie/new glibc.
+  run_one_docker "debian:trixie-slim" "trixie/new-glibc" 0 "$MADMAIL_BIN" || rc=1
+  return "$rc"
+}
+
+# ─── main ───────────────────────────────────────────────────────────────────
+
+MODE="all"
+for arg in "$@"; do
+  case "$arg" in
+    --docker-only) MODE="docker" ;;
+    --host-only) MODE="host" ;;
+    -h|--help)
+      sed -n '2,35p' "$0"
+      exit 0
+      ;;
+  esac
+done
+
+echo "=== madmail upgrade safety harness (issue #114) ==="
+
+case "$MODE" in
+  host)
+    run_host_scenarios
+    ;;
+  docker)
+    run_docker_matrix
+    exit $?
+    ;;
+  all)
+    echo "--- host (may skip root-only / old-glibc scenarios) ---"
+    run_host_scenarios || true
+    echo
+    echo "--- docker matrix ---"
+    run_docker_matrix
+    ;;
+esac
+
+echo
+echo "=== summary: $PASS passed, $FAIL failed, $SKIP skipped ==="
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

`madmail update` / `upgrade` could install the default glibc release over a working `*-legacy` / `*-musl` binary, leave the service down, and make further `madmail update` impossible (loader errors). Fixes #114.

Changes in `perform_upgrade`:

- **Host preflight** — after Ed25519 verify, run the new binary with `version` **before** stopping services or replacing the live binary
- **Backup** — copy current executable to sibling `*.prev` (e.g. `/usr/local/bin/madmail.prev`)
- **Rollback** — restore `*.prev` if post-install smoke fails (or start fails *and* smoke fails); leave a good binary alone on pure service/config start issues
- **URL hint** — default (non-legacy/non-musl) Linux assets log a short variant warning
- **Docs** — CLI upgrade/update, quick-start, man page call out release variants
- **Tests** — unit coverage for preflight/backup; e2e upgrade scenario asserts live binary stays intact; `tests/upgrade-safety.sh` container matrix

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Build / CI / tooling
- [ ] Refactor (no functional change)

## Area

- [ ] SMTP
- [ ] IMAP
- [ ] Federation / delivery queue
- [ ] Authentication / JIT
- [ ] Admin API / admin web UI (`external/madmail-admin-web`)
- [ ] TURN / Iroh / proxy services
- [ ] Storage / quota / DB migrations
- [x] Configuration / CLI
- [x] Docs (`docs/project/`, `docs/TDD/`, user guide)
- [ ] Other:

## Testing

- [x] `cargo fmt --all -- --check` (not re-run this turn; clippy clean on chatmail earlier)
- [x] `cargo clippy -p chatmail --lib -- -D warnings`
- [x] `cargo test --workspace` (or targeted crate/tests: `cargo test -p chatmail --lib upgrade::` — 27/27; related filter 33/33)
- [x] Manual / E2E verification (describe below)

**Manual verification (if any):**

```text
# Unit
cargo test -p chatmail --lib upgrade::   # 27 passed

# Container matrix (real release assets v2.18.2)
cargo build -p chatmail --release
# bookworm-compatible build of this branch for old-glibc matrix:
#   docker run … rust:1-bookworm cargo build -p chatmail --release
#   (CARGO_TARGET_DIR=target/bookworm-release)
./tests/upgrade-safety.sh --docker-only

# Results:
#   debian:bookworm-slim (glibc 2.36): 8/8 PASS
#     including H: default amd64 (GLIBC_2.39) refused; live binary untouched
#     arm64 wrong-arch preflight; legacy success + *.prev; tar.gz URL; re-upgrade
#   debian:trixie-slim (glibc 2.41): 7 PASS, 1 SKIP (H N/A), 0 FAIL
#     default amd64 success path + *.prev + tar.gz

# Host non-root: 4 pass / 4 skip (root-only paths correctly skipped)
```

## Documentation

- [ ] No doc updates needed
- [x] Updated operator/user docs (`docs/project/user-guide/`, install guides)
- [ ] Updated developer docs (`docs/project/`)
- [ ] Updated or added TDD section (`docs/TDD/`) — required for significant design changes

Also: `docs/guide/cli/upgrade.md`, `update.md`, man page.

## Security & privacy

- [ ] Not security-sensitive
- [x] Security-sensitive — added/updated tests for the security property
- [x] Reviewed error messages for information leakage

Preflight only execs after Ed25519 signature verification. Variant/GLIBC hints do not leak host secrets.

## Commits

- `fix:` bug fix

## Checklist

- [x] PR is focused and reviewable (small vertical slices preferred)
- [x] No secrets, `data/`, `target/`, or `node_modules/` committed
- [x] Submodule pointers updated if `external/madmail-admin-web` changed
- [x] Behavior parity with Madmail v1 considered (or intentional difference documented)