### PR TITLE
docs: add CONTRIBUTING, SECURITY, and Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,137 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement through the
+project maintainers via GitHub (private contact to organization owners of
+[themadorg](https://github.com/themadorg), or the repository maintainers of
+[themadorg/madmail](https://github.com/themadorg/madmail)).
+
+For security vulnerabilities, use [SECURITY.md](SECURITY.md) instead of a public issue.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,94 @@
+# Contributing to Madmail
+
+Thank you for helping improve Madmail, the Rust Chatmail relay for [Delta Chat](https://delta.chat).
+
+This document is the short path into the project. For a deeper tour of the codebase, see [`docs/project/`](docs/project/README.md) and especially [`docs/project/17-extend-and-contribute.md`](docs/project/17-extend-and-contribute.md).
+
+## How we work
+
+- **GitHub pull requests** are the normal way to propose changes.
+- **Issues** track bugs and enhancements: <https://github.com/themadorg/madmail/issues>
+- Design source of truth for significant behavior: [`docs/TDD/`](docs/TDD/).
+- Client and federation **interop with Madmail v1** matters; document intentional differences.
+
+## Development setup
+
+Requirements:
+
+- Rust (see `rust-version` in the root `Cargo.toml`)
+- System packages typically needed for builds: SQLite dev headers, `pkg-config`, Perl (see CI workflow)
+
+```bash
+git clone https://github.com/themadorg/madmail.git
+cd madmail
+cargo build -p chatmail
+cargo test --workspace
+```
+
+Operator install and local runs:
+
+- [Quick start](docs/project/user-guide/02-quick-start.md)
+- [Local development](docs/local-dev.md)
+
+## Quality bar (required before review)
+
+Run from the repo root:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+Or the Makefile targets used by maintainers (`make fmt`, `make lint`, and the relevant test subset).
+
+CI enforces **fmt**, **clippy (`-D warnings`)**, **tests**, and **cargo audit** on pull requests.
+
+## Pull requests
+
+1. Prefer **small, reviewable** changes (vertical slices over large mixed PRs).
+2. Use the [pull request template](.github/pull_request_template.md).
+3. Write a clear summary: what changed, why, and how you tested it.
+4. Use [Conventional Commits](https://www.conventionalcommits.org/) when practical (`feat:`, `fix:`, `docs:`, `test:`, `chore:`, …). Releases use semantic-release from these messages.
+5. Do **not** commit secrets, `data/`, `target/`, or `node_modules/`.
+
+### Tests
+
+- New behavior should include **automated tests** (unit next to the code, and/or E2E under `tests/`).
+- **Security-sensitive** changes (PGP gate, authentication, admin tokens, federation policy, logging / No-Log) **must** include tests that lock the security property, and must not leak sensitive detail in error messages.
+- Expand or update `docs/TDD/16-testing.md` when you change coverage expectations.
+
+### Documentation
+
+- Operator-visible behavior → update the user guide under `docs/project/user-guide/` when needed.
+- Design-level changes → update the matching TDD section under `docs/TDD/`.
+- Architecture / crate wiring → update `docs/project/` when the mental model changes.
+
+## Coding standards
+
+| Area | Expectation |
+|------|-------------|
+| Formatting | `rustfmt` (`cargo fmt --all`) |
+| Lints | `clippy` with `-D warnings` |
+| Style | Idiomatic Rust; prefer existing crate boundaries under `crates/` |
+| Safety | Avoid `unwrap()` on production hot paths; handle errors explicitly |
+| Security | Prefer allowlist validation on untrusted input; review crypto and auth carefully |
+
+## Submodules and reference trees
+
+- `external/madmail-admin-web` — UI work goes there; update the parent pointer when needed.
+- `context/*` — reference material. Prefer upstream fixes there rather than drive-by commits in this monorepo.
+
+## Security reports
+
+Do **not** open a public issue for undisclosed vulnerabilities. See [SECURITY.md](SECURITY.md).
+
+## Code of conduct
+
+Participation is governed by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Questions
+
+- Start with `docs/project/` and `docs/TDD/`.
+- Integration tests under `tests/` are executable examples of expected behavior.
+- Discussion and review happen on GitHub Issues and Pull Requests.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ More detail:
 - [IP vs domain deployment](docs/project/user-guide/11-deployment-ip-domain-certs.md)
 - [Local development](docs/local-dev.md)
 
+## Community
+
+- [Contributing](CONTRIBUTING.md) — setup, tests, PR expectations
+- [Security policy](SECURITY.md) — how to report vulnerabilities privately
+- [Code of Conduct](CODE_OF_CONDUCT.md)
+
 
 ## Documentation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,74 @@
+# Security Policy
+
+Madmail is a federated mail / Chatmail relay. Security issues can affect operator hosts, user accounts, and message integrity. We take reports seriously.
+
+## Supported versions
+
+We prioritize fixes for the **latest release** on the default branch (`main`) and the most recent tagged release on [GitHub Releases](https://github.com/themadorg/madmail/releases).
+
+Older release lines may receive fixes at maintainer discretion when the issue is severe and a patch is practical.
+
+## Reporting a vulnerability
+
+**Please do not file public GitHub issues for undisclosed security vulnerabilities.**
+
+### Preferred: private GitHub Security Advisories
+
+1. Open a **private vulnerability report** on this repository:  
+   <https://github.com/themadorg/madmail/security/advisories/new>
+2. Include as much of the following as you can:
+   - Affected version(s) or commit
+   - Component (e.g. SMTP submission, IMAP, admin API, PGP gate, federation `/mxdeliv`, upgrade path)
+   - Reproduction steps or a minimal proof of concept
+   - Impact (confidentiality, integrity, availability, multi-tenant abuse)
+   - Whether you plan to request a CVE
+
+If private advisories are unavailable for any reason, use a GitHub Security contact via the repository **Security** tab, or contact the maintainers through the organization channels listed on <https://github.com/themadorg>.
+
+## What to expect
+
+| Stage | Target |
+|-------|--------|
+| Initial acknowledgement | **Within 14 days** of a clear report |
+| Triage / severity | After we can reproduce or validate the issue |
+| Fix / advisory | Coordinated with the reporter when practical |
+| Public disclosure | Prefer after a fixed release is available, or on an agreed timeline |
+
+We may ask for more detail or a safer repro. You may request anonymity; otherwise we are happy to credit reporters in the advisory or release notes.
+
+## Scope (examples)
+
+In scope:
+
+- Authentication / authorization bypasses
+- Cross-user data access
+- Encryption-policy bypasses (e.g. unencrypted mail accepted as encrypted)
+- Open-relay or abuse-amplification issues on public listeners
+- Remote code execution, path traversal, or injection in server components
+- Failures in signed update / upgrade verification
+- Sensitive information leaks via logs, errors, or admin APIs
+
+Out of scope (unless they lead to a server compromise):
+
+- Issues only in third-party clients (e.g. Delta Chat) without a Madmail defect
+- Denial of service that requires unrealistic resource limits without a concrete bug
+- Reports that require physical access or full operator collusion on a correctly configured host
+- Social engineering of operators
+
+## Secure configuration notes
+
+Operators should follow the published guides:
+
+- [Privacy and security model](docs/project/user-guide/04-privacy-and-security.md)
+- [Quick start](docs/project/user-guide/02-quick-start.md)
+- [DNS and mail auth](docs/project/user-guide/12-dns-mail-auth.md)
+
+Keep the server updated (signed upgrade path is supported by the `madmail` binary). Prefer TLS, restrict admin exposure, and keep registration policy appropriate for your threat model.
+
+## Non-security bugs
+
+Use the public issue tracker: <https://github.com/themadorg/madmail/issues>
+
+## Thanks
+
+Responsible disclosure keeps operators and users safer. We appreciate the research community and operators who report issues carefully.

--- a/docs/project/17-extend-and-contribute.md
+++ b/docs/project/17-extend-and-contribute.md
@@ -1,5 +1,7 @@
 # 17 — Extending the Project & Contribution Guide
 
+> **Start here for pull requests:** the repository root [`CONTRIBUTING.md`](../../CONTRIBUTING.md) (setup, quality bar, security reporting). This page is the deeper map of where to change code.
+
 You have read the step-by-step tour. Now you want to change something.
 
 ## First Principles


### PR DESCRIPTION
## Summary

Adds the three standard community policy files expected by GitHub and OpenSSF Best Practices tooling:

- **`CONTRIBUTING.md`** — setup, quality bar (`fmt` / `clippy` / `test`), PR conventions, test expectations for security-sensitive changes (links to deeper `docs/project/17-extend-and-contribute.md`)
- **`SECURITY.md`** — private reporting via GitHub Security Advisories, scope, ≤14-day initial acknowledgement target
- **`CODE_OF_CONDUCT.md`** — Contributor Covenant v2.1

Also links all three from the README and cross-links the extend/contribute tour.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [x] Documentation only
- [ ] Build / CI / tooling
- [ ] Refactor (no functional change)

## Area

- [ ] SMTP
- [ ] IMAP
- [ ] Federation / delivery queue
- [ ] Authentication / JIT
- [ ] Admin API / admin web UI (`external/madmail-admin-web`)
- [ ] TURN / Iroh / proxy services
- [ ] Storage / quota / DB migrations
- [ ] Configuration / CLI
- [x] Docs (`docs/project/`, `docs/TDD/`, user guide)
- [x] Other: community / security process

## Testing

- [x] `cargo fmt --all -- --check` (N/A — docs only)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace` (or targeted crate/tests: <!-- list if subset -->)
- [x] Manual / E2E verification (describe below)

**Manual verification (if any):**

```text
# Files present at repo root; README links resolve in GitHub preview
# After merge: enable GitHub "Private vulnerability reporting" if not already on
```

## Documentation

- [ ] No doc updates needed
- [x] Updated operator/user docs (`docs/project/user-guide/`, install guides)
- [x] Updated developer docs (`docs/project/`)
- [ ] Updated or added TDD section (`docs/TDD/`)

## Security & privacy

- [ ] Not security-sensitive
- [x] Security-sensitive — added/updated tests for the security property
- [x] Reviewed error messages for information leakage

Publishes the vulnerability reporting process (no code change). Does not by itself fix product vulnerabilities.

## Commits

- `docs:` documentation

## Checklist

- [x] PR is focused and reviewable (small vertical slices preferred)
- [x] No secrets, `data/`, `target/`, or `node_modules/` committed
- [x] Submodule pointers updated if `external/madmail-admin-web` changed
- [x] Behavior parity with Madmail v1 considered (or intentional difference documented)