### PR TITLE
feat(versions): version manager, update latest, and versions CLI

### DIFF
--- a/crates/chatmail-config/src/cli.rs
+++ b/crates/chatmail-config/src/cli.rs
@@ -44,8 +44,11 @@ pub enum Command {
     /// Start the mail server (default).
     Run,
     /// Replace this executable from a signed local file or URL.
+    ///
+    /// Pass `latest` to download the current GitHub Releases asset for this host
+    /// (full signature, size, and preflight checks — same as an explicit URL).
     Upgrade {
-        /// Path to signed binary, or `http://` / `https://` URL to a raw binary or `.tar.gz` / `.tgz` archive.
+        /// Path to signed binary, `http(s)://` URL, or the keyword `latest` (GitHub Releases).
         #[arg(value_name = "PATH_OR_URL")]
         path_or_url: String,
         /// Allow HTTPS downloads with self-signed or otherwise untrusted TLS certificates.
@@ -57,8 +60,11 @@ pub enum Command {
         accept_unsafe_https: bool,
     },
     /// Replace this executable from a signed local file or URL (alias for `upgrade`).
+    ///
+    /// `madmail update latest` fetches the latest GitHub release for this OS/arch with
+    /// mandatory Ed25519 verification (TLS relax does not skip signatures).
     Update {
-        /// Path to signed binary, or `http://` / `https://` URL to a raw binary or `.tar.gz` / `.tgz` archive.
+        /// Path to signed binary, `http(s)://` URL, or the keyword `latest` (GitHub Releases).
         #[arg(value_name = "PATH_OR_URL")]
         path_or_url: String,
         /// Allow HTTPS downloads with self-signed or otherwise untrusted TLS certificates.
@@ -69,6 +75,9 @@ pub enum Command {
         #[arg(long = "accept-unsafe-https")]
         accept_unsafe_https: bool,
     },
+    /// Manage versioned installs under the platform install root (`/opt/madmail` or `%ProgramFiles%\\Madmail`).
+    #[command(subcommand)]
+    Versions(VersionsCommand),
     /// Display the admin API credentials.
     #[command(name = "admin-token")]
     AdminToken {
@@ -271,6 +280,46 @@ pub enum Command {
     /// Emit fish completion script (Madmail hidden helper).
     #[command(name = "generate-fish-completion", hide = true)]
     GenerateFishCompletion,
+}
+
+/// `madmail versions` — list / switch / prune versioned binaries.
+#[derive(Debug, Subcommand, Clone)]
+pub enum VersionsCommand {
+    /// List installed versions (add `--remote` for GitHub Releases metadata).
+    List {
+        /// Also show remote GitHub releases and compare to local installs (no binary download).
+        #[arg(long)]
+        remote: bool,
+    },
+    /// Print the active version id and path.
+    Current,
+    /// Activate an installed version (Ed25519 signature + host preflight required).
+    Use {
+        /// Version directory id (e.g. `2.20.0`).
+        version: String,
+    },
+    /// Delete oldest non-active versions beyond `--keep` (default 5).
+    Prune {
+        /// Number of non-active versions to retain.
+        #[arg(long)]
+        keep: Option<usize>,
+        /// Confirm deletion.
+        #[arg(long, short = 'y')]
+        yes: bool,
+    },
+    /// Remove one non-active version directory.
+    Remove {
+        /// Version directory id.
+        version: String,
+        /// Confirm deletion.
+        #[arg(long, short = 'y')]
+        yes: bool,
+    },
+    /// Print filesystem path for a version (default: active).
+    Path {
+        /// Optional version id.
+        version: Option<String>,
+    },
 }
 
 /// `madmail completion` — shell tab completion (clap_complete).
@@ -1182,5 +1231,93 @@ mod tests {
             cli.command,
             Some(Command::Openrelay(OpenrelayCommand::Disable))
         ));
+    }
+
+    #[test]
+    fn parses_update_latest_and_versions_list() {
+        let cli = Cli::try_parse_from(["madmail", "update", "latest"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Update {
+                path_or_url,
+                accept_unsafe_https: false
+            }) if path_or_url == "latest"
+        ));
+        let cli = Cli::try_parse_from(["madmail", "versions", "list", "--remote"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Versions(VersionsCommand::List { remote: true }))
+        ));
+        let cli = Cli::try_parse_from(["madmail", "versions", "use", "2.20.0"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Versions(VersionsCommand::Use { version })) if version == "2.20.0"
+        ));
+    }
+
+    #[test]
+    fn parses_upgrade_latest_and_versions_subcommands() {
+        let cli = Cli::try_parse_from(["madmail", "upgrade", "latest"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Upgrade {
+                path_or_url,
+                ..
+            }) if path_or_url == "latest"
+        ));
+
+        let cli = Cli::try_parse_from(["madmail", "versions", "list"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Versions(VersionsCommand::List { remote: false }))
+        ));
+
+        let cli = Cli::try_parse_from(["madmail", "versions", "current"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Versions(VersionsCommand::Current))
+        ));
+
+        let cli = Cli::try_parse_from(["madmail", "versions", "path"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Versions(VersionsCommand::Path { version: None }))
+        ));
+
+        let cli = Cli::try_parse_from(["madmail", "versions", "path", "2.1.0"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Versions(VersionsCommand::Path { version: Some(v) })) if v == "2.1.0"
+        ));
+
+        let cli =
+            Cli::try_parse_from(["madmail", "versions", "prune", "--keep", "3", "-y"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Versions(VersionsCommand::Prune {
+                keep: Some(3),
+                yes: true
+            }))
+        ));
+
+        let cli =
+            Cli::try_parse_from(["madmail", "versions", "remove", "1.0.0", "--yes"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Versions(VersionsCommand::Remove {
+                version,
+                yes: true
+            })) if version == "1.0.0"
+        ));
+    }
+
+    #[test]
+    fn versions_use_requires_version_arg() {
+        let err = Cli::try_parse_from(["madmail", "versions", "use"]).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("required") || msg.contains("VERSION") || msg.contains("version"),
+            "got: {msg}"
+        );
     }
 }

--- a/crates/chatmail-config/src/cli.rs
+++ b/crates/chatmail-config/src/cli.rs
@@ -1300,8 +1300,7 @@ mod tests {
             }))
         ));
 
-        let cli =
-            Cli::try_parse_from(["madmail", "versions", "remove", "1.0.0", "--yes"]).unwrap();
+        let cli = Cli::try_parse_from(["madmail", "versions", "remove", "1.0.0", "--yes"]).unwrap();
         assert!(matches!(
             cli.command,
             Some(Command::Versions(VersionsCommand::Remove {

--- a/crates/chatmail-config/src/lib.rs
+++ b/crates/chatmail-config/src/lib.rs
@@ -45,7 +45,7 @@ pub use cli::{
     FirewallCommand, LanguageCommand, OpenrelayCommand, PortCommand, PortServiceCommand,
     ProxyCommand, ProxySettingCommand, PushCommand, QueueCommand, RegistrationCommand,
     RegistrationTokensCommand, ServiceCommand, ServiceToggleCommand, SharingCommand, TasksCommand,
-    UninstallArgs, DEFAULT_WINDOWS_SERVICE_NAME, FIREWALL_RULE_PREFIX,
+    UninstallArgs, VersionsCommand, DEFAULT_WINDOWS_SERVICE_NAME, FIREWALL_RULE_PREFIX,
 };
 pub use client_mail::{
     build_dclogin_link, client_connect_host, effective_http_listen, effective_http_plain_listen,

--- a/crates/chatmail/src/ctl/dispatch.rs
+++ b/crates/chatmail/src/ctl/dispatch.rs
@@ -24,7 +24,7 @@ use super::{
     accounts, admin_token, admin_web, blocklist_cmd, certificate, delete_cmd, docs, endpoint_cache,
     federation, firewall_cmd, html, install, language, message_size, openrelay, port, proxy, push,
     queue_cmd, registration, registration_tokens, reload, service_cmd, service_toggle, sharing,
-    status_cmd, tasks, uninstall, version, webmail_cors,
+    status_cmd, tasks, uninstall, version, versions_cmd, webmail_cors,
 };
 
 pub async fn dispatch(cli: &Cli) -> Result<()> {
@@ -122,6 +122,7 @@ pub async fn dispatch(cli: &Cli) -> Result<()> {
         Some(Command::Completion(shell)) => docs::print_completion(shell),
         Some(Command::GenerateMan) => docs::print_generate_man(&cli.args),
         Some(Command::GenerateFishCompletion) => docs::print_generate_fish_completion(&cli.args),
+        Some(Command::Versions(cmd)) => versions_cmd::versions(&cli.args, cmd).await,
         Some(cmd) => not_implemented(cmd),
     }
 }
@@ -134,7 +135,7 @@ fn not_implemented(cmd: &Command) -> Result<()> {
          Implemented: run, upgrade, update, version, admin-token, admin-web, install, certificate, \
          accounts, ban-list, blocklist, create-user, delete, registration, openrelay, language, \
          html-export, html-serve, html-migrate, webimap, websmtp, webmail-cors, push, federation, registration-tokens, sharing, \
-         status, uninstall, service, firewall, endpoint-cache, port, proxy, reload, message-size, tasks, queue, completion"
+         status, uninstall, service, firewall, endpoint-cache, port, proxy, reload, message-size, tasks, queue, versions, completion"
     )))
 }
 
@@ -143,6 +144,7 @@ fn command_name(cmd: &Command) -> &'static str {
         Command::Run => "run",
         Command::Upgrade { .. } => "upgrade",
         Command::Update { .. } => "update",
+        Command::Versions(_) => "versions",
         Command::AdminToken { .. } => "admin-token",
         Command::AdminWeb { .. } => "admin-web",
         Command::Version => "version",

--- a/crates/chatmail/src/ctl/mod.rs
+++ b/crates/chatmail/src/ctl/mod.rs
@@ -54,6 +54,7 @@ mod tasks;
 mod uninstall;
 pub(crate) mod util;
 mod version;
+mod versions_cmd;
 mod webmail_cors;
 
 #[cfg(test)]

--- a/crates/chatmail/src/ctl/versions_cmd.rs
+++ b/crates/chatmail/src/ctl/versions_cmd.rs
@@ -146,11 +146,30 @@ fn use_cmd(args: &Args, root: &std::path::Path, version: &str) -> Result<()> {
     let out = CtlOut::from_args(args, "versions use");
     let id = version_manager::sanitize_version_id(version)?;
     let bin = version_binary_path(root, &id);
-    if !bin.is_file() {
-        return Err(ChatmailError::config(format!(
-            "version {id} not found at {}",
-            bin.display()
-        )));
+    // TDD: activation requires a regular file under versions/<id>/ — not a symlink
+    // (symlink would pass verify/preflight against the target while set_active
+    // still points at the symlink path).
+    match std::fs::symlink_metadata(&bin) {
+        Ok(meta) if meta.file_type().is_symlink() => {
+            return Err(ChatmailError::config(format!(
+                "version {id} binary at {} is a symlink; refusing to activate \
+                 (install a regular file under versions/{id}/)",
+                bin.display()
+            )));
+        }
+        Ok(meta) if meta.is_file() => {}
+        Ok(_) => {
+            return Err(ChatmailError::config(format!(
+                "version {id} binary at {} is not a regular file",
+                bin.display()
+            )));
+        }
+        Err(_) => {
+            return Err(ChatmailError::config(format!(
+                "version {id} not found at {}",
+                bin.display()
+            )));
+        }
     }
 
     // Mandatory signature check before stop/activate
@@ -186,15 +205,18 @@ fn use_cmd(args: &Args, root: &std::path::Path, version: &str) -> Result<()> {
     }
 
     if let Err(e) = preflight_binary_for_version_manager(&bin) {
-        // restore previous
-        if let Some(p) = prev.as_deref() {
-            let _ = set_active(root, p, &stable);
-        }
+        let restore_note = match prev.as_deref() {
+            Some(p) => match set_active(root, p, &stable) {
+                Ok(()) => format!("restored previous version {p}"),
+                Err(re) => format!("FAILED to restore previous version {p}: {re}"),
+            },
+            None => "no previous version to restore".to_string(),
+        };
         if manage_services {
             start_services_best_effort();
         }
         return Err(ChatmailError::config(format!(
-            "smoke check failed after switch; restored previous: {e}"
+            "smoke check failed after switch ({restore_note}): {e}"
         )));
     }
 
@@ -217,8 +239,8 @@ fn use_cmd(args: &Args, root: &std::path::Path, version: &str) -> Result<()> {
 fn prune_cmd(args: &Args, root: &std::path::Path, keep: Option<usize>, yes: bool) -> Result<()> {
     let out = CtlOut::from_args(args, "versions prune");
     let keep = keep.unwrap_or(version_manager::default_keep());
-    if !yes && !args.json {
-        // non-interactive require --yes for destructive
+    // Always require --yes for destructive ops (including --json automation).
+    if !yes {
         return Err(ChatmailError::config(
             "versions prune requires --yes to delete old versions",
         ));
@@ -236,7 +258,8 @@ fn prune_cmd(args: &Args, root: &std::path::Path, keep: Option<usize>, yes: bool
 
 fn remove_cmd(args: &Args, root: &std::path::Path, version: &str, yes: bool) -> Result<()> {
     let out = CtlOut::from_args(args, "versions remove");
-    if !yes && !args.json {
+    // Always require --yes (including with --json) to avoid accidental deletes.
+    if !yes {
         return Err(ChatmailError::config("versions remove requires --yes"));
     }
     version_manager::remove_version(root, version)?;

--- a/crates/chatmail/src/ctl/versions_cmd.rs
+++ b/crates/chatmail/src/ctl/versions_cmd.rs
@@ -65,10 +65,7 @@ fn list_cmd(args: &Args, root: &std::path::Path, remote: bool) -> Result<()> {
         if local.is_empty() {
             out.line("  (no versions installed)");
         } else {
-            out.line(format!(
-                "{:<12} {:<8} {}",
-                "VERSION", "ACTIVE", "PATH"
-            ));
+            out.line(format!("{:<12} {:<8} {}", "VERSION", "ACTIVE", "PATH"));
             for v in &local {
                 out.line(format!(
                     "{:<12} {:<8} {}",
@@ -83,12 +80,8 @@ fn list_cmd(args: &Args, root: &std::path::Path, remote: bool) -> Result<()> {
     }
 
     // --remote: metadata only (no binary download / no signature)
-    let remote_list = version_manager::fetch_remote_releases(false).or_else(|e| {
-        // allow TLS override only via global flag is not on Args here; fail clearly
-        Err(ChatmailError::config(format!(
-            "versions list --remote failed: {e}"
-        )))
-    })?;
+    let remote_list = version_manager::fetch_remote_releases(false)
+        .map_err(|e| ChatmailError::config(format!("versions list --remote failed: {e}")))?;
     let merged = merge_local_and_remote(&local, &remote_list);
     if out.is_json() {
         return out.emit(json!({
@@ -131,9 +124,7 @@ fn list_cmd(args: &Args, root: &std::path::Path, remote: bool) -> Result<()> {
 fn current_cmd(args: &Args, root: &std::path::Path) -> Result<()> {
     let out = CtlOut::from_args(args, "versions current");
     let active = resolve_active_version(root)?;
-    let path = active
-        .as_ref()
-        .map(|id| version_binary_path(root, id));
+    let path = active.as_ref().map(|id| version_binary_path(root, id));
     if out.is_json() {
         return out.emit(json!({
             "install_root": root,
@@ -234,7 +225,10 @@ fn prune_cmd(args: &Args, root: &std::path::Path, keep: Option<usize>, yes: bool
     }
     let removed = version_manager::prune(root, keep)?;
     out.done_msg(
-        format!("✅ Pruned {} version(s) (keep non-active={keep})", removed.len()),
+        format!(
+            "✅ Pruned {} version(s) (keep non-active={keep})",
+            removed.len()
+        ),
         json!({ "removed": removed, "keep": keep }),
         "Pruned old versions",
     )
@@ -243,9 +237,7 @@ fn prune_cmd(args: &Args, root: &std::path::Path, keep: Option<usize>, yes: bool
 fn remove_cmd(args: &Args, root: &std::path::Path, version: &str, yes: bool) -> Result<()> {
     let out = CtlOut::from_args(args, "versions remove");
     if !yes && !args.json {
-        return Err(ChatmailError::config(
-            "versions remove requires --yes",
-        ));
+        return Err(ChatmailError::config("versions remove requires --yes"));
     }
     version_manager::remove_version(root, version)?;
     out.done_msg(
@@ -273,7 +265,7 @@ fn path_cmd(args: &Args, root: &std::path::Path, version: Option<&str>) -> Resul
         return out.emit(json!({
             "path": path,
             "install_root": root,
-            "version_dir": version.and_then(|v| sanitize_ok(v)).map(|id| version_dir(root, &id)),
+            "version_dir": version.and_then(sanitize_ok).map(|id| version_dir(root, &id)),
         }));
     }
     out.line(path.display().to_string());

--- a/crates/chatmail/src/ctl/versions_cmd.rs
+++ b/crates/chatmail/src/ctl/versions_cmd.rs
@@ -1,0 +1,309 @@
+// Copyright (C) 2026 themadorg
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! `madmail versions` — list/use/prune versioned installs (TDD 24).
+
+use chatmail_config::{Args, VersionsCommand};
+use chatmail_types::{ChatmailError, Result};
+use serde_json::json;
+
+use crate::upgrade::{preflight_binary_for_version_manager, verify_signature};
+use crate::version_manager::{
+    self, default_stable_binary_path, install_root, list_installed, merge_local_and_remote,
+    resolve_active_version, set_active, version_binary_path, version_dir,
+};
+
+use super::output::CtlOut;
+
+pub async fn versions(args: &Args, cmd: &VersionsCommand) -> Result<()> {
+    // Filesystem + optional blocking HTTP (remote list).
+    let args = args.clone();
+    let cmd = cmd.clone();
+    tokio::task::spawn_blocking(move || versions_blocking(&args, &cmd))
+        .await
+        .map_err(|e| ChatmailError::config(format!("versions task failed: {e}")))?
+}
+
+fn versions_blocking(args: &Args, cmd: &VersionsCommand) -> Result<()> {
+    let root = install_root();
+    match cmd {
+        VersionsCommand::List { remote } => list_cmd(args, &root, *remote),
+        VersionsCommand::Current => current_cmd(args, &root),
+        VersionsCommand::Use { version } => use_cmd(args, &root, version),
+        VersionsCommand::Prune { keep, yes } => prune_cmd(args, &root, *keep, *yes),
+        VersionsCommand::Remove { version, yes } => remove_cmd(args, &root, version, *yes),
+        VersionsCommand::Path { version } => path_cmd(args, &root, version.as_deref()),
+    }
+}
+
+fn list_cmd(args: &Args, root: &std::path::Path, remote: bool) -> Result<()> {
+    let out = CtlOut::from_args(args, "versions list");
+    let local = list_installed(root)?;
+    if !remote {
+        if out.is_json() {
+            return out.emit(json!({
+                "install_root": root,
+                "versions": local,
+            }));
+        }
+        out.blank();
+        out.line(format!("Install root: {}", root.display()));
+        if local.is_empty() {
+            out.line("  (no versions installed)");
+        } else {
+            out.line(format!(
+                "{:<12} {:<8} {}",
+                "VERSION", "ACTIVE", "PATH"
+            ));
+            for v in &local {
+                out.line(format!(
+                    "{:<12} {:<8} {}",
+                    v.version,
+                    if v.active { "*" } else { "" },
+                    v.binary.display()
+                ));
+            }
+        }
+        out.blank();
+        return Ok(());
+    }
+
+    // --remote: metadata only (no binary download / no signature)
+    let remote_list = version_manager::fetch_remote_releases(false).or_else(|e| {
+        // allow TLS override only via global flag is not on Args here; fail clearly
+        Err(ChatmailError::config(format!(
+            "versions list --remote failed: {e}"
+        )))
+    })?;
+    let merged = merge_local_and_remote(&local, &remote_list);
+    if out.is_json() {
+        return out.emit(json!({
+            "install_root": root,
+            "remote": true,
+            "versions": merged,
+        }));
+    }
+    out.blank();
+    out.line(format!("Install root: {}", root.display()));
+    out.line(format!(
+        "{:<12} {:<8} {:<8} {}",
+        "VERSION", "SOURCE", "ACTIVE", "NOTES"
+    ));
+    for e in &merged {
+        let mut notes = Vec::new();
+        if e.remote_latest {
+            notes.push("remote latest");
+        }
+        if e.installed {
+            notes.push("installed");
+        } else {
+            notes.push("available");
+        }
+        if e.source == "local" {
+            notes.push("local-only");
+        }
+        out.line(format!(
+            "{:<12} {:<8} {:<8} {}",
+            e.version,
+            e.source,
+            if e.active { "*" } else { "" },
+            notes.join("; ")
+        ));
+    }
+    out.blank();
+    Ok(())
+}
+
+fn current_cmd(args: &Args, root: &std::path::Path) -> Result<()> {
+    let out = CtlOut::from_args(args, "versions current");
+    let active = resolve_active_version(root)?;
+    let path = active
+        .as_ref()
+        .map(|id| version_binary_path(root, id));
+    if out.is_json() {
+        return out.emit(json!({
+            "install_root": root,
+            "version": active,
+            "path": path,
+        }));
+    }
+    match (&active, &path) {
+        (Some(v), Some(p)) => {
+            out.line(format!("Active version: {v}"));
+            out.line(format!("Path: {}", p.display()));
+        }
+        _ => out.line("No active version under the install root."),
+    }
+    Ok(())
+}
+
+fn use_cmd(args: &Args, root: &std::path::Path, version: &str) -> Result<()> {
+    let out = CtlOut::from_args(args, "versions use");
+    let id = version_manager::sanitize_version_id(version)?;
+    let bin = version_binary_path(root, &id);
+    if !bin.is_file() {
+        return Err(ChatmailError::config(format!(
+            "version {id} not found at {}",
+            bin.display()
+        )));
+    }
+
+    // Mandatory signature check before stop/activate
+    eprintln!("🔍 Verifying digital signature for version {id}...");
+    match verify_signature(&bin)? {
+        true => eprintln!("✅ Signature verification successful."),
+        false => {
+            return Err(ChatmailError::config(
+                "INVALID SIGNATURE: cannot activate this version; refusing to switch",
+            ));
+        }
+    }
+
+    preflight_binary_for_version_manager(&bin)?;
+
+    let prev = resolve_active_version(root)?;
+    let stable = default_stable_binary_path();
+
+    // Service stop/start when not in unit-test layout (MADMAIL_INSTALL_ROOT alone still
+    // attempts services only if not skipped). Skip when root is under temp / non-default
+    // and MADMAIL_VERSION_MANAGER_NO_SERVICE is set, or always try best-effort systemctl.
+    let manage_services = std::env::var_os("MADMAIL_VERSION_MANAGER_NO_SERVICE").is_none();
+
+    if manage_services {
+        stop_services_best_effort();
+    }
+
+    if let Err(e) = set_active(root, &id, &stable) {
+        if manage_services {
+            start_services_best_effort();
+        }
+        return Err(e);
+    }
+
+    if let Err(e) = preflight_binary_for_version_manager(&bin) {
+        // restore previous
+        if let Some(p) = prev.as_deref() {
+            let _ = set_active(root, p, &stable);
+        }
+        if manage_services {
+            start_services_best_effort();
+        }
+        return Err(ChatmailError::config(format!(
+            "smoke check failed after switch; restored previous: {e}"
+        )));
+    }
+
+    if manage_services {
+        start_services_best_effort();
+    }
+
+    out.done_msg(
+        format!("✅ Active version is now {id}"),
+        json!({
+            "version": id,
+            "previous": prev,
+            "path": bin,
+            "signature_ok": true,
+        }),
+        format!("Active version is now {id}"),
+    )
+}
+
+fn prune_cmd(args: &Args, root: &std::path::Path, keep: Option<usize>, yes: bool) -> Result<()> {
+    let out = CtlOut::from_args(args, "versions prune");
+    let keep = keep.unwrap_or(version_manager::default_keep());
+    if !yes && !args.json {
+        // non-interactive require --yes for destructive
+        return Err(ChatmailError::config(
+            "versions prune requires --yes to delete old versions",
+        ));
+    }
+    let removed = version_manager::prune(root, keep)?;
+    out.done_msg(
+        format!("✅ Pruned {} version(s) (keep non-active={keep})", removed.len()),
+        json!({ "removed": removed, "keep": keep }),
+        "Pruned old versions",
+    )
+}
+
+fn remove_cmd(args: &Args, root: &std::path::Path, version: &str, yes: bool) -> Result<()> {
+    let out = CtlOut::from_args(args, "versions remove");
+    if !yes && !args.json {
+        return Err(ChatmailError::config(
+            "versions remove requires --yes",
+        ));
+    }
+    version_manager::remove_version(root, version)?;
+    out.done_msg(
+        format!("✅ Removed version {version}"),
+        json!({ "removed": version }),
+        format!("Removed version {version}"),
+    )
+}
+
+fn path_cmd(args: &Args, root: &std::path::Path, version: Option<&str>) -> Result<()> {
+    let out = CtlOut::from_args(args, "versions path");
+    let path = match version {
+        Some(v) => {
+            let id = version_manager::sanitize_version_id(v)?;
+            version_binary_path(root, &id)
+        }
+        None => {
+            let id = resolve_active_version(root)?.ok_or_else(|| {
+                ChatmailError::config("no active version; pass an explicit version")
+            })?;
+            version_binary_path(root, &id)
+        }
+    };
+    if out.is_json() {
+        return out.emit(json!({
+            "path": path,
+            "install_root": root,
+            "version_dir": version.and_then(|v| sanitize_ok(v)).map(|id| version_dir(root, &id)),
+        }));
+    }
+    out.line(path.display().to_string());
+    Ok(())
+}
+
+fn sanitize_ok(v: &str) -> Option<String> {
+    version_manager::sanitize_version_id(v).ok()
+}
+
+fn stop_services_best_effort() {
+    #[cfg(unix)]
+    {
+        let _ = std::process::Command::new("systemctl")
+            .args(["stop", "madmail.service"])
+            .status();
+        let _ = std::process::Command::new("systemctl")
+            .args(["stop", "chatmail.service"])
+            .status();
+    }
+}
+
+fn start_services_best_effort() {
+    #[cfg(unix)]
+    {
+        let _ = std::process::Command::new("systemctl")
+            .args(["start", "madmail.service"])
+            .status();
+        let _ = std::process::Command::new("systemctl")
+            .args(["start", "chatmail.service"])
+            .status();
+    }
+}

--- a/crates/chatmail/src/lib.rs
+++ b/crates/chatmail/src/lib.rs
@@ -31,3 +31,4 @@ pub mod supervisor;
 pub mod tls_boot;
 pub mod turn_boot;
 pub mod upgrade;
+pub mod version_manager;

--- a/crates/chatmail/src/upgrade.rs
+++ b/crates/chatmail/src/upgrade.rs
@@ -649,11 +649,9 @@ pub fn preflight_binary_for_version_manager(new_bin: &Path) -> Result<()> {
 
 fn capture_version_id(new_bin: &Path) -> String {
     match Command::new(new_bin).arg("version").output() {
-        Ok(o) if o.status.success() => {
-            crate::version_manager::parse_version_from_preflight_output(&String::from_utf8_lossy(
-                &o.stdout,
-            ))
-        }
+        Ok(o) if o.status.success() => crate::version_manager::parse_version_from_preflight_output(
+            &String::from_utf8_lossy(&o.stdout),
+        ),
         _ => crate::version_manager::parse_version_from_preflight_output(env!("CARGO_PKG_VERSION")),
     }
 }
@@ -887,10 +885,7 @@ pub fn perform_upgrade(new_bin_path: &Path, args: &Args) -> Result<()> {
             true
         }
         Err(e) => {
-            eprintln!(
-                "⚠️ Version tree install skipped ({}): {e}",
-                vroot.display()
-            );
+            eprintln!("⚠️ Version tree install skipped ({}): {e}", vroot.display());
             false
         }
     };
@@ -1313,9 +1308,7 @@ mod tests {
     #[test]
     fn upgrade_latest_keyword_resolves_github_url() {
         let url = crate::version_manager::github_latest_asset_url();
-        assert!(
-            url.starts_with("https://github.com/themadorg/madmail/releases/latest/download/")
-        );
+        assert!(url.starts_with("https://github.com/themadorg/madmail/releases/latest/download/"));
         assert!(url.contains("madmail"));
         // Keyword is handled before local-path open; empty/whitespace still rejected.
         assert!(upgrade_command("  ", &test_args(), false).is_err());

--- a/crates/chatmail/src/upgrade.rs
+++ b/crates/chatmail/src/upgrade.rs
@@ -642,9 +642,13 @@ const INSTALLED_EXEC_MODE: u32 = 0o755;
 /// Catches wrong-variant installs (default glibc build on older distros) **before**
 /// services are stopped or the live binary is replaced. Signature verification must
 /// already have passed — we only exec trusted, signed bytes.
-/// Host preflight for version-manager activation (`versions use` / install into tree).
+/// Host preflight for live archives under the version tree (`versions use`).
+///
+/// Uses [`BinaryExecLocation::Installed`] (`0755`) so a successful switch does not
+/// leave `versions/<id>/madmail` owner-only (`0700`). Staging downloads still use
+/// [`preflight_new_binary`] with [`BinaryExecLocation::Staging`] in the upgrade path.
 pub fn preflight_binary_for_version_manager(new_bin: &Path) -> Result<()> {
-    preflight_new_binary(new_bin, BinaryExecLocation::Staging)
+    preflight_new_binary(new_bin, BinaryExecLocation::Installed)
 }
 
 fn capture_version_id(new_bin: &Path) -> String {
@@ -1423,6 +1427,23 @@ mod tests {
             "installed mode must be 0755, got {mode:#o}"
         );
         assert_ne!(mode, STAGING_EXEC_MODE);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn preflight_for_version_manager_keeps_world_executable() {
+        // `versions use` must not chmod archived binaries to 0700 (non-root User=).
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dir.path().join("madmail");
+        fs::write(&bin, b"#!/bin/sh\necho 'madmail 2.20.0'\n").unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&bin, fs::Permissions::from_mode(0o600)).unwrap();
+        preflight_binary_for_version_manager(&bin).unwrap();
+        let mode = fs::metadata(&bin).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, INSTALLED_EXEC_MODE,
+            "versions use preflight must leave 0755, got {mode:#o}"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/chatmail/src/upgrade.rs
+++ b/crates/chatmail/src/upgrade.rs
@@ -333,8 +333,19 @@ fn extract_binary_from_tar_gz(archive_path: &Path, dest: &Path) -> Result<()> {
 pub fn upgrade_command(input: &str, args: &Args, accept_unsafe_https: bool) -> Result<()> {
     let input = input.trim();
     if input.is_empty() {
-        return Err(ChatmailError::config("PATH or URL is required"));
+        return Err(ChatmailError::config(
+            "PATH, URL, or the keyword `latest` is required",
+        ));
     }
+    // `update latest` / `upgrade latest` → GitHub Releases for this host (same security as URL).
+    let resolved_latest;
+    let input = if input.eq_ignore_ascii_case("latest") {
+        resolved_latest = crate::version_manager::github_latest_asset_url();
+        eprintln!("📦 Resolving GitHub latest: {resolved_latest}");
+        resolved_latest.as_str()
+    } else {
+        input
+    };
     let result = if is_download_url(input) {
         handle_update_url(input, args, accept_unsafe_https)
     } else {
@@ -631,6 +642,47 @@ const INSTALLED_EXEC_MODE: u32 = 0o755;
 /// Catches wrong-variant installs (default glibc build on older distros) **before**
 /// services are stopped or the live binary is replaced. Signature verification must
 /// already have passed — we only exec trusted, signed bytes.
+/// Host preflight for version-manager activation (`versions use` / install into tree).
+pub fn preflight_binary_for_version_manager(new_bin: &Path) -> Result<()> {
+    preflight_new_binary(new_bin, BinaryExecLocation::Staging)
+}
+
+fn capture_version_id(new_bin: &Path) -> String {
+    match Command::new(new_bin).arg("version").output() {
+        Ok(o) if o.status.success() => {
+            crate::version_manager::parse_version_from_preflight_output(&String::from_utf8_lossy(
+                &o.stdout,
+            ))
+        }
+        _ => crate::version_manager::parse_version_from_preflight_output(env!("CARGO_PKG_VERSION")),
+    }
+}
+
+fn install_into_version_tree(src: &Path, version_id: &str, root: &Path) -> Result<()> {
+    use crate::version_manager::{install_candidate, VersionMeta};
+    let meta = VersionMeta {
+        version: version_id.to_string(),
+        installed_at: Some(chrono_like_now()),
+        source: Some("upgrade".into()),
+        source_url: None,
+        sha256: None,
+        variant: None,
+        os: Some(std::env::consts::OS.to_string()),
+        signature_ok: Some(true),
+    };
+    install_candidate(root, version_id, src, meta)?;
+    Ok(())
+}
+
+fn chrono_like_now() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    format!("{secs}")
+}
+
 fn preflight_new_binary(new_bin: &Path, location: BinaryExecLocation) -> Result<()> {
     #[cfg(unix)]
     {
@@ -807,6 +859,9 @@ pub fn perform_upgrade(new_bin_path: &Path, args: &Args) -> Result<()> {
     // Abort early (services still up, live binary untouched) if this host cannot run it.
     preflight_new_binary(new_bin_path, BinaryExecLocation::Staging)?;
 
+    // Capture version id for the version tree (TDD 24).
+    let version_id = capture_version_id(new_bin_path);
+
     let current_bin = std::env::current_exe()
         .map_err(|e| ChatmailError::config(format!("failed to get current executable: {e}")))?;
     let real_bin_path = fs::canonicalize(&current_bin).unwrap_or(current_bin);
@@ -819,6 +874,26 @@ pub fn perform_upgrade(new_bin_path: &Path, args: &Args) -> Result<()> {
             "upgrade must be run as root (sudo) to manage services and replace the binary",
         ));
     }
+
+    // Install into platform version tree first (non-fatal if root is not writable yet).
+    // Active pointer is updated only after a successful live replace (below).
+    let vroot = crate::version_manager::install_root();
+    let version_tree_ok = match install_into_version_tree(new_bin_path, &version_id, &vroot) {
+        Ok(()) => {
+            eprintln!(
+                "📦 Archived binary under {}/versions/{version_id}/",
+                vroot.display()
+            );
+            true
+        }
+        Err(e) => {
+            eprintln!(
+                "⚠️ Version tree install skipped ({}): {e}",
+                vroot.display()
+            );
+            false
+        }
+    };
 
     // Keep a runnable previous binary so a post-replace failure can recover in-band.
     let backup = backup_current_binary(&real_bin_path)?;
@@ -919,6 +994,15 @@ pub fn perform_upgrade(new_bin_path: &Path, args: &Args) -> Result<()> {
     }
 
     refresh_cli_docs_after_upgrade();
+
+    if version_tree_ok {
+        let stable = crate::version_manager::default_stable_binary_path();
+        if let Err(e) = crate::version_manager::set_active(&vroot, &version_id, &stable) {
+            eprintln!("⚠️ Could not update version-manager active pointer: {e}");
+        } else {
+            eprintln!("🔗 Active version pointer set to {version_id}");
+        }
+    }
 
     eprintln!(
         "🎉 Upgrade complete. (previous binary kept at {} for manual rollback if needed)",
@@ -1219,7 +1303,98 @@ mod tests {
     #[test]
     fn upgrade_command_requires_input() {
         let err = upgrade_command("  ", &test_args(), false).unwrap_err();
-        assert!(err.to_string().contains("PATH or URL is required"));
+        let msg = err.to_string();
+        assert!(
+            msg.contains("PATH") || msg.contains("required") || msg.contains("latest"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn upgrade_latest_keyword_resolves_github_url() {
+        let url = crate::version_manager::github_latest_asset_url();
+        assert!(
+            url.starts_with("https://github.com/themadorg/madmail/releases/latest/download/")
+        );
+        assert!(url.contains("madmail"));
+        // Keyword is handled before local-path open; empty/whitespace still rejected.
+        assert!(upgrade_command("  ", &test_args(), false).is_err());
+    }
+
+    #[test]
+    fn capture_version_id_from_script() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dir.path().join("madmail");
+        fs::write(&bin, b"#!/bin/sh\necho madmail-v2 4.5.6\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        assert_eq!(capture_version_id(&bin), "4.5.6");
+    }
+
+    #[test]
+    fn install_into_version_tree_writes_binary_and_meta() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("opt-madmail");
+        let src = dir.path().join("payload");
+        fs::write(&src, b"#!/bin/sh\necho madmail-v2 1.2.3\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&src, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        install_into_version_tree(&src, "1.2.3", &root).unwrap();
+        let bin = crate::version_manager::version_binary_path(&root, "1.2.3");
+        assert!(bin.is_file());
+        let meta = crate::version_manager::read_meta(&root, "1.2.3")
+            .unwrap()
+            .expect("meta");
+        assert_eq!(meta.version, "1.2.3");
+        assert_eq!(meta.signature_ok, Some(true));
+        assert_eq!(meta.source.as_deref(), Some("upgrade"));
+    }
+
+    #[test]
+    fn unsigned_binary_fails_verify_before_version_tree() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dir.path().join("madmail");
+        // Large enough to not trip "too small for signature", but unsigned.
+        let mut payload = vec![0u8; 128];
+        payload[..8].copy_from_slice(b"unsigned");
+        fs::write(&bin, &payload).unwrap();
+        assert!(!verify_signature(&bin).unwrap());
+    }
+
+    #[test]
+    fn signed_binary_passes_verify_for_version_activation() {
+        let Some(key) = official_private_key_path() else {
+            eprintln!("skip: official private key not available");
+            return;
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dir.path().join("madmail");
+        // Script body + signature trailer; shell ignores trailing bytes after script.
+        fs::write(
+            &bin,
+            b"#!/bin/sh\nif [ \"$1\" = version ]; then echo madmail-v2 0.0.1; fi\nexit 0\n",
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        sign_with_official_key(&bin, &key);
+        assert!(verify_signature(&bin).unwrap());
+        preflight_binary_for_version_manager(&bin).unwrap();
+
+        // Install into tree and confirm signature still verifies on archived copy.
+        let root = dir.path().join("root");
+        install_into_version_tree(&bin, "0.0.1", &root).unwrap();
+        let archived = crate::version_manager::version_binary_path(&root, "0.0.1");
+        assert!(verify_signature(&archived).unwrap());
     }
 
     #[test]

--- a/crates/chatmail/src/upgrade.rs
+++ b/crates/chatmail/src/upgrade.rs
@@ -880,13 +880,15 @@ pub fn perform_upgrade(new_bin_path: &Path, args: &Args) -> Result<()> {
     let stable = crate::version_manager::default_stable_binary_path();
 
     // Prefer version-tree install + pointer flip (no write into versions/<old>/).
+    // Probe install root while services are still up; only stop after a successful
+    // archive write so a non-writable tree falls back to legacy cleanly.
     match install_into_version_tree(new_bin_path, &version_id, &vroot) {
         Ok(()) => {
             eprintln!(
                 "📦 Installed candidate under {}/versions/{version_id}/",
                 vroot.display()
             );
-            return perform_upgrade_versioned(&version_id, &vroot, &stable, args);
+            return finish_versioned_upgrade(&version_id, &vroot, &stable, args);
         }
         Err(e) => {
             eprintln!(
@@ -899,19 +901,16 @@ pub fn perform_upgrade(new_bin_path: &Path, args: &Args) -> Result<()> {
     perform_upgrade_legacy_inplace(new_bin_path, &vroot, args)
 }
 
-/// Versioned upgrade after the candidate is already under `versions/<id>/`.
-///
-/// Only flips active pointers; never copies over an older version directory.
-fn perform_upgrade_versioned(
+/// Stop services, flip active pointer, smoke, start services (candidate already archived).
+fn finish_versioned_upgrade(
     version_id: &str,
     vroot: &Path,
     stable: &Path,
     args: &Args,
 ) -> Result<()> {
-    use crate::version_manager::{resolve_active_version, set_active, version_binary_path};
+    use crate::version_manager::version_binary_path;
 
     let installed_bin = version_binary_path(vroot, version_id);
-    let prev = resolve_active_version(vroot)?;
 
     eprintln!(
         "🚀 Versioned activate: {} (stable entry {})",
@@ -926,22 +925,16 @@ fn perform_upgrade_versioned(
     thread::sleep(Duration::from_secs(1));
 
     eprintln!("🔗 Switching active version to {version_id}...");
-    if let Err(e) = set_active(vroot, version_id, stable) {
-        eprintln!("▶️ Starting services after failed activate...");
-        let _ = systemctl_succeeded(&["start", &service]);
-        return Err(e);
-    }
-
-    // Smoke on the versioned regular file (not only via the PATH symlink).
-    if let Err(e) = preflight_new_binary(&installed_bin, BinaryExecLocation::Installed) {
-        let restore_note = restore_previous_active(vroot, prev.as_deref(), stable);
-        eprintln!("▶️ Restarting services after failed smoke check...");
-        let _ = systemctl_succeeded(&["start", &service]);
-        return Err(ChatmailError::config(format!(
-            "upgrade rolled back: installed binary failed smoke check: {e}\n\
-             {restore_note}\n{VARIANT_HINT}"
-        )));
-    }
+    let prev = match activate_versioned_install(version_id, vroot, stable) {
+        Ok(prev) => prev,
+        Err(e) => {
+            eprintln!("▶️ Starting services after failed activate...");
+            let _ = systemctl_succeeded(&["start", &service]);
+            return Err(ChatmailError::config(format!(
+                "upgrade rolled back: {e}\n{VARIANT_HINT}"
+            )));
+        }
+    };
 
     run_post_upgrade_www_migrate(&installed_bin, args);
 
@@ -984,7 +977,6 @@ fn perform_upgrade_versioned(
     }
 
     refresh_cli_docs_after_upgrade();
-
     eprintln!(
         "🎉 Upgrade complete. Active version {version_id} (previous: {:?}).",
         prev
@@ -1004,12 +996,163 @@ fn restore_previous_active(vroot: &Path, prev: Option<&str>, stable: &Path) -> S
     }
 }
 
-/// True if `path` is under `{root}/versions/` (after canonicalize when possible).
-fn path_is_under_version_tree(path: &Path, root: &Path) -> bool {
+/// True if resolving `path` (following symlinks) lands under `{root}/versions/`.
+///
+/// After the first versioned upgrade, the stable PATH entry is a symlink into the
+/// tree, so `canonicalize(stable)` is under `versions/` even though the *entry*
+/// lives outside it (e.g. `/usr/local/bin/madmail`).
+fn path_resolves_into_version_tree(path: &Path, root: &Path) -> bool {
     let versions = crate::version_manager::versions_dir(root);
     let versions_real = fs::canonicalize(&versions).unwrap_or_else(|_| versions.clone());
     let path_real = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
-    path_real.starts_with(&versions_real) || path.starts_with(&versions)
+    path_real.starts_with(&versions_real)
+}
+
+/// True if the path **entry** itself lives under `{root}/versions/` (no follow of
+/// the final component). Used to refuse writing *into* the archive tree.
+fn path_entry_is_under_version_tree(path: &Path, root: &Path) -> bool {
+    let versions = crate::version_manager::versions_dir(root);
+    let versions_real = fs::canonicalize(&versions).unwrap_or_else(|_| versions.clone());
+    // Absolute-ize without following a final symlink: canonicalize the parent,
+    // then join the file name.
+    if let Some(parent) = path.parent() {
+        if parent.as_os_str().is_empty() {
+            return false;
+        }
+        let parent_real = fs::canonicalize(parent).unwrap_or_else(|_| parent.to_path_buf());
+        if parent_real.starts_with(&versions_real) {
+            return true;
+        }
+    }
+    path.starts_with(&versions) || path.starts_with(&versions_real)
+}
+
+/// Choose the filesystem path to replace for a legacy (non-version-tree) upgrade.
+///
+/// After `set_active`, `current_bin` often resolves into `versions/<old>/`. Writing
+/// there clobbers history. Prefer the stable PATH **entry** (symlink/file node)
+/// outside the tree so replace unlinks the symlink instead of writing through it.
+///
+/// Returns an error only when every candidate would write into the version tree.
+fn legacy_upgrade_replace_target(
+    current_bin: &Path,
+    vroot: &Path,
+    stable: &Path,
+) -> Result<PathBuf> {
+    let canonical = fs::canonicalize(current_bin).unwrap_or_else(|_| current_bin.to_path_buf());
+
+    // Safe: replace path is outside the archive tree.
+    if !path_resolves_into_version_tree(&canonical, vroot)
+        && !path_entry_is_under_version_tree(&canonical, vroot)
+    {
+        return Ok(canonical);
+    }
+
+    // Current exe resolved into versions/ — use stable PATH entry if its *location*
+    // is outside the tree (even when it is a symlink whose target is inside).
+    if !path_entry_is_under_version_tree(stable, vroot) {
+        return Ok(stable.to_path_buf());
+    }
+
+    // Last resort: non-canonical current_exe path if it is not under versions/.
+    if !path_entry_is_under_version_tree(current_bin, vroot) {
+        return Ok(current_bin.to_path_buf());
+    }
+
+    Err(ChatmailError::config(format!(
+        "refusing to clobber version-tree binary at {}; \
+         fix permissions on {} so upgrades can install via install_candidate",
+        canonical.display(),
+        vroot.display()
+    )))
+}
+
+/// Flip `current` + stable PATH to `version_id` and smoke-check (no systemd).
+///
+/// Candidate must already be installed under `versions/<id>/`. Never writes into
+/// an older version directory.
+fn activate_versioned_install(
+    version_id: &str,
+    vroot: &Path,
+    stable: &Path,
+) -> Result<Option<String>> {
+    use crate::version_manager::{resolve_active_version, set_active, version_binary_path};
+
+    let installed_bin = version_binary_path(vroot, version_id);
+    let prev = resolve_active_version(vroot)?;
+
+    set_active(vroot, version_id, stable).map_err(|e| {
+        ChatmailError::config(format!(
+            "failed to activate version {version_id} at {}: {e}",
+            installed_bin.display()
+        ))
+    })?;
+
+    if let Err(e) = preflight_new_binary(&installed_bin, BinaryExecLocation::Installed) {
+        let restore_note = restore_previous_active(vroot, prev.as_deref(), stable);
+        return Err(ChatmailError::config(format!(
+            "installed binary failed smoke check: {e} ({restore_note})"
+        )));
+    }
+    Ok(prev)
+}
+
+/// Install candidate into the version tree and flip active pointers (no systemd).
+///
+/// Dual-upgrade-safe core used by tests; production uses install +
+/// [`activate_versioned_install`] after the service stop window.
+#[cfg(test)]
+fn apply_versioned_install_and_activate(
+    new_bin_path: &Path,
+    version_id: &str,
+    vroot: &Path,
+    stable: &Path,
+) -> Result<Option<String>> {
+    install_into_version_tree(new_bin_path, version_id, vroot)?;
+    activate_versioned_install(version_id, vroot, stable)
+}
+
+/// Replace a PATH entry (file or symlink) with `new_bin` **without** following a
+/// symlink into the version tree (unlink the entry first when it is a symlink).
+fn replace_path_entry_without_following(new_bin: &Path, dest: &Path) -> Result<()> {
+    let parent = dest
+        .parent()
+        .ok_or_else(|| ChatmailError::config("replace path has no parent"))?;
+    fs::create_dir_all(parent)
+        .map_err(|e| ChatmailError::config(format!("mkdir {}: {e}", parent.display())))?;
+    let tmp = parent.join(format!(".madmail-replace-{}", std::process::id()));
+    {
+        let mut src = File::open(new_bin)
+            .map_err(|e| ChatmailError::config(format!("open {}: {e}", new_bin.display())))?;
+        let mut dst = File::create(&tmp)
+            .map_err(|e| ChatmailError::config(format!("create {}: {e}", tmp.display())))?;
+        io::copy(&mut src, &mut dst)
+            .map_err(|e| ChatmailError::config(format!("copy replace staging: {e}")))?;
+        dst.sync_all()
+            .map_err(|e| ChatmailError::config(format!("sync replace staging: {e}")))?;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&tmp, fs::Permissions::from_mode(INSTALLED_EXEC_MODE))
+            .map_err(|e| ChatmailError::config(format!("chmod replace staging: {e}")))?;
+    }
+    // Replace the entry node: if `dest` is a symlink into versions/, remove it
+    // first so rename does not write through to the archive.
+    if dest
+        .symlink_metadata()
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false)
+    {
+        fs::remove_file(dest).map_err(|e| {
+            ChatmailError::config(format!("unlink symlink {}: {e}", dest.display()))
+        })?;
+    }
+    fs::rename(&tmp, dest).map_err(|e| {
+        let _ = fs::remove_file(&tmp);
+        ChatmailError::config(format!("replace entry {}: {e}", dest.display()))
+    })?;
+    Ok(())
 }
 
 /// Legacy single-file replace used when the version tree is not writable.
@@ -1018,26 +1161,8 @@ fn path_is_under_version_tree(path: &Path, root: &Path) -> bool {
 fn perform_upgrade_legacy_inplace(new_bin_path: &Path, vroot: &Path, args: &Args) -> Result<()> {
     let current_bin = std::env::current_exe()
         .map_err(|e| ChatmailError::config(format!("failed to get current executable: {e}")))?;
-    // Do not follow a PATH symlink into the version tree — that is how dual-upgrade
-    // clobbered `versions/<old>/madmail`. Prefer the non-canonical current_exe when
-    // canonicalize would land under versions/.
-    let canonical = fs::canonicalize(&current_bin).unwrap_or_else(|_| current_bin.clone());
-    let real_bin_path = if path_is_under_version_tree(&canonical, vroot) {
-        // Stable PATH entry without following into versions/ when possible.
-        let stable = crate::version_manager::default_stable_binary_path();
-        if path_is_under_version_tree(&stable, vroot) {
-            return Err(ChatmailError::config(format!(
-                "refusing to clobber version-tree binary at {}; \
-                 fix permissions on {} so upgrades can install via install_candidate",
-                canonical.display(),
-                vroot.display()
-            )));
-        }
-        // Replace the stable entry itself (symlink or file), not its target under versions/.
-        stable
-    } else {
-        canonical
-    };
+    let stable = crate::version_manager::default_stable_binary_path();
+    let real_bin_path = legacy_upgrade_replace_target(&current_bin, vroot, &stable)?;
 
     eprintln!(
         "🚀 Target binary (legacy in-place): {}",
@@ -1055,44 +1180,12 @@ fn perform_upgrade_legacy_inplace(new_bin_path: &Path, vroot: &Path, args: &Args
     thread::sleep(Duration::from_secs(1));
 
     eprintln!("🔄 Replacing binary...");
-    let tmp_dir = real_bin_path
-        .parent()
-        .ok_or_else(|| ChatmailError::config("executable has no parent directory"))?;
-
-    let tmp_path = tmp_dir.join(format!(".chatmail-upgrade-{}", std::process::id()));
-
-    {
-        let mut src = File::open(new_bin_path)?;
-        let mut dst = File::create(&tmp_path)?;
-        io::copy(&mut src, &mut dst)?;
-        dst.sync_all()?;
-    }
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        // Install path must stay 0755 so systemd User=madmail can exec (issue #131).
-        fs::set_permissions(&tmp_path, fs::Permissions::from_mode(INSTALLED_EXEC_MODE))?;
-    }
-
-    // If the install path is a symlink into versions/, replace the symlink node
-    // itself with a regular file rather than writing through to the archive.
-    if real_bin_path
-        .symlink_metadata()
-        .map(|m| m.file_type().is_symlink())
-        .unwrap_or(false)
-    {
-        let _ = fs::remove_file(&real_bin_path);
-    }
-
-    if let Err(e) = fs::rename(&tmp_path, &real_bin_path) {
-        let _ = fs::remove_file(&tmp_path);
-        // Live binary should still be the old one if rename failed; try to keep services up.
+    // Never write through a symlink into versions/<old>/ — unlink the PATH entry
+    // first when needed (see replace_path_entry_without_following).
+    if let Err(e) = replace_path_entry_without_following(new_bin_path, &real_bin_path) {
         eprintln!("▶️ Starting services after failed replace...");
         let _ = systemctl_succeeded(&["start", &service]);
-        return Err(ChatmailError::config(format!(
-            "failed to replace binary: {e}"
-        )));
+        return Err(e);
     }
 
     // Belt-and-suspenders: re-smoke the installed path (catches corrupt write).
@@ -1505,99 +1598,206 @@ mod tests {
         assert_eq!(meta.source.as_deref(), Some("upgrade"));
     }
 
+    fn write_version_script(path: &Path, version: &str, marker: &str) {
+        let body = format!(
+            "#!/bin/sh\nif [ \"$1\" = version ]; then echo madmail-v2 {version}; fi\necho {marker}\nexit 0\n"
+        );
+        fs::write(path, body.as_bytes()).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+    }
+
     #[test]
-    fn path_is_under_version_tree_detects_archived_binary() {
+    fn path_tree_helpers_distinguish_symlink_entry_from_target() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().join("opt");
         let versions = crate::version_manager::versions_dir(&root);
         let archived = versions.join("2.18.2").join("madmail");
         fs::create_dir_all(archived.parent().unwrap()).unwrap();
         fs::write(&archived, b"old").unwrap();
-        assert!(path_is_under_version_tree(&archived, &root));
-        let outside = dir.path().join("usr-local-bin-madmail");
+
+        assert!(path_resolves_into_version_tree(&archived, &root));
+        assert!(path_entry_is_under_version_tree(&archived, &root));
+
+        let outside = dir.path().join("outside-madmail");
         fs::write(&outside, b"live").unwrap();
-        assert!(!path_is_under_version_tree(&outside, &root));
+        assert!(!path_resolves_into_version_tree(&outside, &root));
+        assert!(!path_entry_is_under_version_tree(&outside, &root));
+
+        // Stable PATH symlink into the tree: resolves into tree, but entry is outside.
+        let stable = dir.path().join("bin").join("madmail");
+        fs::create_dir_all(stable.parent().unwrap()).unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&archived, &stable).unwrap();
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_file(&archived, &stable).unwrap();
+
+        assert!(
+            path_resolves_into_version_tree(&stable, &root),
+            "canonicalize(stable) must land under versions/"
+        );
+        assert!(
+            !path_entry_is_under_version_tree(&stable, &root),
+            "stable PATH entry itself must not be considered under versions/"
+        );
     }
 
-    /// Simulate upgrade #1 then #2 via install_candidate + set_active (the versioned
-    /// path `perform_upgrade` uses). Prior version bytes must stay intact.
+    /// Full dual-upgrade regression for review #136:
+    /// 1) install+activate v1 (PATH becomes symlink into versions/v1)
+    /// 2) install+activate v2 via the same core as perform_upgrade
+    /// 3) v1 bytes must stay bit-identical
+    /// 4) legacy replace target must be the stable *entry*, not versions/v1
+    /// 5) legacy replace of the stable entry must not clobber v1
+    /// 6) document that write-through canonicalize(stable) would destroy v1
     #[test]
-    fn dual_upgrade_versioned_path_preserves_prior_archive() {
-        use crate::version_manager::{
-            install_candidate, set_active, version_binary_path, VersionMeta,
-        };
+    fn dual_upgrade_preserves_prior_archive_and_legacy_target() {
+        use crate::version_manager::{resolve_active_version, version_binary_path};
+
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().join("opt-madmail");
         let stable = dir.path().join("usr-local-bin").join("madmail");
         fs::create_dir_all(stable.parent().unwrap()).unwrap();
 
-        let v1 = dir.path().join("v1");
-        let v2 = dir.path().join("v2");
-        fs::write(&v1, b"ARCHIVE-V1-BYTES").unwrap();
-        fs::write(&v2, b"ARCHIVE-V2-BYTES").unwrap();
+        let v1_src = dir.path().join("payload-v1");
+        let v2_src = dir.path().join("payload-v2");
+        write_version_script(&v1_src, "2.18.2", "MARKER-V1");
+        write_version_script(&v2_src, "2.20.0", "MARKER-V2");
+
+        // --- Upgrade #1 (versioned core) ---
+        let prev1 =
+            apply_versioned_install_and_activate(&v1_src, "2.18.2", &root, &stable).unwrap();
+        assert_eq!(prev1, None);
+        assert_eq!(
+            resolve_active_version(&root).unwrap().as_deref(),
+            Some("2.18.2")
+        );
+        let v1_path = version_binary_path(&root, "2.18.2");
+        let v1_bytes = fs::read(&v1_path).unwrap();
+        assert!(
+            String::from_utf8_lossy(&v1_bytes).contains("MARKER-V1"),
+            "v1 archive should contain marker"
+        );
+
+        // After activate, PATH entry is a symlink into the version tree — the
+        // dangerous canonicalize target that the old upgrade used.
+        let meta = fs::symlink_metadata(&stable).unwrap();
+        assert!(
+            meta.file_type().is_symlink(),
+            "stable PATH must be a symlink after set_active"
+        );
+        let clobber_target = fs::canonicalize(&stable).unwrap();
+        assert!(
+            path_resolves_into_version_tree(&clobber_target, &root),
+            "canonicalize(stable) should resolve under versions/"
+        );
+        assert_eq!(
+            clobber_target,
+            fs::canonicalize(&v1_path).unwrap(),
+            "stable should resolve to the v1 archive binary"
+        );
+
+        // Legacy replace target must be the stable entry, NOT the archive path.
+        let replace_target = legacy_upgrade_replace_target(&stable, &root, &stable).unwrap();
+        assert_eq!(
+            replace_target, stable,
+            "must replace the PATH entry, not versions/<old>/madmail"
+        );
+        assert!(
+            !path_entry_is_under_version_tree(&replace_target, &root),
+            "replace target entry must live outside the version tree"
+        );
+
+        // --- Document the old bug: write-through would destroy v1 ---
+        // (do not leave this state — restore immediately after the assert setup)
+        let destroyed_probe = dir.path().join("would-clobber");
+        fs::write(&destroyed_probe, b"V2-OVERWRITE").unwrap();
+        // Simulate old code: copy onto canonicalize(stable)
+        fs::copy(&destroyed_probe, &clobber_target).unwrap();
+        assert_ne!(
+            fs::read(&v1_path).unwrap(),
+            v1_bytes,
+            "sanity: writing through canonicalize(stable) must clobber v1"
+        );
+        // Restore v1 archive for the real dual-upgrade path
+        fs::write(&v1_path, &v1_bytes).unwrap();
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            fs::set_permissions(&v1, fs::Permissions::from_mode(0o755)).unwrap();
-            fs::set_permissions(&v2, fs::Permissions::from_mode(0o755)).unwrap();
+            fs::set_permissions(&v1_path, fs::Permissions::from_mode(0o755)).unwrap();
         }
 
-        install_candidate(
-            &root,
-            "2.18.2",
-            &v1,
-            VersionMeta {
-                version: "2.18.2".into(),
-                installed_at: None,
-                source: Some("upgrade".into()),
-                source_url: None,
-                sha256: None,
-                variant: None,
-                os: None,
-                signature_ok: Some(true),
-            },
-        )
-        .unwrap();
-        set_active(&root, "2.18.2", &stable).unwrap();
-        // After activate, canonicalize(stable) lands under versions/2.18.2 — this is
-        // exactly the dangerous target the old in-place replace used.
-        let clobber_target = fs::canonicalize(&stable).unwrap();
+        // --- Upgrade #2 via versioned core (install_candidate + set_active) ---
+        let prev2 =
+            apply_versioned_install_and_activate(&v2_src, "2.20.0", &root, &stable).unwrap();
+        assert_eq!(prev2.as_deref(), Some("2.18.2"));
+        assert_eq!(
+            resolve_active_version(&root).unwrap().as_deref(),
+            Some("2.20.0")
+        );
+
+        assert_eq!(
+            fs::read(&v1_path).unwrap(),
+            v1_bytes,
+            "versions/2.18.2 must remain bit-identical after installing 2.20.0"
+        );
+        let v2_path = version_binary_path(&root, "2.20.0");
         assert!(
-            path_is_under_version_tree(&clobber_target, &root),
-            "expected stable to resolve under version tree"
+            String::from_utf8_lossy(&fs::read(&v2_path).unwrap()).contains("MARKER-V2"),
+            "v2 archive should contain its own marker"
+        );
+        let real = fs::canonicalize(&stable).unwrap();
+        assert!(
+            real.to_string_lossy().contains("2.20.0"),
+            "stable should now resolve into 2.20.0, got {}",
+            real.display()
         );
 
-        install_candidate(
-            &root,
-            "2.20.0",
-            &v2,
-            VersionMeta {
-                version: "2.20.0".into(),
-                installed_at: None,
-                source: Some("upgrade".into()),
-                source_url: None,
-                sha256: None,
-                variant: None,
-                os: None,
-                signature_ok: Some(true),
-            },
-        )
-        .unwrap();
-        set_active(&root, "2.20.0", &stable).unwrap();
+        // --- Legacy replace of stable entry must not touch either archive ---
+        let v1_after = fs::read(&v1_path).unwrap();
+        let v2_after = fs::read(&v2_path).unwrap();
+        let v3_src = dir.path().join("payload-v3");
+        write_version_script(&v3_src, "2.21.0", "MARKER-LEGACY");
+        let target = legacy_upgrade_replace_target(&stable, &root, &stable).unwrap();
+        replace_path_entry_without_following(&v3_src, &target).unwrap();
+        assert_eq!(
+            fs::read(&v1_path).unwrap(),
+            v1_after,
+            "legacy replace must not clobber versions/2.18.2"
+        );
+        assert_eq!(
+            fs::read(&v2_path).unwrap(),
+            v2_after,
+            "legacy replace must not clobber versions/2.20.0"
+        );
+        // Stable is now a regular file (symlink replaced), not a version-tree path.
+        let stable_meta = fs::symlink_metadata(&stable).unwrap();
+        assert!(
+            !stable_meta.file_type().is_symlink(),
+            "legacy replace should leave a regular file at the PATH entry"
+        );
+        assert!(
+            String::from_utf8_lossy(&fs::read(&stable).unwrap()).contains("MARKER-LEGACY"),
+            "stable entry should hold the legacy-replaced binary"
+        );
+    }
 
-        assert_eq!(
-            fs::read(version_binary_path(&root, "2.18.2")).unwrap(),
-            b"ARCHIVE-V1-BYTES"
+    #[test]
+    fn legacy_target_refuses_when_only_version_tree_paths_available() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("opt");
+        let versions = crate::version_manager::versions_dir(&root);
+        let archived = versions.join("1.0.0").join("madmail");
+        fs::create_dir_all(archived.parent().unwrap()).unwrap();
+        fs::write(&archived, b"x").unwrap();
+        // Both current and stable live under versions/ → refuse.
+        let err = legacy_upgrade_replace_target(&archived, &root, &archived).unwrap_err();
+        assert!(
+            err.to_string().contains("refusing to clobber"),
+            "got: {err}"
         );
-        assert_eq!(
-            fs::read(version_binary_path(&root, "2.20.0")).unwrap(),
-            b"ARCHIVE-V2-BYTES"
-        );
-        // Guard: path under version tree detection still true for old archive.
-        assert!(path_is_under_version_tree(
-            &version_binary_path(&root, "2.18.2"),
-            &root
-        ));
     }
 
     #[test]

--- a/crates/chatmail/src/upgrade.rs
+++ b/crates/chatmail/src/upgrade.rs
@@ -644,9 +644,9 @@ const INSTALLED_EXEC_MODE: u32 = 0o755;
 /// already have passed — we only exec trusted, signed bytes.
 /// Host preflight for live archives under the version tree (`versions use`).
 ///
-/// Uses [`BinaryExecLocation::Installed`] (`0755`) so a successful switch does not
-/// leave `versions/<id>/madmail` owner-only (`0700`). Staging downloads still use
-/// [`preflight_new_binary`] with [`BinaryExecLocation::Staging`] in the upgrade path.
+/// Uses installed exec mode (`0755` on Unix) so a successful switch does not leave
+/// `versions/<id>/madmail` owner-only (`0700`). Staging downloads still use staging
+/// mode (`0700`) only on the upgrade download path.
 pub fn preflight_binary_for_version_manager(new_bin: &Path) -> Result<()> {
     preflight_new_binary(new_bin, BinaryExecLocation::Installed)
 }

--- a/crates/chatmail/src/upgrade.rs
+++ b/crates/chatmail/src/upgrade.rs
@@ -837,12 +837,21 @@ fn rollback_on_broken_install(
     )))
 }
 
-/// Upgrade in place: verify signature, preflight, backup, stop service, replace, start.
+/// Upgrade: verify signature, preflight, install, activate, start.
+///
+/// Prefer the version tree (TDD 24): `install_candidate` into
+/// `{install_root}/versions/<id>/` then flip `current` + stable PATH symlink.
+/// Never in-place overwrite a file under the version tree (that would clobber
+/// archived history after the first upgrade when PATH is a symlink into
+/// `versions/<old>/`).
+///
+/// If the install root is not writable, fall back to legacy single-file replace
+/// of a non-version-tree path (with `*.prev` backup).
 ///
 /// Safety (issue #114):
-/// - Host preflight (`new_bin version`) runs **before** services stop / binary replace.
-/// - Live binary is copied to `*.prev` before replace.
-/// - If the installed binary fails a post-replace smoke check, restore `*.prev` and restart.
+/// - Host preflight (`new_bin version`) runs **before** services stop / activate.
+/// - Versioned path: previous version remains on disk; rollback flips the pointer.
+/// - Legacy path: live binary is copied to `*.prev` before replace.
 pub fn perform_upgrade(new_bin_path: &Path, args: &Args) -> Result<()> {
     eprintln!("🔍 Verifying digital signature...");
     match verify_signature(new_bin_path)? {
@@ -860,12 +869,6 @@ pub fn perform_upgrade(new_bin_path: &Path, args: &Args) -> Result<()> {
     // Capture version id for the version tree (TDD 24).
     let version_id = capture_version_id(new_bin_path);
 
-    let current_bin = std::env::current_exe()
-        .map_err(|e| ChatmailError::config(format!("failed to get current executable: {e}")))?;
-    let real_bin_path = fs::canonicalize(&current_bin).unwrap_or(current_bin);
-
-    eprintln!("🚀 Target binary: {}", real_bin_path.display());
-
     #[cfg(unix)]
     if unsafe { libc::geteuid() } != 0 {
         return Err(ChatmailError::config(
@@ -873,24 +876,176 @@ pub fn perform_upgrade(new_bin_path: &Path, args: &Args) -> Result<()> {
         ));
     }
 
-    // Install into platform version tree first (non-fatal if root is not writable yet).
-    // Active pointer is updated only after a successful live replace (below).
     let vroot = crate::version_manager::install_root();
-    let version_tree_ok = match install_into_version_tree(new_bin_path, &version_id, &vroot) {
+    let stable = crate::version_manager::default_stable_binary_path();
+
+    // Prefer version-tree install + pointer flip (no write into versions/<old>/).
+    match install_into_version_tree(new_bin_path, &version_id, &vroot) {
         Ok(()) => {
             eprintln!(
-                "📦 Archived binary under {}/versions/{version_id}/",
+                "📦 Installed candidate under {}/versions/{version_id}/",
                 vroot.display()
             );
-            true
+            return perform_upgrade_versioned(&version_id, &vroot, &stable, args);
         }
         Err(e) => {
-            eprintln!("⚠️ Version tree install skipped ({}): {e}", vroot.display());
-            false
+            eprintln!(
+                "⚠️ Version tree install skipped ({}): {e} — falling back to in-place replace",
+                vroot.display()
+            );
         }
+    }
+
+    perform_upgrade_legacy_inplace(new_bin_path, &vroot, args)
+}
+
+/// Versioned upgrade after the candidate is already under `versions/<id>/`.
+///
+/// Only flips active pointers; never copies over an older version directory.
+fn perform_upgrade_versioned(
+    version_id: &str,
+    vroot: &Path,
+    stable: &Path,
+    args: &Args,
+) -> Result<()> {
+    use crate::version_manager::{resolve_active_version, set_active, version_binary_path};
+
+    let installed_bin = version_binary_path(vroot, version_id);
+    let prev = resolve_active_version(vroot)?;
+
+    eprintln!(
+        "🚀 Versioned activate: {} (stable entry {})",
+        installed_bin.display(),
+        stable.display()
+    );
+
+    let service = systemd_service_name();
+    eprintln!("⏹️ Stopping services...");
+    run_systemctl(&["stop", &service]);
+    run_systemctl(&["stop", "iroh-relay.service"]);
+    thread::sleep(Duration::from_secs(1));
+
+    eprintln!("🔗 Switching active version to {version_id}...");
+    if let Err(e) = set_active(vroot, version_id, stable) {
+        eprintln!("▶️ Starting services after failed activate...");
+        let _ = systemctl_succeeded(&["start", &service]);
+        return Err(e);
+    }
+
+    // Smoke on the versioned regular file (not only via the PATH symlink).
+    if let Err(e) = preflight_new_binary(&installed_bin, BinaryExecLocation::Installed) {
+        let restore_note = restore_previous_active(vroot, prev.as_deref(), stable);
+        eprintln!("▶️ Restarting services after failed smoke check...");
+        let _ = systemctl_succeeded(&["start", &service]);
+        return Err(ChatmailError::config(format!(
+            "upgrade rolled back: installed binary failed smoke check: {e}\n\
+             {restore_note}\n{VARIANT_HINT}"
+        )));
+    }
+
+    run_post_upgrade_www_migrate(&installed_bin, args);
+
+    eprintln!("▶️ Starting services...");
+    let started = systemctl_succeeded(&["start", &service]);
+    if !started {
+        if preflight_new_binary(&installed_bin, BinaryExecLocation::Installed).is_err() {
+            let restore_note = restore_previous_active(vroot, prev.as_deref(), stable);
+            let _ = systemctl_succeeded(&["start", &service]);
+            return Err(ChatmailError::config(format!(
+                "upgrade rolled back: failed to start {service} and binary fails smoke check\n\
+                 {restore_note}\n{VARIANT_HINT}"
+            )));
+        }
+        eprintln!(
+            "⚠️ Warning: failed to start {service}; the new binary passed smoke checks. \
+             Try: systemctl start {service}  (and inspect journalctl -u {service}). \
+             Previous version pointer: {:?}.",
+            prev
+        );
+    } else {
+        thread::sleep(Duration::from_secs(1));
+        if !systemctl_succeeded(&["is-active", "--quiet", &service])
+            && preflight_new_binary(&installed_bin, BinaryExecLocation::Installed).is_err()
+        {
+            let restore_note = restore_previous_active(vroot, prev.as_deref(), stable);
+            let _ = systemctl_succeeded(&["start", &service]);
+            return Err(ChatmailError::config(format!(
+                "upgrade rolled back: {service} is not active and installed binary fails smoke check\n\
+                 {restore_note}\n{VARIANT_HINT}"
+            )));
+        }
+    }
+
+    let iroh_unit = PathBuf::from("/etc/systemd/system/iroh-relay.service");
+    if iroh_unit.is_file() && !systemctl_succeeded(&["start", "iroh-relay.service"]) {
+        eprintln!(
+            "⚠️ Warning: failed to start iroh-relay.service; try: systemctl start iroh-relay.service"
+        );
+    }
+
+    refresh_cli_docs_after_upgrade();
+
+    eprintln!(
+        "🎉 Upgrade complete. Active version {version_id} (previous: {:?}).",
+        prev
+    );
+    Ok(())
+}
+
+/// Best-effort restore of the previous active version pointer after a failed activate.
+fn restore_previous_active(vroot: &Path, prev: Option<&str>, stable: &Path) -> String {
+    use crate::version_manager::set_active;
+    match prev {
+        Some(p) => match set_active(vroot, p, stable) {
+            Ok(()) => format!("restored previous version {p}"),
+            Err(re) => format!("FAILED to restore previous version {p}: {re}"),
+        },
+        None => "no previous version pointer to restore".to_string(),
+    }
+}
+
+/// True if `path` is under `{root}/versions/` (after canonicalize when possible).
+fn path_is_under_version_tree(path: &Path, root: &Path) -> bool {
+    let versions = crate::version_manager::versions_dir(root);
+    let versions_real = fs::canonicalize(&versions).unwrap_or_else(|_| versions.clone());
+    let path_real = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    path_real.starts_with(&versions_real) || path.starts_with(&versions)
+}
+
+/// Legacy single-file replace used when the version tree is not writable.
+///
+/// Refuses to write into `{install_root}/versions/**` (would clobber archives).
+fn perform_upgrade_legacy_inplace(new_bin_path: &Path, vroot: &Path, args: &Args) -> Result<()> {
+    let current_bin = std::env::current_exe()
+        .map_err(|e| ChatmailError::config(format!("failed to get current executable: {e}")))?;
+    // Do not follow a PATH symlink into the version tree — that is how dual-upgrade
+    // clobbered `versions/<old>/madmail`. Prefer the non-canonical current_exe when
+    // canonicalize would land under versions/.
+    let canonical = fs::canonicalize(&current_bin).unwrap_or_else(|_| current_bin.clone());
+    let real_bin_path = if path_is_under_version_tree(&canonical, vroot) {
+        // Stable PATH entry without following into versions/ when possible.
+        let stable = crate::version_manager::default_stable_binary_path();
+        if path_is_under_version_tree(&stable, vroot) {
+            return Err(ChatmailError::config(format!(
+                "refusing to clobber version-tree binary at {}; \
+                 fix permissions on {} so upgrades can install via install_candidate",
+                canonical.display(),
+                vroot.display()
+            )));
+        }
+        // Replace the stable entry itself (symlink or file), not its target under versions/.
+        stable
+    } else {
+        canonical
     };
 
+    eprintln!(
+        "🚀 Target binary (legacy in-place): {}",
+        real_bin_path.display()
+    );
+
     // Keep a runnable previous binary so a post-replace failure can recover in-band.
+    // When real_bin_path is a symlink, copy follows the target for backup contents.
     let backup = backup_current_binary(&real_bin_path)?;
 
     let service = systemd_service_name();
@@ -918,6 +1073,16 @@ pub fn perform_upgrade(new_bin_path: &Path, args: &Args) -> Result<()> {
         use std::os::unix::fs::PermissionsExt;
         // Install path must stay 0755 so systemd User=madmail can exec (issue #131).
         fs::set_permissions(&tmp_path, fs::Permissions::from_mode(INSTALLED_EXEC_MODE))?;
+    }
+
+    // If the install path is a symlink into versions/, replace the symlink node
+    // itself with a regular file rather than writing through to the archive.
+    if real_bin_path
+        .symlink_metadata()
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false)
+    {
+        let _ = fs::remove_file(&real_bin_path);
     }
 
     if let Err(e) = fs::rename(&tmp_path, &real_bin_path) {
@@ -989,15 +1154,6 @@ pub fn perform_upgrade(new_bin_path: &Path, args: &Args) -> Result<()> {
     }
 
     refresh_cli_docs_after_upgrade();
-
-    if version_tree_ok {
-        let stable = crate::version_manager::default_stable_binary_path();
-        if let Err(e) = crate::version_manager::set_active(&vroot, &version_id, &stable) {
-            eprintln!("⚠️ Could not update version-manager active pointer: {e}");
-        } else {
-            eprintln!("🔗 Active version pointer set to {version_id}");
-        }
-    }
 
     eprintln!(
         "🎉 Upgrade complete. (previous binary kept at {} for manual rollback if needed)",
@@ -1347,6 +1503,118 @@ mod tests {
         assert_eq!(meta.version, "1.2.3");
         assert_eq!(meta.signature_ok, Some(true));
         assert_eq!(meta.source.as_deref(), Some("upgrade"));
+    }
+
+    #[test]
+    fn path_is_under_version_tree_detects_archived_binary() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("opt");
+        let versions = crate::version_manager::versions_dir(&root);
+        let archived = versions.join("2.18.2").join("madmail");
+        fs::create_dir_all(archived.parent().unwrap()).unwrap();
+        fs::write(&archived, b"old").unwrap();
+        assert!(path_is_under_version_tree(&archived, &root));
+        let outside = dir.path().join("usr-local-bin-madmail");
+        fs::write(&outside, b"live").unwrap();
+        assert!(!path_is_under_version_tree(&outside, &root));
+    }
+
+    /// Simulate upgrade #1 then #2 via install_candidate + set_active (the versioned
+    /// path `perform_upgrade` uses). Prior version bytes must stay intact.
+    #[test]
+    fn dual_upgrade_versioned_path_preserves_prior_archive() {
+        use crate::version_manager::{
+            install_candidate, set_active, version_binary_path, VersionMeta,
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("opt-madmail");
+        let stable = dir.path().join("usr-local-bin").join("madmail");
+        fs::create_dir_all(stable.parent().unwrap()).unwrap();
+
+        let v1 = dir.path().join("v1");
+        let v2 = dir.path().join("v2");
+        fs::write(&v1, b"ARCHIVE-V1-BYTES").unwrap();
+        fs::write(&v2, b"ARCHIVE-V2-BYTES").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&v1, fs::Permissions::from_mode(0o755)).unwrap();
+            fs::set_permissions(&v2, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        install_candidate(
+            &root,
+            "2.18.2",
+            &v1,
+            VersionMeta {
+                version: "2.18.2".into(),
+                installed_at: None,
+                source: Some("upgrade".into()),
+                source_url: None,
+                sha256: None,
+                variant: None,
+                os: None,
+                signature_ok: Some(true),
+            },
+        )
+        .unwrap();
+        set_active(&root, "2.18.2", &stable).unwrap();
+        // After activate, canonicalize(stable) lands under versions/2.18.2 — this is
+        // exactly the dangerous target the old in-place replace used.
+        let clobber_target = fs::canonicalize(&stable).unwrap();
+        assert!(
+            path_is_under_version_tree(&clobber_target, &root),
+            "expected stable to resolve under version tree"
+        );
+
+        install_candidate(
+            &root,
+            "2.20.0",
+            &v2,
+            VersionMeta {
+                version: "2.20.0".into(),
+                installed_at: None,
+                source: Some("upgrade".into()),
+                source_url: None,
+                sha256: None,
+                variant: None,
+                os: None,
+                signature_ok: Some(true),
+            },
+        )
+        .unwrap();
+        set_active(&root, "2.20.0", &stable).unwrap();
+
+        assert_eq!(
+            fs::read(version_binary_path(&root, "2.18.2")).unwrap(),
+            b"ARCHIVE-V1-BYTES"
+        );
+        assert_eq!(
+            fs::read(version_binary_path(&root, "2.20.0")).unwrap(),
+            b"ARCHIVE-V2-BYTES"
+        );
+        // Guard: path under version tree detection still true for old archive.
+        assert!(path_is_under_version_tree(
+            &version_binary_path(&root, "2.18.2"),
+            &root
+        ));
+    }
+
+    #[test]
+    fn restore_previous_active_reports_honest_status() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("opt");
+        let stable = dir.path().join("bin").join("madmail");
+        // No previous → honest message
+        let note = restore_previous_active(&root, None, &stable);
+        assert!(note.contains("no previous"), "got: {note}");
+        // Missing prev version → failed restore, not "restored"
+        let note = restore_previous_active(&root, Some("9.9.9"), &stable);
+        assert!(
+            note.contains("FAILED") || note.contains("not found"),
+            "got: {note}"
+        );
+        assert!(!note.starts_with("restored previous"), "got: {note}");
     }
 
     #[test]

--- a/crates/chatmail/src/version_manager.rs
+++ b/crates/chatmail/src/version_manager.rs
@@ -498,20 +498,35 @@ fn atomic_symlink(target: &Path, link: &Path) -> Result<()> {
             ))
         })?;
     }
-    // Replace existing link/file
-    if link.exists() || link.symlink_metadata().is_ok() {
-        let _ = fs::remove_file(link);
-        // directory junction/symlink
-        let _ = fs::remove_dir(link);
+    // Prefer atomic rename over an existing symlink/file so the stable PATH entry
+    // is never briefly missing (Linux rename replaces the destination inode).
+    // Windows often cannot rename-over an existing name; remove then rename there.
+    #[cfg(unix)]
+    {
+        fs::rename(&tmp, link).map_err(|e| {
+            let _ = fs::remove_file(&tmp);
+            ChatmailError::config(format!(
+                "activate link {} -> {}: {e}",
+                link.display(),
+                target.display()
+            ))
+        })?;
     }
-    fs::rename(&tmp, link).map_err(|e| {
-        let _ = fs::remove_file(&tmp);
-        ChatmailError::config(format!(
-            "activate link {} -> {}: {e}",
-            link.display(),
-            target.display()
-        ))
-    })?;
+    #[cfg(windows)]
+    {
+        if link.exists() || link.symlink_metadata().is_ok() {
+            let _ = fs::remove_file(link);
+            let _ = fs::remove_dir(link);
+        }
+        fs::rename(&tmp, link).map_err(|e| {
+            let _ = fs::remove_file(&tmp);
+            ChatmailError::config(format!(
+                "activate link {} -> {}: {e}",
+                link.display(),
+                target.display()
+            ))
+        })?;
+    }
     Ok(())
 }
 
@@ -795,6 +810,104 @@ mod tests {
         let url = github_latest_asset_url();
         assert!(url.starts_with("https://github.com/themadorg/madmail/releases/latest/download/"));
         assert!(url.contains("madmail"));
+    }
+
+    /// Dual-upgrade regression: installing v2 must leave v1 bytes unchanged
+    /// (review #136 — in-place replace via canonicalize clobbered versions/<old>/).
+    #[test]
+    fn dual_install_leaves_prior_version_bytes_unchanged() {
+        let root = TempDir::new().unwrap();
+        let stable = root.path().join("bin").join(binary_file_name());
+        let src_v1 = root.path().join("payload-v1");
+        let src_v2 = root.path().join("payload-v2");
+        fs::write(&src_v1, b"VERSION-2.18.2-UNIQUE-BYTES").unwrap();
+        fs::write(&src_v2, b"VERSION-2.20.0-UNIQUE-BYTES").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&src_v1, fs::Permissions::from_mode(0o755)).unwrap();
+            fs::set_permissions(&src_v2, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        install_candidate(
+            root.path(),
+            "2.18.2",
+            &src_v1,
+            VersionMeta {
+                version: "2.18.2".into(),
+                installed_at: None,
+                source: Some("test".into()),
+                source_url: None,
+                sha256: None,
+                variant: None,
+                os: None,
+                signature_ok: Some(true),
+            },
+        )
+        .unwrap();
+        set_active(root.path(), "2.18.2", &stable).unwrap();
+        let v1_path = version_binary_path(root.path(), "2.18.2");
+        let v1_before = fs::read(&v1_path).unwrap();
+        assert_eq!(v1_before, b"VERSION-2.18.2-UNIQUE-BYTES");
+
+        // Second install + activate (mirrors upgrade #2) must not rewrite v1.
+        install_candidate(
+            root.path(),
+            "2.20.0",
+            &src_v2,
+            VersionMeta {
+                version: "2.20.0".into(),
+                installed_at: None,
+                source: Some("test".into()),
+                source_url: None,
+                sha256: None,
+                variant: None,
+                os: None,
+                signature_ok: Some(true),
+            },
+        )
+        .unwrap();
+        set_active(root.path(), "2.20.0", &stable).unwrap();
+
+        assert_eq!(
+            fs::read(&v1_path).unwrap(),
+            v1_before,
+            "versions/2.18.2 must remain bit-identical after installing 2.20.0"
+        );
+        assert_eq!(
+            fs::read(version_binary_path(root.path(), "2.20.0")).unwrap(),
+            b"VERSION-2.20.0-UNIQUE-BYTES"
+        );
+        assert_eq!(
+            resolve_active_version(root.path()).unwrap().as_deref(),
+            Some("2.20.0")
+        );
+        let real = fs::canonicalize(&stable).unwrap();
+        assert!(
+            real.to_string_lossy().contains("2.20.0"),
+            "stable PATH should resolve into 2.20.0, got {}",
+            real.display()
+        );
+    }
+
+    /// `atomic_symlink` must replace without leaving a missing PATH entry on Unix
+    /// (rename-over; no remove-then-rename window).
+    #[cfg(unix)]
+    #[test]
+    fn atomic_symlink_replaces_existing_without_pre_delete_gap() {
+        let root = TempDir::new().unwrap();
+        let link = root.path().join("stable");
+        let t1 = root.path().join("t1");
+        let t2 = root.path().join("t2");
+        fs::write(&t1, b"one").unwrap();
+        fs::write(&t2, b"two").unwrap();
+        atomic_symlink(&t1, &link).unwrap();
+        assert!(link.symlink_metadata().unwrap().file_type().is_symlink());
+        assert_eq!(fs::read(&link).unwrap(), b"one");
+        atomic_symlink(&t2, &link).unwrap();
+        assert!(link.symlink_metadata().unwrap().file_type().is_symlink());
+        assert_eq!(fs::read(&link).unwrap(), b"two");
+        assert_eq!(fs::read_link(&link).unwrap(), t2);
     }
 
     #[test]

--- a/crates/chatmail/src/version_manager.rs
+++ b/crates/chatmail/src/version_manager.rs
@@ -435,11 +435,28 @@ pub fn install_candidate(
 pub fn set_active(root: &Path, version_id: &str, stable_path: &Path) -> Result<()> {
     let id = sanitize_version_id(version_id)?;
     let bin = version_binary_path(root, &id);
-    if !bin.is_file() {
-        return Err(ChatmailError::config(format!(
-            "version {id} binary not found at {}",
-            bin.display()
-        )));
+    // Defense in depth: same regular-file rule as `versions use` (do not follow
+    // symlink-to-file via `is_file()` and activate a symlink path).
+    match fs::symlink_metadata(&bin) {
+        Ok(meta) if meta.file_type().is_symlink() => {
+            return Err(ChatmailError::config(format!(
+                "version {id} binary at {} is a symlink; refusing to activate",
+                bin.display()
+            )));
+        }
+        Ok(meta) if meta.is_file() => {}
+        Ok(_) => {
+            return Err(ChatmailError::config(format!(
+                "version {id} binary at {} is not a regular file",
+                bin.display()
+            )));
+        }
+        Err(_) => {
+            return Err(ChatmailError::config(format!(
+                "version {id} binary not found at {}",
+                bin.display()
+            )));
+        }
     }
     ensure_install_layout(root)?;
 
@@ -551,6 +568,10 @@ pub fn prune(root: &Path, keep: usize) -> Result<Vec<String>> {
             kept += 1;
             continue;
         }
+        // Do not empty the tree (remove_version also refuses only-remaining).
+        if list_installed(root)?.len() <= 1 {
+            break;
+        }
         remove_version(root, &v.version)?;
         removed.push(v.version.clone());
     }
@@ -567,6 +588,14 @@ pub fn remove_version(root: &Path, version_id: &str) -> Result<()> {
     let dir = version_dir(root, &id);
     if !dir.is_dir() {
         return Err(ChatmailError::config(format!("version {id} not found")));
+    }
+    // TDD 24: refuse removing the only remaining installed version (even if
+    // the active pointer is missing / broken).
+    let installed = list_installed(root)?;
+    if installed.len() == 1 && installed[0].version == id {
+        return Err(ChatmailError::config(format!(
+            "refusing to remove the only remaining version {id}"
+        )));
     }
     fs::remove_dir_all(&dir)
         .map_err(|e| ChatmailError::config(format!("remove {}: {e}", dir.display())))?;
@@ -1286,6 +1315,53 @@ mod tests {
         let root = TempDir::new().unwrap();
         let err = remove_version(root.path(), "0.0.1").unwrap_err();
         assert!(err.to_string().contains("not found"), "got: {err}");
+    }
+
+    #[test]
+    fn remove_only_remaining_version_errors() {
+        let root = TempDir::new().unwrap();
+        let src = root.path().join("p");
+        write_fake_bin(&src);
+        install_candidate(
+            root.path(),
+            "1.0.0",
+            &src,
+            VersionMeta {
+                version: "1.0.0".into(),
+                installed_at: None,
+                source: None,
+                source_url: None,
+                sha256: None,
+                variant: None,
+                os: None,
+                signature_ok: None,
+            },
+        )
+        .unwrap();
+        // No active pointer: still refuse deleting the sole install.
+        let err = remove_version(root.path(), "1.0.0").unwrap_err();
+        assert!(
+            err.to_string().contains("only remaining"),
+            "got: {err}"
+        );
+        assert_eq!(list_installed(root.path()).unwrap().len(), 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn set_active_rejects_symlink_binary() {
+        let root = TempDir::new().unwrap();
+        let stable = root.path().join("bin").join(binary_file_name());
+        let vdir = version_dir(root.path(), "1.0.0");
+        fs::create_dir_all(&vdir).unwrap();
+        let target = root.path().join("real-bin");
+        write_fake_bin(&target);
+        std::os::unix::fs::symlink(&target, version_binary_path(root.path(), "1.0.0")).unwrap();
+        let err = set_active(root.path(), "1.0.0", &stable).unwrap_err();
+        assert!(
+            err.to_string().contains("symlink"),
+            "expected symlink refuse, got: {err}"
+        );
     }
 
     #[test]

--- a/crates/chatmail/src/version_manager.rs
+++ b/crates/chatmail/src/version_manager.rs
@@ -1340,10 +1340,7 @@ mod tests {
         .unwrap();
         // No active pointer: still refuse deleting the sole install.
         let err = remove_version(root.path(), "1.0.0").unwrap_err();
-        assert!(
-            err.to_string().contains("only remaining"),
-            "got: {err}"
-        );
+        assert!(err.to_string().contains("only remaining"), "got: {err}");
         assert_eq!(list_installed(root.path()).unwrap().len(), 1);
     }
 

--- a/crates/chatmail/src/version_manager.rs
+++ b/crates/chatmail/src/version_manager.rs
@@ -255,9 +255,8 @@ pub struct VersionListEntry {
 /// Ensure `{root}/versions` exists.
 pub fn ensure_install_layout(root: &Path) -> Result<()> {
     let vdir = versions_dir(root);
-    fs::create_dir_all(&vdir).map_err(|e| {
-        ChatmailError::config(format!("failed to create {}: {e}", vdir.display()))
-    })?;
+    fs::create_dir_all(&vdir)
+        .map_err(|e| ChatmailError::config(format!("failed to create {}: {e}", vdir.display())))?;
     Ok(())
 }
 
@@ -295,10 +294,7 @@ pub fn resolve_active_version(root: &Path) -> Result<Option<String>> {
             let target = if target.is_absolute() {
                 target
             } else {
-                current
-                    .parent()
-                    .unwrap_or(root)
-                    .join(target)
+                current.parent().unwrap_or(root).join(target)
             };
             if let Some(name) = target.file_name().and_then(|s| s.to_str()) {
                 if versions_dir(root).join(name).is_dir() {
@@ -361,11 +357,7 @@ pub fn list_installed(root: &Path) -> Result<Vec<InstalledVersion>> {
         let ent = ent.map_err(|e| ChatmailError::config(format!("readdir: {e}")))?;
         let name = ent.file_name();
         let name = name.to_string_lossy();
-        if !ent
-            .file_type()
-            .map(|t| t.is_dir())
-            .unwrap_or(false)
-        {
+        if !ent.file_type().map(|t| t.is_dir()).unwrap_or(false) {
             continue;
         }
         let Ok(id) = sanitize_version_id(&name) else {
@@ -403,7 +395,11 @@ pub fn install_candidate(
     let dest = version_binary_path(root, &id);
 
     // Refuse to follow unexpected symlink dest
-    if dest.symlink_metadata().map(|m| m.file_type().is_symlink()).unwrap_or(false) {
+    if dest
+        .symlink_metadata()
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false)
+    {
         return Err(ChatmailError::config(format!(
             "refusing to write through symlink at {}",
             dest.display()
@@ -424,9 +420,8 @@ pub fn install_candidate(
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(&staging, fs::Permissions::from_mode(0o755)).map_err(|e| {
-            ChatmailError::config(format!("chmod staging: {e}"))
-        })?;
+        fs::set_permissions(&staging, fs::Permissions::from_mode(0o755))
+            .map_err(|e| ChatmailError::config(format!("chmod staging: {e}")))?;
     }
     fs::rename(&staging, &dest).map_err(|e| {
         let _ = fs::remove_file(&staging);
@@ -455,9 +450,8 @@ pub fn set_active(root: &Path, version_id: &str, stable_path: &Path) -> Result<(
 
     // stable PATH -> binary
     if let Some(parent) = stable_path.parent() {
-        fs::create_dir_all(parent).map_err(|e| {
-            ChatmailError::config(format!("mkdir {}: {e}", parent.display()))
-        })?;
+        fs::create_dir_all(parent)
+            .map_err(|e| ChatmailError::config(format!("mkdir {}: {e}", parent.display())))?;
     }
     atomic_symlink(&bin, stable_path)?;
     Ok(())
@@ -528,12 +522,8 @@ pub fn prune(root: &Path, keep: usize) -> Result<Vec<String>> {
     let mut installed = list_installed(root)?;
     // sort by version string descending already; for prune use mtime of dir
     installed.sort_by(|a, b| {
-        let ma = fs::metadata(&a.path)
-            .and_then(|m| m.modified())
-            .ok();
-        let mb = fs::metadata(&b.path)
-            .and_then(|m| m.modified())
-            .ok();
+        let ma = fs::metadata(&a.path).and_then(|m| m.modified()).ok();
+        let mb = fs::metadata(&b.path).and_then(|m| m.modified()).ok();
         mb.cmp(&ma)
     });
     let mut removed = Vec::new();
@@ -603,16 +593,18 @@ pub fn merge_local_and_remote(
     }
 
     for r in remote {
-        let e = map.entry(r.version.clone()).or_insert_with(|| VersionListEntry {
-            version: r.version.clone(),
-            source: "remote".into(),
-            active: false,
-            installed: false,
-            remote_latest: false,
-            published_at: None,
-            asset: None,
-            asset_size: None,
-        });
+        let e = map
+            .entry(r.version.clone())
+            .or_insert_with(|| VersionListEntry {
+                version: r.version.clone(),
+                source: "remote".into(),
+                active: false,
+                installed: false,
+                remote_latest: false,
+                published_at: None,
+                asset: None,
+                asset_size: None,
+            });
         if e.installed {
             e.source = "both".into();
         } else {
@@ -636,7 +628,10 @@ pub fn normalize_release_tag(tag: &str) -> String {
 }
 
 /// Parse a minimal subset of GitHub releases JSON into [`RemoteRelease`]s.
-pub fn parse_github_releases_json(body: &str, host_asset_substr: &str) -> Result<Vec<RemoteRelease>> {
+pub fn parse_github_releases_json(
+    body: &str,
+    host_asset_substr: &str,
+) -> Result<Vec<RemoteRelease>> {
     let val: serde_json::Value = serde_json::from_str(body)
         .map_err(|e| ChatmailError::config(format!("github releases json: {e}")))?;
     let arr = val
@@ -681,9 +676,7 @@ pub fn parse_github_releases_json(body: &str, host_asset_substr: &str) -> Result
                     || name.contains("madmail")
                 {
                     // Prefer exact host asset
-                    if name == host_release_asset_name()
-                        || name.contains(host_asset_substr)
-                    {
+                    if name == host_release_asset_name() || name.contains(host_asset_substr) {
                         asset = Some(name.to_string());
                         asset_size = a.get("size").and_then(|s| s.as_u64());
                         if name == host_release_asset_name() {
@@ -729,11 +722,7 @@ pub fn fetch_remote_releases(accept_invalid_certs: bool) -> Result<Vec<RemoteRel
     let body = resp
         .text()
         .map_err(|e| ChatmailError::config(format!("github releases body: {e}")))?;
-    let substr = if cfg!(windows) {
-        "windows"
-    } else {
-        "linux"
-    };
+    let substr = if cfg!(windows) { "windows" } else { "linux" };
     parse_github_releases_json(&body, substr)
 }
 
@@ -775,10 +764,7 @@ mod tests {
             parse_version_from_preflight_output("madmail-v2 2.20.1\n"),
             "2.20.1"
         );
-        assert_eq!(
-            parse_version_from_preflight_output("2.19.0"),
-            "2.19.0"
-        );
+        assert_eq!(parse_version_from_preflight_output("2.19.0"), "2.19.0");
     }
 
     #[test]
@@ -807,9 +793,7 @@ mod tests {
     #[test]
     fn github_latest_url_uses_releases_latest_download() {
         let url = github_latest_asset_url();
-        assert!(url.starts_with(
-            "https://github.com/themadorg/madmail/releases/latest/download/"
-        ));
+        assert!(url.starts_with("https://github.com/themadorg/madmail/releases/latest/download/"));
         assert!(url.contains("madmail"));
     }
 
@@ -935,10 +919,7 @@ mod tests {
         let rels = parse_github_releases_json(body, "linux").unwrap();
         assert_eq!(rels[0].version, "2.20.1");
         assert!(rels[0].is_latest);
-        assert_eq!(
-            rels[0].asset.as_deref(),
-            Some("madmail-linux-amd64.tar.gz")
-        );
+        assert_eq!(rels[0].asset.as_deref(), Some("madmail-linux-amd64.tar.gz"));
         assert_eq!(rels[1].version, "2.20.0");
     }
 
@@ -1015,9 +996,15 @@ mod tests {
         );
         assert_eq!(
             version_binary_path(&root, "2.1.0"),
-            PathBuf::from(format!("/opt/madmail/versions/2.1.0/{}", binary_file_name()))
+            PathBuf::from(format!(
+                "/opt/madmail/versions/2.1.0/{}",
+                binary_file_name()
+            ))
         );
-        assert_eq!(current_link_path(&root), PathBuf::from("/opt/madmail/current"));
+        assert_eq!(
+            current_link_path(&root),
+            PathBuf::from("/opt/madmail/current")
+        );
         assert_eq!(default_keep(), 5);
         assert_eq!(
             github_releases_api_url(),
@@ -1402,7 +1389,10 @@ mod tests {
         // Cross-check: default_install_root documentation contract for non-Windows.
         #[cfg(not(windows))]
         {
-            assert_eq!(default_stable_binary_path(), PathBuf::from("/usr/local/bin/madmail"));
+            assert_eq!(
+                default_stable_binary_path(),
+                PathBuf::from("/usr/local/bin/madmail")
+            );
         }
         #[cfg(windows)]
         {

--- a/crates/chatmail/src/version_manager.rs
+++ b/crates/chatmail/src/version_manager.rs
@@ -1,0 +1,1416 @@
+// Copyright (C) 2026 themadorg
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Versioned install tree under a platform install root (TDD `24-version-manager.md`).
+//!
+//! - Unix default root: `/opt/madmail`
+//! - Windows default root: `%ProgramFiles%\Madmail`
+//! - Override: `MADMAIL_INSTALL_ROOT` (Unix alias: `MADMAIL_OPT_ROOT`)
+
+use std::fs::{self, File};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use chatmail_types::{ChatmailError, Result};
+use serde::{Deserialize, Serialize};
+
+/// Env var for install root (tests and custom layouts).
+pub const ENV_INSTALL_ROOT: &str = "MADMAIL_INSTALL_ROOT";
+/// Deprecated Unix alias for [`ENV_INSTALL_ROOT`].
+pub const ENV_OPT_ROOT_ALIAS: &str = "MADMAIL_OPT_ROOT";
+
+const DEFAULT_KEEP: usize = 5;
+
+/// Default platform install root (no env override).
+pub fn default_install_root() -> PathBuf {
+    #[cfg(windows)]
+    {
+        std::env::var_os("ProgramFiles")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(r"C:\Program Files"))
+            .join("Madmail")
+    }
+    #[cfg(not(windows))]
+    {
+        PathBuf::from("/opt/madmail")
+    }
+}
+
+/// Resolve install root: `MADMAIL_INSTALL_ROOT`, else Unix `MADMAIL_OPT_ROOT`, else default.
+pub fn install_root() -> PathBuf {
+    if let Ok(p) = std::env::var(ENV_INSTALL_ROOT) {
+        let t = p.trim();
+        if !t.is_empty() {
+            return PathBuf::from(t);
+        }
+    }
+    #[cfg(not(windows))]
+    if let Ok(p) = std::env::var(ENV_OPT_ROOT_ALIAS) {
+        let t = p.trim();
+        if !t.is_empty() {
+            return PathBuf::from(t);
+        }
+    }
+    default_install_root()
+}
+
+/// Executable file name inside a version directory.
+pub fn binary_file_name() -> &'static str {
+    #[cfg(windows)]
+    {
+        "madmail.exe"
+    }
+    #[cfg(not(windows))]
+    {
+        "madmail"
+    }
+}
+
+/// Stable PATH entry path (symlink/junction target side).
+pub fn default_stable_binary_path() -> PathBuf {
+    #[cfg(windows)]
+    {
+        install_root().join("bin").join(binary_file_name())
+    }
+    #[cfg(not(windows))]
+    {
+        PathBuf::from("/usr/local/bin/madmail")
+    }
+}
+
+pub fn versions_dir(root: &Path) -> PathBuf {
+    root.join("versions")
+}
+
+pub fn version_dir(root: &Path, version_id: &str) -> PathBuf {
+    versions_dir(root).join(version_id)
+}
+
+pub fn version_binary_path(root: &Path, version_id: &str) -> PathBuf {
+    version_dir(root, version_id).join(binary_file_name())
+}
+
+pub fn current_link_path(root: &Path) -> PathBuf {
+    root.join("current")
+}
+
+/// Reject path separators and invalid version directory names.
+pub fn sanitize_version_id(raw: &str) -> Result<String> {
+    let s = raw.trim();
+    if s.is_empty() {
+        return Err(ChatmailError::config("version id is empty"));
+    }
+    if s.contains('/') || s.contains('\\') || s.contains("..") {
+        return Err(ChatmailError::config(format!(
+            "invalid version id (path separators not allowed): {s}"
+        )));
+    }
+    if !s
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '+' | '-'))
+    {
+        return Err(ChatmailError::config(format!(
+            "invalid version id (allowed [0-9A-Za-z._+-]): {s}"
+        )));
+    }
+    // Windows reserved device names
+    let upper = s.to_ascii_uppercase();
+    if matches!(
+        upper.as_str(),
+        "CON" | "PRN" | "AUX" | "NUL" | "COM1" | "LPT1"
+    ) {
+        return Err(ChatmailError::config(format!(
+            "invalid version id (reserved name): {s}"
+        )));
+    }
+    Ok(s.to_string())
+}
+
+/// Parse a version id from `madmail version` stdout (e.g. `madmail-v2 2.20.1`).
+pub fn parse_version_from_preflight_output(stdout: &str) -> String {
+    let first = stdout
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .unwrap_or("");
+    // Prefer last whitespace-separated token that looks like semver-ish
+    for tok in first.split_whitespace().rev() {
+        if tok.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+            if let Ok(id) = sanitize_version_id(tok) {
+                return id;
+            }
+        }
+    }
+    // Fallback: whole first line sanitized or timestamp
+    if let Ok(id) = sanitize_version_id(&first.replace(' ', "-")) {
+        return id;
+    }
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    format!("unknown-{ts}")
+}
+
+/// GitHub Releases latest download URL for this host (no network).
+pub fn github_latest_asset_url() -> String {
+    let asset = host_release_asset_name();
+    format!("https://github.com/themadorg/madmail/releases/latest/download/{asset}")
+}
+
+/// Asset file name for the running OS/arch.
+pub fn host_release_asset_name() -> &'static str {
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    {
+        "madmail-linux-amd64.tar.gz"
+    }
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    {
+        "madmail-linux-arm64.tar.gz"
+    }
+    #[cfg(all(windows, target_arch = "x86_64"))]
+    {
+        "madmail-windows-amd64.tar.gz"
+    }
+    #[cfg(all(windows, target_arch = "aarch64"))]
+    {
+        "madmail-windows-arm64.tar.gz"
+    }
+    #[cfg(not(any(
+        all(target_os = "linux", target_arch = "x86_64"),
+        all(target_os = "linux", target_arch = "aarch64"),
+        all(windows, target_arch = "x86_64"),
+        all(windows, target_arch = "aarch64"),
+    )))]
+    {
+        "madmail-linux-amd64.tar.gz"
+    }
+}
+
+/// GitHub Releases API (list remote metadata).
+pub fn github_releases_api_url() -> &'static str {
+    "https://api.github.com/repos/themadorg/madmail/releases"
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct VersionMeta {
+    pub version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installed_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub variant: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub os: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signature_ok: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct InstalledVersion {
+    pub version: String,
+    pub path: PathBuf,
+    pub binary: PathBuf,
+    pub active: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub meta: Option<VersionMeta>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct VersionListEntry {
+    pub version: String,
+    /// `local` | `remote` | `both`
+    pub source: String,
+    pub active: bool,
+    pub installed: bool,
+    pub remote_latest: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub published_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub asset: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub asset_size: Option<u64>,
+}
+
+/// Ensure `{root}/versions` exists.
+pub fn ensure_install_layout(root: &Path) -> Result<()> {
+    let vdir = versions_dir(root);
+    fs::create_dir_all(&vdir).map_err(|e| {
+        ChatmailError::config(format!("failed to create {}: {e}", vdir.display()))
+    })?;
+    Ok(())
+}
+
+pub fn write_meta(root: &Path, version_id: &str, meta: &VersionMeta) -> Result<()> {
+    let dir = version_dir(root, version_id);
+    fs::create_dir_all(&dir)
+        .map_err(|e| ChatmailError::config(format!("mkdir {}: {e}", dir.display())))?;
+    let path = dir.join("meta.json");
+    let json = serde_json::to_vec_pretty(meta)
+        .map_err(|e| ChatmailError::config(format!("serialize meta: {e}")))?;
+    let mut f = File::create(&path)
+        .map_err(|e| ChatmailError::config(format!("write {}: {e}", path.display())))?;
+    f.write_all(&json)
+        .map_err(|e| ChatmailError::config(format!("write {}: {e}", path.display())))?;
+    Ok(())
+}
+
+pub fn read_meta(root: &Path, version_id: &str) -> Result<Option<VersionMeta>> {
+    let path = version_dir(root, version_id).join("meta.json");
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let data = fs::read(&path)
+        .map_err(|e| ChatmailError::config(format!("read {}: {e}", path.display())))?;
+    let meta: VersionMeta = serde_json::from_slice(&data)
+        .map_err(|e| ChatmailError::config(format!("parse meta {}: {e}", path.display())))?;
+    Ok(Some(meta))
+}
+
+/// Resolve active version id from `current` symlink or stable path.
+pub fn resolve_active_version(root: &Path) -> Result<Option<String>> {
+    let current = current_link_path(root);
+    if current.exists() || current.symlink_metadata().is_ok() {
+        if let Ok(target) = fs::read_link(&current) {
+            let target = if target.is_absolute() {
+                target
+            } else {
+                current
+                    .parent()
+                    .unwrap_or(root)
+                    .join(target)
+            };
+            if let Some(name) = target.file_name().and_then(|s| s.to_str()) {
+                if versions_dir(root).join(name).is_dir() {
+                    return Ok(Some(name.to_string()));
+                }
+            }
+            // current might point at versions/X/madmail
+            if let Some(parent) = target.parent() {
+                if let Some(name) = parent.file_name().and_then(|s| s.to_str()) {
+                    if parent
+                        .parent()
+                        .is_some_and(|p| p == versions_dir(root) || p.ends_with("versions"))
+                    {
+                        return Ok(Some(name.to_string()));
+                    }
+                }
+            }
+        }
+    }
+    // Fall back: which version binary is the same inode/path as stable?
+    let stable = default_stable_binary_path();
+    if let Ok(real) = fs::canonicalize(&stable) {
+        if let Some(id) = version_id_from_binary_path(root, &real) {
+            return Ok(Some(id));
+        }
+    }
+    Ok(None)
+}
+
+fn version_id_from_binary_path(root: &Path, binary: &Path) -> Option<String> {
+    let versions = versions_dir(root);
+    let parent = binary.parent()?;
+    if parent.parent()? != versions && !parent.starts_with(&versions) {
+        // still try file_name of parent
+    }
+    let name = parent.file_name()?.to_str()?;
+    if version_binary_path(root, name) == *binary
+        || fs::canonicalize(version_binary_path(root, name))
+            .ok()
+            .is_some_and(|p| p == binary)
+    {
+        return Some(name.to_string());
+    }
+    if parent.starts_with(&versions) {
+        return Some(name.to_string());
+    }
+    None
+}
+
+pub fn list_installed(root: &Path) -> Result<Vec<InstalledVersion>> {
+    let vdir = versions_dir(root);
+    if !vdir.is_dir() {
+        return Ok(Vec::new());
+    }
+    let active = resolve_active_version(root)?.unwrap_or_default();
+    let mut out = Vec::new();
+    for ent in fs::read_dir(&vdir)
+        .map_err(|e| ChatmailError::config(format!("read {}: {e}", vdir.display())))?
+    {
+        let ent = ent.map_err(|e| ChatmailError::config(format!("readdir: {e}")))?;
+        let name = ent.file_name();
+        let name = name.to_string_lossy();
+        if !ent
+            .file_type()
+            .map(|t| t.is_dir())
+            .unwrap_or(false)
+        {
+            continue;
+        }
+        let Ok(id) = sanitize_version_id(&name) else {
+            continue;
+        };
+        let bin = version_binary_path(root, &id);
+        if !bin.is_file() {
+            continue;
+        }
+        let meta = read_meta(root, &id).ok().flatten();
+        out.push(InstalledVersion {
+            version: id.clone(),
+            path: version_dir(root, &id),
+            binary: bin,
+            active: id == active,
+            meta,
+        });
+    }
+    out.sort_by(|a, b| b.version.cmp(&a.version));
+    Ok(out)
+}
+
+/// Copy candidate into the version tree (does not activate). Caller must verify signature first.
+pub fn install_candidate(
+    root: &Path,
+    version_id: &str,
+    src: &Path,
+    meta: VersionMeta,
+) -> Result<PathBuf> {
+    let id = sanitize_version_id(version_id)?;
+    ensure_install_layout(root)?;
+    let dest_dir = version_dir(root, &id);
+    fs::create_dir_all(&dest_dir)
+        .map_err(|e| ChatmailError::config(format!("mkdir {}: {e}", dest_dir.display())))?;
+    let dest = version_binary_path(root, &id);
+
+    // Refuse to follow unexpected symlink dest
+    if dest.symlink_metadata().map(|m| m.file_type().is_symlink()).unwrap_or(false) {
+        return Err(ChatmailError::config(format!(
+            "refusing to write through symlink at {}",
+            dest.display()
+        )));
+    }
+
+    let staging = dest_dir.join(format!(".staging-{}", std::process::id()));
+    {
+        let mut from = File::open(src)
+            .map_err(|e| ChatmailError::config(format!("open {}: {e}", src.display())))?;
+        let mut to = File::create(&staging)
+            .map_err(|e| ChatmailError::config(format!("create {}: {e}", staging.display())))?;
+        io::copy(&mut from, &mut to)
+            .map_err(|e| ChatmailError::config(format!("copy to staging: {e}")))?;
+        to.sync_all()
+            .map_err(|e| ChatmailError::config(format!("sync staging: {e}")))?;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&staging, fs::Permissions::from_mode(0o755)).map_err(|e| {
+            ChatmailError::config(format!("chmod staging: {e}"))
+        })?;
+    }
+    fs::rename(&staging, &dest).map_err(|e| {
+        let _ = fs::remove_file(&staging);
+        ChatmailError::config(format!("install binary to {}: {e}", dest.display()))
+    })?;
+    write_meta(root, &id, &meta)?;
+    Ok(dest)
+}
+
+/// Point `current` and stable PATH entry at `version_id`.
+pub fn set_active(root: &Path, version_id: &str, stable_path: &Path) -> Result<()> {
+    let id = sanitize_version_id(version_id)?;
+    let bin = version_binary_path(root, &id);
+    if !bin.is_file() {
+        return Err(ChatmailError::config(format!(
+            "version {id} binary not found at {}",
+            bin.display()
+        )));
+    }
+    ensure_install_layout(root)?;
+
+    // current -> versions/<id> (directory)
+    let current = current_link_path(root);
+    let ver_dir = version_dir(root, &id);
+    atomic_symlink(&ver_dir, &current)?;
+
+    // stable PATH -> binary
+    if let Some(parent) = stable_path.parent() {
+        fs::create_dir_all(parent).map_err(|e| {
+            ChatmailError::config(format!("mkdir {}: {e}", parent.display()))
+        })?;
+    }
+    atomic_symlink(&bin, stable_path)?;
+    Ok(())
+}
+
+fn atomic_symlink(target: &Path, link: &Path) -> Result<()> {
+    let parent = link
+        .parent()
+        .ok_or_else(|| ChatmailError::config("symlink has no parent"))?;
+    fs::create_dir_all(parent)
+        .map_err(|e| ChatmailError::config(format!("mkdir {}: {e}", parent.display())))?;
+    let tmp = parent.join(format!(
+        ".madmail-link-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    let _ = fs::remove_file(&tmp);
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(target, &tmp).map_err(|e| {
+            ChatmailError::config(format!(
+                "symlink {} -> {}: {e}",
+                tmp.display(),
+                target.display()
+            ))
+        })?;
+    }
+    #[cfg(windows)]
+    {
+        // Prefer file symlink when target is a file; dir symlink for directories.
+        let res = if target.is_dir() {
+            std::os::windows::fs::symlink_dir(target, &tmp)
+        } else {
+            std::os::windows::fs::symlink_file(target, &tmp)
+        };
+        res.map_err(|e| {
+            ChatmailError::config(format!(
+                "symlink {} -> {}: {e} (Administrator or Developer Mode may be required)",
+                tmp.display(),
+                target.display()
+            ))
+        })?;
+    }
+    // Replace existing link/file
+    if link.exists() || link.symlink_metadata().is_ok() {
+        let _ = fs::remove_file(link);
+        // directory junction/symlink
+        let _ = fs::remove_dir(link);
+    }
+    fs::rename(&tmp, link).map_err(|e| {
+        let _ = fs::remove_file(&tmp);
+        ChatmailError::config(format!(
+            "activate link {} -> {}: {e}",
+            link.display(),
+            target.display()
+        ))
+    })?;
+    Ok(())
+}
+
+/// Delete oldest non-active versions beyond `keep` (default 5). Returns removed ids.
+pub fn prune(root: &Path, keep: usize) -> Result<Vec<String>> {
+    let keep = if keep == 0 { 0 } else { keep };
+    let active = resolve_active_version(root)?;
+    let mut installed = list_installed(root)?;
+    // sort by version string descending already; for prune use mtime of dir
+    installed.sort_by(|a, b| {
+        let ma = fs::metadata(&a.path)
+            .and_then(|m| m.modified())
+            .ok();
+        let mb = fs::metadata(&b.path)
+            .and_then(|m| m.modified())
+            .ok();
+        mb.cmp(&ma)
+    });
+    let mut removed = Vec::new();
+    let mut kept = 0usize;
+    for v in &installed {
+        if active.as_deref() == Some(v.version.as_str()) {
+            continue; // never prune active
+        }
+        if keep > 0 && kept < keep {
+            kept += 1;
+            continue;
+        }
+        remove_version(root, &v.version)?;
+        removed.push(v.version.clone());
+    }
+    Ok(removed)
+}
+
+pub fn remove_version(root: &Path, version_id: &str) -> Result<()> {
+    let id = sanitize_version_id(version_id)?;
+    if resolve_active_version(root)?.as_deref() == Some(id.as_str()) {
+        return Err(ChatmailError::config(format!(
+            "refusing to remove active version {id}"
+        )));
+    }
+    let dir = version_dir(root, &id);
+    if !dir.is_dir() {
+        return Err(ChatmailError::config(format!("version {id} not found")));
+    }
+    fs::remove_dir_all(&dir)
+        .map_err(|e| ChatmailError::config(format!("remove {}: {e}", dir.display())))?;
+    Ok(())
+}
+
+/// Remote release tag metadata (from API or tests).
+#[derive(Debug, Clone)]
+pub struct RemoteRelease {
+    pub version: String,
+    pub published_at: Option<String>,
+    pub asset: Option<String>,
+    pub asset_size: Option<u64>,
+    pub is_latest: bool,
+}
+
+/// Merge local installs with remote releases for `versions list --remote`.
+pub fn merge_local_and_remote(
+    local: &[InstalledVersion],
+    remote: &[RemoteRelease],
+) -> Vec<VersionListEntry> {
+    use std::collections::BTreeMap;
+    let mut map: BTreeMap<String, VersionListEntry> = BTreeMap::new();
+
+    for l in local {
+        map.insert(
+            l.version.clone(),
+            VersionListEntry {
+                version: l.version.clone(),
+                source: "local".into(),
+                active: l.active,
+                installed: true,
+                remote_latest: false,
+                published_at: None,
+                asset: None,
+                asset_size: None,
+            },
+        );
+    }
+
+    for r in remote {
+        let e = map.entry(r.version.clone()).or_insert_with(|| VersionListEntry {
+            version: r.version.clone(),
+            source: "remote".into(),
+            active: false,
+            installed: false,
+            remote_latest: false,
+            published_at: None,
+            asset: None,
+            asset_size: None,
+        });
+        if e.installed {
+            e.source = "both".into();
+        } else {
+            e.source = "remote".into();
+        }
+        e.remote_latest = r.is_latest;
+        e.published_at = r.published_at.clone();
+        e.asset = r.asset.clone();
+        e.asset_size = r.asset_size;
+    }
+
+    let mut out: Vec<_> = map.into_values().collect();
+    out.sort_by(|a, b| b.version.cmp(&a.version));
+    out
+}
+
+/// Strip leading `v` from GitHub tag names.
+pub fn normalize_release_tag(tag: &str) -> String {
+    let t = tag.trim();
+    t.strip_prefix('v').unwrap_or(t).to_string()
+}
+
+/// Parse a minimal subset of GitHub releases JSON into [`RemoteRelease`]s.
+pub fn parse_github_releases_json(body: &str, host_asset_substr: &str) -> Result<Vec<RemoteRelease>> {
+    let val: serde_json::Value = serde_json::from_str(body)
+        .map_err(|e| ChatmailError::config(format!("github releases json: {e}")))?;
+    let arr = val
+        .as_array()
+        .ok_or_else(|| ChatmailError::config("github releases: expected array"))?;
+    let mut out = Vec::new();
+    let mut first = true;
+    for item in arr {
+        if item.get("draft").and_then(|d| d.as_bool()).unwrap_or(false) {
+            continue;
+        }
+        if item
+            .get("prerelease")
+            .and_then(|d| d.as_bool())
+            .unwrap_or(false)
+        {
+            continue;
+        }
+        let tag = item
+            .get("tag_name")
+            .and_then(|t| t.as_str())
+            .unwrap_or("")
+            .to_string();
+        if tag.is_empty() {
+            continue;
+        }
+        let version = normalize_release_tag(&tag);
+        let Ok(version) = sanitize_version_id(&version) else {
+            continue;
+        };
+        let published_at = item
+            .get("published_at")
+            .and_then(|t| t.as_str())
+            .map(|s| s.to_string());
+        let mut asset = None;
+        let mut asset_size = None;
+        if let Some(assets) = item.get("assets").and_then(|a| a.as_array()) {
+            for a in assets {
+                let name = a.get("name").and_then(|n| n.as_str()).unwrap_or("");
+                if name.contains(host_asset_substr)
+                    || name == host_release_asset_name()
+                    || name.contains("madmail")
+                {
+                    // Prefer exact host asset
+                    if name == host_release_asset_name()
+                        || name.contains(host_asset_substr)
+                    {
+                        asset = Some(name.to_string());
+                        asset_size = a.get("size").and_then(|s| s.as_u64());
+                        if name == host_release_asset_name() {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        out.push(RemoteRelease {
+            version,
+            published_at,
+            asset,
+            asset_size,
+            is_latest: first,
+        });
+        first = false;
+        if out.len() >= 20 {
+            break;
+        }
+    }
+    Ok(out)
+}
+
+/// Fetch remote releases (network). Used by `versions list --remote`.
+pub fn fetch_remote_releases(accept_invalid_certs: bool) -> Result<Vec<RemoteRelease>> {
+    let client = reqwest::blocking::Client::builder()
+        .user_agent("madmail-version-manager")
+        .danger_accept_invalid_certs(accept_invalid_certs)
+        .build()
+        .map_err(|e| ChatmailError::config(format!("http client: {e}")))?;
+    let resp = client
+        .get(github_releases_api_url())
+        .header("Accept", "application/vnd.github+json")
+        .send()
+        .map_err(|e| ChatmailError::config(format!("github releases fetch failed: {e}")))?;
+    if !resp.status().is_success() {
+        return Err(ChatmailError::config(format!(
+            "github releases HTTP {}",
+            resp.status()
+        )));
+    }
+    let body = resp
+        .text()
+        .map_err(|e| ChatmailError::config(format!("github releases body: {e}")))?;
+    let substr = if cfg!(windows) {
+        "windows"
+    } else {
+        "linux"
+    };
+    parse_github_releases_json(&body, substr)
+}
+
+pub fn default_keep() -> usize {
+    DEFAULT_KEEP
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn write_fake_bin(path: &Path) {
+        if let Some(p) = path.parent() {
+            fs::create_dir_all(p).unwrap();
+        }
+        let mut f = File::create(path).unwrap();
+        f.write_all(b"#!/bin/sh\necho madmail-v2 2.20.0\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+    }
+
+    #[test]
+    fn sanitize_rejects_path_separators() {
+        assert!(sanitize_version_id("../x").is_err());
+        assert!(sanitize_version_id("a/b").is_err());
+        assert!(sanitize_version_id("a\\b").is_err());
+        assert!(sanitize_version_id("2.20.0").is_ok());
+        assert!(sanitize_version_id("2.20.0+git.abc").is_ok());
+    }
+
+    #[test]
+    fn parse_version_from_preflight() {
+        assert_eq!(
+            parse_version_from_preflight_output("madmail-v2 2.20.1\n"),
+            "2.20.1"
+        );
+        assert_eq!(
+            parse_version_from_preflight_output("2.19.0"),
+            "2.19.0"
+        );
+    }
+
+    #[test]
+    fn default_root_is_platform_specific() {
+        #[cfg(windows)]
+        {
+            let r = default_install_root();
+            assert!(r.to_string_lossy().contains("Madmail"));
+            assert!(!r.to_string_lossy().contains("/opt"));
+        }
+        #[cfg(not(windows))]
+        {
+            assert_eq!(default_install_root(), PathBuf::from("/opt/madmail"));
+        }
+    }
+
+    #[test]
+    fn install_root_env_override() {
+        let dir = TempDir::new().unwrap();
+        // SAFETY: test-only env mutation; serial tests in this module.
+        std::env::set_var(ENV_INSTALL_ROOT, dir.path());
+        assert_eq!(install_root(), dir.path());
+        std::env::remove_var(ENV_INSTALL_ROOT);
+    }
+
+    #[test]
+    fn github_latest_url_uses_releases_latest_download() {
+        let url = github_latest_asset_url();
+        assert!(url.starts_with(
+            "https://github.com/themadorg/madmail/releases/latest/download/"
+        ));
+        assert!(url.contains("madmail"));
+    }
+
+    #[test]
+    fn install_list_activate_prune() {
+        let root = TempDir::new().unwrap();
+        let stable = root.path().join("bin").join(binary_file_name());
+        let src1 = root.path().join("payload1");
+        write_fake_bin(&src1);
+
+        install_candidate(
+            root.path(),
+            "2.19.0",
+            &src1,
+            VersionMeta {
+                version: "2.19.0".into(),
+                installed_at: None,
+                source: Some("test".into()),
+                source_url: None,
+                sha256: None,
+                variant: None,
+                os: None,
+                signature_ok: Some(true),
+            },
+        )
+        .unwrap();
+        install_candidate(
+            root.path(),
+            "2.20.0",
+            &src1,
+            VersionMeta {
+                version: "2.20.0".into(),
+                installed_at: None,
+                source: Some("test".into()),
+                source_url: None,
+                sha256: None,
+                variant: None,
+                os: None,
+                signature_ok: Some(true),
+            },
+        )
+        .unwrap();
+        install_candidate(
+            root.path(),
+            "2.18.0",
+            &src1,
+            VersionMeta {
+                version: "2.18.0".into(),
+                installed_at: None,
+                source: Some("test".into()),
+                source_url: None,
+                sha256: None,
+                variant: None,
+                os: None,
+                signature_ok: Some(true),
+            },
+        )
+        .unwrap();
+
+        set_active(root.path(), "2.20.0", &stable).unwrap();
+        assert_eq!(
+            resolve_active_version(root.path()).unwrap().as_deref(),
+            Some("2.20.0")
+        );
+        let list = list_installed(root.path()).unwrap();
+        assert_eq!(list.len(), 3);
+        assert!(list.iter().any(|v| v.active && v.version == "2.20.0"));
+
+        // keep 1 non-active → remove one of the two non-active
+        let removed = prune(root.path(), 1).unwrap();
+        assert_eq!(removed.len(), 1);
+        assert!(!removed.contains(&"2.20.0".to_string()));
+        assert!(list_installed(root.path()).unwrap().len() >= 2);
+
+        // cannot remove active
+        assert!(remove_version(root.path(), "2.20.0").is_err());
+    }
+
+    #[test]
+    fn merge_local_remote_marks_sources() {
+        let local = vec![InstalledVersion {
+            version: "2.20.0".into(),
+            path: PathBuf::from("/x"),
+            binary: PathBuf::from("/x/b"),
+            active: true,
+            meta: None,
+        }];
+        let remote = vec![
+            RemoteRelease {
+                version: "2.20.1".into(),
+                published_at: Some("2026-01-01T00:00:00Z".into()),
+                asset: Some("madmail-linux-amd64.tar.gz".into()),
+                asset_size: Some(100),
+                is_latest: true,
+            },
+            RemoteRelease {
+                version: "2.20.0".into(),
+                published_at: None,
+                asset: None,
+                asset_size: None,
+                is_latest: false,
+            },
+        ];
+        let merged = merge_local_and_remote(&local, &remote);
+        let v201 = merged.iter().find(|e| e.version == "2.20.1").unwrap();
+        assert_eq!(v201.source, "remote");
+        assert!(!v201.installed);
+        assert!(v201.remote_latest);
+        let v200 = merged.iter().find(|e| e.version == "2.20.0").unwrap();
+        assert_eq!(v200.source, "both");
+        assert!(v200.installed);
+        assert!(v200.active);
+    }
+
+    #[test]
+    fn parse_github_releases_json_basic() {
+        let body = r#"[
+          {"tag_name":"v2.20.1","draft":false,"prerelease":false,
+           "published_at":"2026-08-01T00:00:00Z",
+           "assets":[{"name":"madmail-linux-amd64.tar.gz","size":123}]},
+          {"tag_name":"v2.20.0","draft":false,"prerelease":false,"assets":[]}
+        ]"#;
+        let rels = parse_github_releases_json(body, "linux").unwrap();
+        assert_eq!(rels[0].version, "2.20.1");
+        assert!(rels[0].is_latest);
+        assert_eq!(
+            rels[0].asset.as_deref(),
+            Some("madmail-linux-amd64.tar.gz")
+        );
+        assert_eq!(rels[1].version, "2.20.0");
+    }
+
+    #[test]
+    fn meta_roundtrip() {
+        let root = TempDir::new().unwrap();
+        let src = root.path().join("b");
+        write_fake_bin(&src);
+        install_candidate(
+            root.path(),
+            "1.0.0",
+            &src,
+            VersionMeta {
+                version: "1.0.0".into(),
+                installed_at: Some("2026-08-03T12:00:00Z".into()),
+                source: Some("upgrade".into()),
+                source_url: None,
+                sha256: None,
+                variant: Some("linux-amd64".into()),
+                os: Some("linux".into()),
+                signature_ok: Some(true),
+            },
+        )
+        .unwrap();
+        let m = read_meta(root.path(), "1.0.0").unwrap().unwrap();
+        assert_eq!(m.version, "1.0.0");
+        assert_eq!(m.signature_ok, Some(true));
+    }
+
+    #[test]
+    fn sanitize_rejects_empty_and_reserved() {
+        assert!(sanitize_version_id("").is_err());
+        assert!(sanitize_version_id("   ").is_err());
+        assert!(sanitize_version_id("bad name").is_err());
+        assert!(sanitize_version_id("a@b").is_err());
+        assert!(sanitize_version_id("CON").is_err());
+        assert!(sanitize_version_id("nul").is_err());
+        assert!(sanitize_version_id("2.20.0-rc.1").is_ok());
+        assert!(sanitize_version_id("2.20.0_build1").is_ok());
+    }
+
+    #[test]
+    fn parse_version_handles_messy_output() {
+        assert_eq!(
+            parse_version_from_preflight_output("madmail-v2 2.20.1 (debug)\nextra\n"),
+            "2.20.1"
+        );
+        assert_eq!(
+            parse_version_from_preflight_output("\n\n  madmail-v2 3.0.0  \n"),
+            "3.0.0"
+        );
+        // No digit token → sanitized first line or unknown-*
+        let fallback = parse_version_from_preflight_output("only-text-here");
+        assert!(
+            fallback.starts_with("only-text-here") || fallback.starts_with("unknown-"),
+            "got {fallback}"
+        );
+    }
+
+    #[test]
+    fn normalize_release_tag_strips_v() {
+        assert_eq!(normalize_release_tag("v2.20.1"), "2.20.1");
+        assert_eq!(normalize_release_tag("2.20.1"), "2.20.1");
+        assert_eq!(normalize_release_tag("  v1.0.0  "), "1.0.0");
+    }
+
+    #[test]
+    fn path_helpers_layout() {
+        let root = PathBuf::from("/opt/madmail");
+        assert_eq!(versions_dir(&root), PathBuf::from("/opt/madmail/versions"));
+        assert_eq!(
+            version_dir(&root, "2.1.0"),
+            PathBuf::from("/opt/madmail/versions/2.1.0")
+        );
+        assert_eq!(
+            version_binary_path(&root, "2.1.0"),
+            PathBuf::from(format!("/opt/madmail/versions/2.1.0/{}", binary_file_name()))
+        );
+        assert_eq!(current_link_path(&root), PathBuf::from("/opt/madmail/current"));
+        assert_eq!(default_keep(), 5);
+        assert_eq!(
+            github_releases_api_url(),
+            "https://api.github.com/repos/themadorg/madmail/releases"
+        );
+        #[cfg(not(windows))]
+        assert_eq!(binary_file_name(), "madmail");
+        #[cfg(windows)]
+        assert_eq!(binary_file_name(), "madmail.exe");
+    }
+
+    #[test]
+    fn host_release_asset_name_is_os_specific() {
+        let name = host_release_asset_name();
+        assert!(name.starts_with("madmail-"));
+        assert!(name.contains("amd64") || name.contains("arm64"));
+        #[cfg(target_os = "linux")]
+        assert!(name.contains("linux"));
+        #[cfg(windows)]
+        assert!(name.contains("windows"));
+        // Must never claim /opt-style paths in the asset name
+        assert!(!name.contains("/opt"));
+    }
+
+    #[test]
+    fn list_installed_empty_without_tree() {
+        let root = TempDir::new().unwrap();
+        assert!(list_installed(root.path()).unwrap().is_empty());
+        assert_eq!(resolve_active_version(root.path()).unwrap(), None);
+    }
+
+    #[test]
+    fn list_skips_dirs_without_binary() {
+        let root = TempDir::new().unwrap();
+        ensure_install_layout(root.path()).unwrap();
+        fs::create_dir_all(version_dir(root.path(), "2.0.0")).unwrap();
+        // no binary → not listed
+        assert!(list_installed(root.path()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn set_active_missing_version_errors() {
+        let root = TempDir::new().unwrap();
+        let stable = root.path().join("bin").join(binary_file_name());
+        let err = set_active(root.path(), "9.9.9", &stable).unwrap_err();
+        assert!(
+            err.to_string().contains("not found") || err.to_string().contains("9.9.9"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn set_active_rejects_invalid_id() {
+        let root = TempDir::new().unwrap();
+        let stable = root.path().join("s");
+        assert!(set_active(root.path(), "../evil", &stable).is_err());
+    }
+
+    #[test]
+    fn switch_active_between_versions() {
+        let root = TempDir::new().unwrap();
+        let stable = root.path().join("bin").join(binary_file_name());
+        let src = root.path().join("p");
+        write_fake_bin(&src);
+        for v in ["1.0.0", "2.0.0"] {
+            install_candidate(
+                root.path(),
+                v,
+                &src,
+                VersionMeta {
+                    version: v.into(),
+                    installed_at: None,
+                    source: Some("test".into()),
+                    source_url: None,
+                    sha256: None,
+                    variant: None,
+                    os: None,
+                    signature_ok: Some(true),
+                },
+            )
+            .unwrap();
+        }
+        set_active(root.path(), "1.0.0", &stable).unwrap();
+        assert_eq!(
+            resolve_active_version(root.path()).unwrap().as_deref(),
+            Some("1.0.0")
+        );
+        set_active(root.path(), "2.0.0", &stable).unwrap();
+        assert_eq!(
+            resolve_active_version(root.path()).unwrap().as_deref(),
+            Some("2.0.0")
+        );
+        // stable link should resolve into 2.0.0 tree
+        let real = fs::canonicalize(&stable).unwrap();
+        assert!(
+            real.to_string_lossy().contains("2.0.0"),
+            "stable points at {}",
+            real.display()
+        );
+    }
+
+    #[test]
+    fn prune_keep_zero_removes_all_non_active() {
+        let root = TempDir::new().unwrap();
+        let stable = root.path().join("bin").join(binary_file_name());
+        let src = root.path().join("p");
+        write_fake_bin(&src);
+        for v in ["1.0.0", "2.0.0", "3.0.0"] {
+            install_candidate(
+                root.path(),
+                v,
+                &src,
+                VersionMeta {
+                    version: v.into(),
+                    installed_at: None,
+                    source: None,
+                    source_url: None,
+                    sha256: None,
+                    variant: None,
+                    os: None,
+                    signature_ok: None,
+                },
+            )
+            .unwrap();
+        }
+        set_active(root.path(), "3.0.0", &stable).unwrap();
+        let removed = prune(root.path(), 0).unwrap();
+        assert_eq!(removed.len(), 2);
+        assert!(!removed.iter().any(|v| v == "3.0.0"));
+        let left = list_installed(root.path()).unwrap();
+        assert_eq!(left.len(), 1);
+        assert_eq!(left[0].version, "3.0.0");
+        assert!(left[0].active);
+    }
+
+    #[test]
+    fn prune_never_removes_only_active() {
+        let root = TempDir::new().unwrap();
+        let stable = root.path().join("bin").join(binary_file_name());
+        let src = root.path().join("p");
+        write_fake_bin(&src);
+        install_candidate(
+            root.path(),
+            "5.0.0",
+            &src,
+            VersionMeta {
+                version: "5.0.0".into(),
+                installed_at: None,
+                source: None,
+                source_url: None,
+                sha256: None,
+                variant: None,
+                os: None,
+                signature_ok: None,
+            },
+        )
+        .unwrap();
+        set_active(root.path(), "5.0.0", &stable).unwrap();
+        let removed = prune(root.path(), 0).unwrap();
+        assert!(removed.is_empty());
+        assert_eq!(list_installed(root.path()).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn remove_nonexistent_errors() {
+        let root = TempDir::new().unwrap();
+        let err = remove_version(root.path(), "0.0.1").unwrap_err();
+        assert!(err.to_string().contains("not found"), "got: {err}");
+    }
+
+    #[test]
+    fn remove_non_active_ok() {
+        let root = TempDir::new().unwrap();
+        let stable = root.path().join("bin").join(binary_file_name());
+        let src = root.path().join("p");
+        write_fake_bin(&src);
+        for v in ["1.0.0", "2.0.0"] {
+            install_candidate(
+                root.path(),
+                v,
+                &src,
+                VersionMeta {
+                    version: v.into(),
+                    installed_at: None,
+                    source: None,
+                    source_url: None,
+                    sha256: None,
+                    variant: None,
+                    os: None,
+                    signature_ok: None,
+                },
+            )
+            .unwrap();
+        }
+        set_active(root.path(), "2.0.0", &stable).unwrap();
+        remove_version(root.path(), "1.0.0").unwrap();
+        let left = list_installed(root.path()).unwrap();
+        assert_eq!(left.len(), 1);
+        assert_eq!(left[0].version, "2.0.0");
+    }
+
+    #[test]
+    fn install_candidate_overwrites_same_version() {
+        let root = TempDir::new().unwrap();
+        let src_a = root.path().join("a");
+        let src_b = root.path().join("b");
+        write_fake_bin(&src_a);
+        {
+            let mut f = File::create(&src_b).unwrap();
+            f.write_all(b"#!/bin/sh\necho madmail-v2 9.9.9\n").unwrap();
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                fs::set_permissions(&src_b, fs::Permissions::from_mode(0o755)).unwrap();
+            }
+        }
+        let meta = VersionMeta {
+            version: "1.0.0".into(),
+            installed_at: None,
+            source: Some("first".into()),
+            source_url: None,
+            sha256: None,
+            variant: None,
+            os: None,
+            signature_ok: Some(true),
+        };
+        install_candidate(root.path(), "1.0.0", &src_a, meta.clone()).unwrap();
+        install_candidate(
+            root.path(),
+            "1.0.0",
+            &src_b,
+            VersionMeta {
+                source: Some("second".into()),
+                ..meta
+            },
+        )
+        .unwrap();
+        let bytes = fs::read(version_binary_path(root.path(), "1.0.0")).unwrap();
+        assert!(String::from_utf8_lossy(&bytes).contains("9.9.9"));
+        assert_eq!(
+            read_meta(root.path(), "1.0.0")
+                .unwrap()
+                .unwrap()
+                .source
+                .as_deref(),
+            Some("second")
+        );
+    }
+
+    #[test]
+    fn merge_local_only_and_remote_only() {
+        let local = vec![InstalledVersion {
+            version: "0.9.0".into(),
+            path: PathBuf::from("/l"),
+            binary: PathBuf::from("/l/b"),
+            active: false,
+            meta: None,
+        }];
+        let remote = vec![RemoteRelease {
+            version: "1.0.0".into(),
+            published_at: None,
+            asset: Some("x".into()),
+            asset_size: Some(1),
+            is_latest: true,
+        }];
+        let merged = merge_local_and_remote(&local, &remote);
+        assert_eq!(merged.len(), 2);
+        let local_only = merged.iter().find(|e| e.version == "0.9.0").unwrap();
+        assert_eq!(local_only.source, "local");
+        assert!(local_only.installed);
+        assert!(!local_only.remote_latest);
+        let remote_only = merged.iter().find(|e| e.version == "1.0.0").unwrap();
+        assert_eq!(remote_only.source, "remote");
+        assert!(!remote_only.installed);
+        assert!(remote_only.remote_latest);
+    }
+
+    #[test]
+    fn merge_empty_inputs() {
+        assert!(merge_local_and_remote(&[], &[]).is_empty());
+    }
+
+    #[test]
+    fn parse_github_skips_draft_and_prerelease() {
+        let body = r#"[
+          {"tag_name":"v3.0.0-rc1","draft":false,"prerelease":true,"assets":[]},
+          {"tag_name":"v2.99.0","draft":true,"prerelease":false,"assets":[]},
+          {"tag_name":"v2.20.0","draft":false,"prerelease":false,
+           "assets":[{"name":"madmail-windows-amd64.tar.gz","size":50}]}
+        ]"#;
+        let rels = parse_github_releases_json(body, "windows").unwrap();
+        assert_eq!(rels.len(), 1);
+        assert_eq!(rels[0].version, "2.20.0");
+        assert!(rels[0].is_latest);
+        assert_eq!(
+            rels[0].asset.as_deref(),
+            Some("madmail-windows-amd64.tar.gz")
+        );
+    }
+
+    #[test]
+    fn parse_github_invalid_json_errors() {
+        assert!(parse_github_releases_json("not-json", "linux").is_err());
+        assert!(parse_github_releases_json("{}", "linux").is_err());
+    }
+
+    #[test]
+    fn parse_github_caps_at_twenty() {
+        let mut items = Vec::new();
+        for i in 0..30 {
+            items.push(format!(
+                r#"{{"tag_name":"v1.0.{i}","draft":false,"prerelease":false,"assets":[]}}"#
+            ));
+        }
+        let body = format!("[{}]", items.join(","));
+        let rels = parse_github_releases_json(&body, "linux").unwrap();
+        assert_eq!(rels.len(), 20);
+        assert!(rels[0].is_latest);
+        assert!(!rels[1].is_latest);
+    }
+
+    #[test]
+    fn install_root_prefers_install_root_over_opt_alias() {
+        let a = TempDir::new().unwrap();
+        let b = TempDir::new().unwrap();
+        std::env::set_var(ENV_INSTALL_ROOT, a.path());
+        std::env::set_var(ENV_OPT_ROOT_ALIAS, b.path());
+        assert_eq!(install_root(), a.path());
+        std::env::remove_var(ENV_INSTALL_ROOT);
+        std::env::remove_var(ENV_OPT_ROOT_ALIAS);
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn install_root_opt_alias_when_install_root_unset() {
+        std::env::remove_var(ENV_INSTALL_ROOT);
+        let b = TempDir::new().unwrap();
+        std::env::set_var(ENV_OPT_ROOT_ALIAS, b.path());
+        assert_eq!(install_root(), b.path());
+        std::env::remove_var(ENV_OPT_ROOT_ALIAS);
+    }
+
+    #[test]
+    fn ensure_install_layout_creates_versions() {
+        let root = TempDir::new().unwrap();
+        ensure_install_layout(root.path()).unwrap();
+        assert!(versions_dir(root.path()).is_dir());
+    }
+
+    #[test]
+    fn read_meta_missing_is_none() {
+        let root = TempDir::new().unwrap();
+        assert!(read_meta(root.path(), "1.0.0").unwrap().is_none());
+    }
+
+    #[test]
+    fn install_candidate_rejects_bad_version_id() {
+        let root = TempDir::new().unwrap();
+        let src = root.path().join("p");
+        write_fake_bin(&src);
+        let err = install_candidate(
+            root.path(),
+            "bad/id",
+            &src,
+            VersionMeta {
+                version: "bad".into(),
+                installed_at: None,
+                source: None,
+                source_url: None,
+                sha256: None,
+                variant: None,
+                os: None,
+                signature_ok: None,
+            },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("invalid"), "got: {err}");
+    }
+
+    #[test]
+    fn windows_style_paths_never_use_opt_in_default_stable_on_windows_cfg() {
+        // Cross-check: default_install_root documentation contract for non-Windows.
+        #[cfg(not(windows))]
+        {
+            assert_eq!(default_stable_binary_path(), PathBuf::from("/usr/local/bin/madmail"));
+        }
+        #[cfg(windows)]
+        {
+            let p = default_stable_binary_path();
+            let s = p.to_string_lossy();
+            assert!(s.contains("Madmail") || s.contains("madmail"));
+            assert!(!s.contains("/opt"));
+            assert!(s.ends_with("madmail.exe") || s.contains("madmail.exe"));
+        }
+    }
+}

--- a/docs/TDD/24-version-manager.md
+++ b/docs/TDD/24-version-manager.md
@@ -1,14 +1,15 @@
-# Version manager (`/opt/madmail`)
+# Version manager (platform install root)
 
 **Status:** design plan (not implemented)  
 **Related code today:**
 
 | Area | Location | Current behavior |
 |------|----------|------------------|
-| Install binary | `crates/chatmail/src/ctl/install/system.rs` | Copies live exe → `/usr/local/bin/madmail` |
-| systemd unit | `crates/chatmail/src/ctl/install/systemd.rs` | `ExecStart=/usr/local/bin/madmail …` |
+| Install binary | `crates/chatmail/src/ctl/install/system.rs` | Unix: copies live exe → `/usr/local/bin/madmail`; Windows: install path under ProgramData-style layout |
+| Service | `systemd.rs` (Unix); Windows service install | Unix: `ExecStart=/usr/local/bin/madmail …`; Windows: service ImagePath to installed exe |
 | Signed upgrade | `crates/chatmail/src/upgrade.rs` | In-place replace of `current_exe`; sibling `*.prev` only |
-| Deploy scripts | `scripts/deploy.sh`, `scripts/deploy.defaults.sh` | `REMOTE_BIN=/usr/local/bin/madmail` |
+| Deploy scripts | `scripts/deploy.sh`, `scripts/deploy.defaults.sh` | Linux: `REMOTE_BIN=/usr/local/bin/madmail` |
+| Install roots | `ctl/install/mod.rs` | Windows config/state: `%ProgramData%\Madmail\{config,data}` via `windows_madmail_root()` — **no `/opt`** |
 | Version stamp | `.version`, workspace `Cargo.toml` | e.g. `2.20.0` |
 
 **Operator CLI (planned):** [`../guide/cli/`](../guide/cli/README.md) — new `versions` / extend `upgrade` (see below).  
@@ -23,33 +24,52 @@ Upgrades keep **one** previous binary (`/usr/local/bin/madmail.prev`). That is e
 - Keep a **history** of N known-good releases on disk
 - Switch between versions without re-downloading
 - Inspect **which** build is live vs archived
-- Avoid filling `/usr/local/bin` with ad-hoc folders of old bins
+- Avoid filling PATH directories (`/usr/local/bin`, or a Windows “bin” folder) with ad-hoc copies of old bins
 
-Putting archives under `/usr/local/bin/` is the wrong place: that directory is for **PATH commands**, not version trees.
+Putting archives next to the PATH command is the wrong place: PATH is for the **stable launcher**, not the version tree. **Windows has no `/opt`** — use a Windows-native install root instead (below).
 
 ---
 
 ## Goals
 
-1. Store versioned madmail binaries under **`/opt/madmail`** (FHS-friendly app root).
-2. Keep **`/usr/local/bin/madmail`** as a stable PATH entry (symlink → active version).
+1. Store versioned madmail binaries under a **platform install root** (not the PATH directory alone):
+   - **Linux/Unix:** `/opt/madmail` (FHS add-on app root)
+   - **Windows:** `%ProgramFiles%\Madmail` (default; no `/opt`)
+2. Keep a **stable PATH / service entry** that points at the active version (symlink, junction, or small launcher — platform-appropriate).
 3. On every successful **install** / **upgrade**, archive the previous binary with a **version id**.
 4. Support **list**, **use** (switch), **prune**, and **rollback** without re-fetch.
-5. Preserve existing safety: Ed25519 signature check, host preflight (`version`), systemd stop/start, automatic rollback if post-install smoke fails.
-6. **Signature on every activation path:** any install/upgrade that writes a binary into the version tree **must** verify Ed25519 first; `versions use` **must** re-verify the on-disk binary before flipping the active symlink. Inventory commands (`list`, `current`, `path`, `prune`, `remove`) do **not** need a signature check.
-7. **One-shot “get latest from GitHub”:** `madmail update latest` downloads the current release asset from GitHub Releases, then runs the **same** URL-upgrade security pipeline (TLS, size caps, archive rules, **mandatory Ed25519 signature check**, host preflight, version-tree install, smoke/rollback) as an explicit download URL. **GitHub does not replace signature verification** — unsigned or bad-signed assets must always abort.
-8. Migrate smoothly from the current single-file install.
+5. Preserve existing safety: Ed25519 signature check, host preflight (`version`), service stop/start (systemd or Windows service), automatic rollback if post-install smoke fails.
+6. **Signature on every activation path:** any install/upgrade that writes a binary into the version tree **must** verify Ed25519 first; `versions use` **must** re-verify the on-disk binary before flipping the active pointer. Inventory commands (`list`, `current`, `path`, `prune`, `remove`) do **not** need a signature check.
+7. **One-shot “get latest from GitHub”:** `madmail update latest` downloads the current **host-matching** release asset (Linux or Windows), then runs the **same** URL-upgrade security pipeline (TLS, size caps, archive rules, **mandatory Ed25519 signature check**, host preflight, version-tree install, smoke/rollback). **GitHub does not replace signature verification** — unsigned or bad-signed assets must always abort.
+8. Migrate smoothly from the current single-file install on **both** Unix and Windows.
+9. **Same CLI semantics** on Windows and Unix (`versions list|use|…`, `update latest`); only roots and service integration differ.
 
 ### Non-goals (v1)
 
 - Multi-arch side-by-side on one host (one primary arch per install tree).
-- Storing full release tarballs / Windows artifacts under `/opt` (Linux server binary only).
+- Storing full multi-platform release tarballs in the version tree (store **this host’s** extracted binary only: `madmail` or `madmail.exe`).
 - Replacing GitHub Releases / `publish.sh` as the distribution channel.
-- Per-user non-root installs (upgrade/install remain root-owned system tools).
+- Per-user non-admin installs as the default (system install remains elevated: root / Administrator). Optional later: per-user root under `%LOCALAPPDATA%\Madmail`.
 
 ---
 
 ## Layout
+
+Paths are resolved by a single helper, e.g. `install_root()` → env override or platform default. **Never hardcode `/opt` on Windows.**
+
+### Platform defaults
+
+| Role | Linux / Unix | Windows |
+|------|----------------|---------|
+| Install / version root | `/opt/madmail` | `%ProgramFiles%\Madmail` (e.g. `C:\Program Files\Madmail`) |
+| Version dirs | `{root}/versions/<ver>/madmail` | `{root}\versions\<ver>\madmail.exe` |
+| Optional `current` pointer | `{root}/current` → `versions/<ver>` (symlink) | `{root}\current` → `versions\<ver>` (**directory junction** or symlink; both need appropriate privileges) |
+| Stable PATH / service binary | `/usr/local/bin/madmail` → active exe (symlink) | Prefer `{root}\bin\madmail.exe` → active exe, **or** re-point Windows service `ImagePath` to active path; add `{root}\bin` to machine PATH if desired |
+| Runtime state (mail, DB) | `/var/lib/madmail` (or `state_dir`) | `%ProgramData%\Madmail\data` (existing `windows_madmail_root()` — **not** under Program Files version tree) |
+| Config | `/etc/…` / configured path | `%ProgramData%\Madmail\config` |
+| Env override (tests + custom) | `MADMAIL_INSTALL_ROOT` (alias: `MADMAIL_OPT_ROOT` on Unix for backward naming) | Same `MADMAIL_INSTALL_ROOT` (e.g. `C:\Temp\madmail-install-test`) |
+
+### Linux tree
 
 ```text
 /opt/madmail/
@@ -57,17 +77,44 @@ Putting archives under `/usr/local/bin/` is the wrong place: that directory is f
   versions/
     2.19.0/
       madmail                        # executable (mode 0755)
-      meta.json                      # optional install metadata
+      meta.json
     2.20.0/
       madmail
       meta.json
-  state/                             # reserved; do NOT put maildir here
-                                     # (runtime state stays under InstallConfig.state_dir,
-                                     #  typically /var/lib/madmail)
 
 /usr/local/bin/madmail -> /opt/madmail/versions/2.20.0/madmail
-# or -> /opt/madmail/current/madmail
 ```
+
+### Windows tree
+
+```text
+%ProgramFiles%\Madmail\
+  current → versions\2.20.0          # junction or symlink (optional)
+  versions\
+    2.19.0\
+      madmail.exe
+      meta.json
+    2.20.0\
+      madmail.exe
+      meta.json
+  bin\
+    madmail.exe → ..\versions\2.20.0\madmail.exe   # stable entry (symlink/junction/hardlink)
+
+# Runtime state stays separate:
+%ProgramData%\Madmail\config\
+%ProgramData%\Madmail\data\
+```
+
+**Windows notes:**
+
+| Topic | Detail |
+|-------|--------|
+| No `/opt` | Do not create or document `C:\opt\madmail` as the default. |
+| Symlinks | Creating symlinks often requires Administrator or Developer Mode; **directory junctions** (`mklink /J`) or **replace-file** of a stable `bin\madmail.exe` copy are acceptable if symlink fails — document chosen strategy in implementation. Prefer **atomic replace** of the active pointer. |
+| Locked exe | Windows may lock the running `madmail.exe`; upgrade must stop the Windows service (and any other holders) before replace, same as stop-systemd-before-replace on Linux. |
+| Binary name | Always `madmail.exe` in version dirs; CLI still invoked as `madmail` when on PATH. |
+| `update latest` asset | Host-matching Windows asset (e.g. `madmail-windows-amd64.zip` / `.tar.gz` / signed exe — follow whatever `publish.sh` ships); same size + signature rules as Linux. |
+| Archive formats | If Windows releases use `.zip`, either allow `.zip` **only for Windows builds** in the download helper or ship `.tar.gz` for both; document in PR that implements `update latest`. |
 
 ### Version directory naming
 
@@ -75,8 +122,8 @@ Putting archives under `/usr/local/bin/` is the wrong place: that directory is f
 |------|--------|
 | Primary id | Semver from binary (`madmail version` / embedded package version), e.g. `2.20.0` |
 | Collision | Same semver rebuilt → use `2.20.0+YYYYMMDDHHMMSS` or `2.20.0+git.<shortsha>` if available |
-| Invalid chars | Reject path separators; only `[0-9A-Za-z._+-]` |
-| Active pointer | Atomic symlink replace for `current` and `/usr/local/bin/madmail` |
+| Invalid chars | Reject path separators (`/`, `\`) and Windows-reserved names; only `[0-9A-Za-z._+-]` |
+| Active pointer | Atomic update of `current` + stable PATH entry (symlink/junction/replace) |
 
 ### `meta.json` (optional but recommended)
 
@@ -88,22 +135,27 @@ Putting archives under `/usr/local/bin/` is the wrong place: that directory is f
   "source_url": "https://github.com/themadorg/madmail/releases/download/v2.20.0/madmail-linux-amd64",
   "sha256": "…",
   "variant": "linux-amd64",
+  "os": "linux",
   "signature_ok": true
 }
 ```
+
+On Windows, `variant` / `os` reflect the Windows asset (e.g. `"windows-amd64"`, `"windows"`).
 
 ---
 
 ## Runtime and PATH contract
 
-| Consumer | Resolution |
-|----------|------------|
-| Shell / admin | `/usr/local/bin/madmail` on `PATH` |
-| systemd | Prefer **stable path** in unit file: either keep `ExecStart=/usr/local/bin/madmail` (symlink) **or** `ExecStart=/opt/madmail/current/madmail` |
-| `madmail upgrade` | Resolves **real** path via `current_exe` + canonicalize; installs new version **next to** version tree, then flips symlink |
-| `*.prev` | Deprecated after migration; keep one generation for compatibility or map to “previous version dir” |
+| Consumer | Linux / Unix | Windows |
+|----------|--------------|---------|
+| Shell / admin | `/usr/local/bin/madmail` on `PATH` | `{install_root}\bin\madmail.exe` on machine PATH (or service-only if PATH not updated) |
+| Service | Prefer stable `ExecStart=/usr/local/bin/madmail` (symlink) | Prefer stable service `ImagePath` → `{install_root}\bin\madmail.exe` (or `current\madmail.exe`) so version flips do not require rewriting the service definition when possible |
+| `madmail upgrade` | Resolve real path via `current_exe` + canonicalize; install into version tree; flip active pointer | Same algorithm; stop Windows service before replace if file is locked |
+| `*.prev` | Deprecated after migration | Same |
 
-**Recommendation:** keep `ExecStart=/usr/local/bin/madmail` so existing units and `REMOTE_BIN` defaults keep working; only the symlink target changes.
+**Recommendation (Linux):** keep `ExecStart=/usr/local/bin/madmail` so existing units and `REMOTE_BIN` defaults keep working; only the symlink target changes.
+
+**Recommendation (Windows):** keep one stable path for the service and PATH; never scatter versioned exes on the user PATH.
 
 ---
 
@@ -124,7 +176,7 @@ madmail versions path [version]     # print filesystem path
 
 | Command | Behavior |
 |---------|----------|
-| `list` | Enumerate **local** `/opt/madmail/versions/*`; mark active; show size, mtime, meta |
+| `list` | Enumerate **local** `{install_root}/versions/*` (Unix `/opt/madmail`, Windows `%ProgramFiles%\Madmail`); mark active; show size, mtime, meta |
 | `list --remote` | Query **GitHub Releases** (same project as `update latest`) and list remote version tags/assets available for this host; mark which are already installed locally and which is active; indicate remote `latest` |
 | `current` | Print active version id + resolved path |
 | `use V` | **Must** re-verify Ed25519 signature on `versions/V/madmail`, then preflight `version`, stop services, flip symlinks, start services; on smoke failure flip back. Refuse switch if signature fails (treat as tampered / unsigned archive). |
@@ -161,7 +213,7 @@ VERSION     SOURCE   ACTIVE  NOTES
 | Operation | Ed25519 signature |
 |-----------|-------------------|
 | Install new binary into the version tree (`install` / `upgrade` from path or URL) | **Always required** before write/activate (same as today — never skip) |
-| **`madmail update latest`** (and `upgrade latest`) | **Always required** after download/extract, **before** writing into `/opt/madmail/versions/` or stopping services. Same `verify_signature` as `perform_upgrade`. **Never skip** because the source is “official GitHub”. Fail closed: unsigned / invalid signature → abort, leave active version unchanged. |
+| **`madmail update latest`** (and `upgrade latest`) | **Always required** after download/extract, **before** writing into `{install_root}/versions/` or stopping services. Same `verify_signature` as `perform_upgrade`. **Never skip** because the source is “official GitHub”. Fail closed: unsigned / invalid signature → abort, leave active version unchanged. |
 | `versions use <V>` (activate an already-archived binary) | **Always required** on that on-disk file before stop/symlink flip |
 | `versions list` (local), `list --remote`, `current`, `path`, `prune`, `remove` | Not required — inventory/metadata only; remote list does **not** download or activate binaries |
 
@@ -184,7 +236,7 @@ Resolve the **latest** published madmail binary from **GitHub Releases** and ins
 |------|------|
 | Intent | “Give me the newest signed release for this host” |
 | Source | GitHub only: `https://github.com/themadorg/madmail/releases` (not arbitrary mirrors) |
-| Default asset | Prefer host-appropriate Linux server asset, e.g. `madmail-linux-amd64.tar.gz` (or musl / arch variant if detection already exists); document exact name table in operator CLI docs |
+| Default asset | Prefer **host OS + arch** asset: e.g. Linux `madmail-linux-amd64.tar.gz` (or musl); Windows `madmail-windows-amd64…` as published; document exact name table in operator CLI docs |
 | Resolution strategy (v1) | Prefer stable redirect URL: `…/releases/latest/download/<asset>` (same family as existing test fixture URL). Optional later: GitHub Releases API for tag/metadata before download. |
 | Entry point | Clap: `update` subcommand accepts either a path/URL **or** the keyword `latest` (not a free-form path). `upgrade latest` should behave the same for parity. |
 | After resolve | Call the **identical** code path as `handle_update_url` → versioned `perform_upgrade` (no bypass of checks). |
@@ -199,7 +251,7 @@ Resolve the **latest** published madmail binary from **GitHub Releases** and ins
 5. extract madmail from tar.gz when needed (owner-only temp; path safety)
 6. **verify Ed25519 signature on candidate (MANDATORY — refuse unsigned / invalid; do not proceed to install)**
 7. host preflight: candidate `version` (captures version id; aborts on exec/loader failure)
-8. install into /opt/madmail/versions/<VERSION>/, flip symlinks, smoke, rollback on failure
+8. install into `{install_root}/versions/<VERSION>/` (`madmail` or `madmail.exe`), flip active pointer, smoke, rollback on failure
 9. optional prune --keep N after success
 ```
 
@@ -224,44 +276,46 @@ Replace the current “overwrite file + `*.prev`” path in `perform_upgrade` wi
 1. verify Ed25519 signature on candidate
 2. preflight: candidate `version` (captures VERSION string)
 3. require root
-4. ensure /opt/madmail/versions exists (mode root-owned 0755)
+4. ensure `{install_root}/versions` exists (Unix: root-owned 0755; Windows: Administrators / appropriate ACLs)
 5. VERSION = parse from preflight output (fallback: meta / timestamp)
-6. DEST = /opt/madmail/versions/VERSION/
+6. DEST = `{install_root}/versions/VERSION/`
    - if DEST exists and same content hash → skip copy or refuse
-   - else install candidate → DEST/madmail (atomic write via temp + rename)
+   - else install candidate → `DEST/madmail` or `DEST/madmail.exe` (atomic write via temp + rename)
 7. write meta.json
-8. PREV = resolve current symlink target (or legacy /usr/local/bin/madmail file)
-9. stop systemd units
-10. atomic symlink update:
-    - /opt/madmail/current → versions/VERSION
-    - /usr/local/bin/madmail → versions/VERSION/madmail
+8. PREV = resolve current active pointer (or legacy single-file install path)
+9. stop services (systemd **or** Windows service)
+10. atomic active-pointer update:
+    - `{install_root}/current` → `versions/VERSION`
+    - stable PATH entry → active binary (Unix symlink; Windows junction/symlink/replace)
 11. smoke preflight on resolved path
-12. on failure: restore previous symlink targets, start services, error
+12. on failure: restore previous active pointer, start services, error
 13. on success: start services; optional prune --keep N
-14. post-upgrade hooks (www migrate, docs refresh) unchanged
+14. post-upgrade hooks (www migrate, docs refresh) unchanged where applicable
 ```
 
 ### Migration from legacy install
 
 | On-disk state | Action on first versioned upgrade/install |
 |---------------|-------------------------------------------|
-| Regular file `/usr/local/bin/madmail` | Copy into `versions/<oldver>/`, then convert PATH entry to symlink |
-| `/usr/local/bin/madmail.prev` | Import as `versions/<prevver>/` if version parseable; else `versions/prev-import-<ts>/` |
-| Already symlink into `/opt/madmail/…` | No-op migrate; continue versioned flow |
-| Unit still points at old path | Symlink keeps unit valid; optional `systemctl daemon-reload` only if unit text changes |
+| Regular file `/usr/local/bin/madmail` (Unix) | Copy into `versions/<oldver>/`, then convert PATH entry to symlink |
+| Single installed `madmail.exe` (Windows) | Copy into `versions\<oldver>\madmail.exe`, establish stable `bin\` or service path |
+| `*.prev` sibling | Import as `versions/<prevver>/` if version parseable; else `versions/prev-import-<ts>/` |
+| Already under platform install root version tree | No-op migrate; continue versioned flow |
+| Service still points at old path | Prefer updating only the stable entry target; rewrite service ImagePath/unit only if needed |
 
 ---
 
 ## Install path changes
 
-`InstallConfig.binary_path` today defaults to `/usr/local/bin/madmail`.
+`InstallConfig.binary_path` today defaults to `/usr/local/bin/madmail` on Unix; Windows uses its install defaults.
 
 | Phase | Install behavior |
 |-------|------------------|
-| v1 | Install into `/opt/madmail/versions/<ver>/madmail`, create `/usr/local/bin/madmail` symlink, leave `binary_path` as the **symlink path** for unit generation |
-| later | Optional flag `--binary-root /opt/madmail` for custom roots (test VMs, multi-instance) |
+| v1 (Unix) | Install into `/opt/madmail/versions/<ver>/madmail`, create `/usr/local/bin/madmail` symlink; `binary_path` stays the **stable** path for unit generation |
+| v1 (Windows) | Install into `%ProgramFiles%\Madmail\versions\<ver>\madmail.exe`, stable entry under `%ProgramFiles%\Madmail\bin\madmail.exe` (or equivalent); service uses stable path |
+| later | Optional flag `--install-root <path>` / `MADMAIL_INSTALL_ROOT` for custom roots (test VMs, multi-instance); **do not** require `/opt` on Windows |
 
-Dry-run (`install --dry-run`) must print both the version dir and the symlink plan.
+Dry-run (`install --dry-run`) must print platform-resolved version dir and stable-entry plan.
 
 ---
 
@@ -270,23 +324,29 @@ Dry-run (`install --dry-run`) must print both the version dir and the symlink pl
 | Knob | Today | After |
 |------|-------|--------|
 | `REMOTE_BIN` | `/usr/local/bin/madmail` | Unchanged (symlink) |
-| Unsigned deploy | `install -m 755` overwrites file | Prefer `madmail upgrade` or a small helper that writes into `/opt/madmail/versions/…` |
+| Unsigned deploy | overwrites single binary | Prefer `madmail upgrade` / helper into `{install_root}/versions/…` |
 | Signed deploy | `madmail upgrade` | Same command; version manager is internal |
 | Disk | N/A | Document prune policy; default keep 5 |
+| Linux servers | `REMOTE_BIN` symlink path | Unchanged |
+| Windows hosts | N/A in `deploy.sh` today | Document manual/service path; version tree under Program Files |
 
-Local dev / CI: version manager is **production-install** concern; unit tests use a temp root via env, e.g. `MADMAIL_OPT_ROOT=/tmp/madmail-opt-test`.
+Local dev / CI: version manager is a **production-install** concern; unit tests use a temp root via env, e.g. `MADMAIL_INSTALL_ROOT=/tmp/madmail-install-test` (Unix) or a temp directory on Windows CI. Accept `MADMAIL_OPT_ROOT` as a **deprecated alias** for the same override on Unix only.
 
 ---
 
 ## Configuration
 
-| Mechanism | Key / env | Default |
-|-----------|-----------|---------|
-| Env (test/override) | `MADMAIL_OPT_ROOT` | `/opt/madmail` |
-| Keep count | setting or flag `--keep` | `5` |
-| Config file | optional later in `madmail.conf` | not required for v1 |
+| Mechanism | Key / env | Default (Unix) | Default (Windows) |
+|-----------|-----------|----------------|-------------------|
+| Env (test/override) | `MADMAIL_INSTALL_ROOT` | `/opt/madmail` | `%ProgramFiles%\Madmail` |
+| Env (alias) | `MADMAIL_OPT_ROOT` | same as install root if set | ignored or maps to install root (document one behavior) |
+| Keep count | setting or flag `--keep` | `5` | `5` |
+| Config file | optional later in conf | not required for v1 | not required for v1 |
 
-Do **not** store mailboxes or `chatmail.db` under `/opt/madmail`; state remains `/var/lib/madmail` (or configured `state_dir`).
+Do **not** store mailboxes or `chatmail.db` under the install/version root. State remains:
+
+- Unix: `/var/lib/madmail` (or configured `state_dir`)
+- Windows: `%ProgramData%\Madmail\data` (existing layout)
 
 ---
 
@@ -294,19 +354,19 @@ Do **not** store mailboxes or `chatmail.db` under `/opt/madmail`; state remains 
 
 | Concern | Mitigation |
 |---------|------------|
-| Untrusted binaries entering versions/ | **Always** Ed25519-verify the candidate before writing into `/opt/madmail/versions/` on install/upgrade (same as today; never skip) |
+| Untrusted binaries entering versions/ | **Always** Ed25519-verify the candidate before writing into `{install_root}/versions/` on install/upgrade (same as today; never skip) |
 | `update latest` / URL download | Same size caps (`MAX_DOWNLOAD_SIZE`), archive allow-list, TLS defaults, then **mandatory Ed25519** + preflight; GitHub “latest” is **not** a trust shortcut and **never** waives signature verification |
 | Tampered archived binary activated via `use` | **Always** re-run Ed25519 verify on `versions/V/madmail` before stop/symlink flip; refuse if verify fails |
 | Inventory without crypto cost | `list` / `list --remote` / `current` / `path` / `prune` / `remove` do not verify binary signatures (remote list is metadata only; installing still requires sig) |
 | Symlink attacks | Create dirs as root; refuse to follow unexpected symlinks when writing DEST |
-| PATH hijack | `/usr/local/bin/madmail` owned root:root, mode 755 symlink |
+| PATH hijack | Unix: `/usr/local/bin/madmail` root:root 755 symlink; Windows: ACL so only Administrators write install root / `bin` |
 | Prune deletes active | Refuse remove/prune of active target |
 | Rollback window | Keep at least previous version until next successful upgrade + prune |
 
 ### Activation order for `versions use V`
 
 ```text
-1. resolve path = versions/V/madmail (reject missing / not a regular file)
+1. resolve path = versions/V/madmail[.exe] (reject missing / not a regular file)
 2. verify_signature(path)  — hard fail if false (do not stop services)
 3. preflight path version
 4. stop systemd units
@@ -322,8 +382,8 @@ Do **not** store mailboxes or `chatmail.db` under `/opt/madmail`; state remains 
 
 | Layer | Cases |
 |-------|--------|
-| Unit | Version id sanitization; symlink atomic update helpers; meta parse; keep-N selection |
-| Unit (upgrade) | Extend `upgrade.rs` tests: install root via `MADMAIL_OPT_ROOT` temp dir; no real systemd; signature always required on install |
+| Unit | Version id sanitization; path helpers for Unix **and** Windows roots; active-pointer update helpers; meta parse; keep-N selection |
+| Unit (upgrade) | Extend `upgrade.rs` tests: install root via `MADMAIL_INSTALL_ROOT` temp dir; no real systemd/service; signature always required on install; `#[cfg(windows)]` path/exe naming |
 | Unit (`use`) | Signed archive → switch OK; unsigned/tampered on-disk binary → refuse before service stop; no sig check on `list` |
 | Unit (`list --remote`) | Mock GitHub API: merge remote tags with local tree; mark active/installed/latest; offline/error path; local-only rows preserved |
 | Unit (`update latest`) | Resolves expected GitHub latest URL for arch; rejects non-GitHub resolution; oversize download aborted; **unsigned / bad-signature payload fails after download and never flips symlink or stops services**; already-latest short-circuit still only after successful sig check on candidate |
@@ -337,15 +397,16 @@ Do **not** store mailboxes or `chatmail.db` under `/opt/madmail`; state remains 
 
 ### PR1 — Layout helpers + docs
 
-- Add module e.g. `crates/chatmail/src/ctl/versions.rs` (or `version_manager.rs`): paths, ensure dirs, read/write meta, list, resolve active.
-- Env `MADMAIL_OPT_ROOT` for tests.
+- Add module e.g. `crates/chatmail/src/ctl/versions.rs` (or `version_manager.rs`): **platform `install_root()`**, paths, ensure dirs, read/write meta, list, resolve active.
+- Env `MADMAIL_INSTALL_ROOT` (and Unix alias `MADMAIL_OPT_ROOT`) for tests.
+- Defaults: Unix `/opt/madmail`; Windows `%ProgramFiles%\Madmail` — **never** `/opt` on Windows.
 - This TDD file + stub operator page under `docs/guide/cli/versions.md` (can land with PR3).
-- Unit tests for pure path logic.
+- Unit tests for pure path logic on both `cfg(unix)` and `cfg(windows)`.
 
 ### PR2 — Install writes version tree
 
-- `install_binary`: copy into `/opt/madmail/versions/<ver>/madmail`, point `/usr/local/bin/madmail` symlink.
-- systemd unit generation unchanged (`ExecStart` still symlink path).
+- `install_binary`: copy into `{install_root}/versions/<ver>/madmail[.exe]`, update stable PATH entry.
+- systemd unit generation unchanged on Unix (`ExecStart` still stable path); Windows service keeps stable ImagePath when possible.
 - Migration: if existing real file at binary_path, import into versions first.
 
 ### PR3 — Upgrade uses version tree
@@ -353,13 +414,13 @@ Do **not** store mailboxes or `chatmail.db` under `/opt/madmail`; state remains 
 - Change `perform_upgrade` to install-to-versions + flip symlink (algorithm above).
 - Map rollback to previous version dir (keep `*.prev` import for one release if needed).
 - CLI: `madmail versions list [--remote]|current|use|prune|remove|path`.
-- `versions list --remote`: GitHub Releases metadata client; merge with local `/opt/madmail/versions`; no binary download.
+- `versions list --remote`: GitHub Releases metadata client; merge with local `{install_root}/versions`; no binary download; filter or label assets by OS.
 - `versions use`: call same `verify_signature` as `perform_upgrade` **before** stop/preflight-activate; fail closed if unsigned/bad signature.
 - Wire clap + `--json`; update parity matrix in `14-cli-tools.md`.
 
 ### PR4 — `update latest` (GitHub)
 
-- Clap: `madmail update latest` and `madmail upgrade latest` resolve GitHub Releases latest asset for this host.
+- Clap: `madmail update latest` and `madmail upgrade latest` resolve GitHub Releases latest asset for **this OS/arch** (Linux and Windows assets).
 - Implement resolver → call existing `handle_update_url` / shared download helper → **`perform_upgrade` (or shared install that always calls `verify_signature`)** — **no** separate install path that skips size/sig/preflight.
 - Hard requirement: signature failure aborts with the same class of error as a bad local upgrade (`INVALID SIGNATURE` / equivalent); active binary and services untouched.
 - Unit tests with mock HTTP for size limit + **signature failure must be covered**; fixture URL shape matching `…/releases/latest/download/…`.
@@ -376,17 +437,18 @@ Do **not** store mailboxes or `chatmail.db` under `/opt/madmail`; state remains 
 
 ## Acceptance criteria
 
-- [ ] Fresh `madmail install` produces `/opt/madmail/versions/<v>/madmail` and `/usr/local/bin/madmail` → that file.
+- [ ] Fresh install produces versioned binary under platform root: Unix `/opt/madmail/versions/<v>/madmail` + `/usr/local/bin/madmail` pointer; Windows `%ProgramFiles%\Madmail\versions\<v>\madmail.exe` + stable `bin` (or service) entry — **not** under `/opt` on Windows.
 - [ ] `madmail upgrade` adds a new version directory without deleting the previous one (until prune).
 - [ ] Failed post-install smoke restores previous active version and services recover (same guarantees as today).
 - [ ] `madmail versions list` / `use` work with `--json`.
 - [ ] `madmail versions list --remote` shows GitHub releases plus local install state (active/installed/available/latest); default `list` stays local-only and offline.
 - [ ] Install/upgrade **never** places a binary under `versions/` without a successful Ed25519 check.
 - [ ] `versions use` **always** re-verifies signature; fails before stopping services if verify fails; `list`/`path`/etc. do not require it.
-- [ ] `madmail update latest` fetches from GitHub Releases latest for this host and applies **full** URL-upgrade security (size cap, archive rules, **mandatory Ed25519 signature**, preflight, smoke/rollback) into the version tree.
+- [ ] `madmail update latest` fetches from GitHub Releases latest for this host OS/arch and applies **full** URL-upgrade security (size cap, archive rules, **mandatory Ed25519 signature**, preflight, smoke/rollback) into the version tree.
 - [ ] `madmail update latest` **never** activates or archives a binary that failed `verify_signature`; GitHub origin does not waive the check.
-- [ ] Existing systemd units with `ExecStart=/usr/local/bin/madmail` need no edit for v1.
-- [ ] Tests pass with `MADMAIL_OPT_ROOT` under tmp; no requirement to write real `/opt` in CI.
+- [ ] Existing systemd units with `ExecStart=/usr/local/bin/madmail` need no edit for v1 (Unix).
+- [ ] Windows service can keep a stable ImagePath across version flips when using `bin\` or `current` pointer.
+- [ ] Tests pass with `MADMAIL_INSTALL_ROOT` under tmp; no requirement to write real `/opt` or real `Program Files` in CI.
 
 ---
 
@@ -394,12 +456,14 @@ Do **not** store mailboxes or `chatmail.db` under `/opt/madmail`; state remains 
 
 1. **Exact CLI name:** `versions` vs `version` vs `bin`?
 2. **Keep count default:** 5 vs 3 vs unlimited until explicit prune?
-3. **Should `current` symlink under `/opt` be required**, or only `/usr/local/bin/madmail`?
+3. **Should `current` under install root be required**, or only the stable PATH entry (`/usr/local/bin/madmail` / `bin\madmail.exe`)?
 4. **Import policy for `madmail.prev`:** always import, or only when version string is recoverable?
-5. **Multi-instance hosts:** one `/opt/madmail` vs `/opt/madmail-<instance>` (out of scope unless needed).
-6. **`update latest` asset selection:** hardcode `madmail-linux-amd64.tar.gz` vs auto-detect arch/musl (prefer auto if reliable; document fallback).
+5. **Multi-instance hosts:** one install root vs `Madmail-<instance>` (out of scope unless needed).
+6. **`update latest` asset selection:** auto-detect OS/arch (required) vs hardcode; Linux musl vs gnu; Windows asset naming from `publish.sh`.
 7. **`update latest` vs Releases API:** redirect URL only (v1) vs API for tag display / multi-asset pick. Note: `versions list --remote` **needs** the Releases API (or equivalent) even if `update latest` uses the redirect URL.
 8. **`list --remote` depth:** all releases vs last N (e.g. 20) vs only latest; default suggest last **20** non-prerelease unless `--all`.
+9. **Windows active pointer:** symlink vs junction vs replace-file for `bin\madmail.exe` when symlinks are restricted.
+10. **Windows default root:** `%ProgramFiles%\Madmail` vs `%ProgramData%\Madmail\bin` tree (prefer Program Files for exes; keep state in ProgramData).
 
 ---
 
@@ -407,7 +471,10 @@ Do **not** store mailboxes or `chatmail.db` under `/opt/madmail`; state remains 
 
 - Current upgrade safety (issue #114 notes in `upgrade.rs`): preflight before stop; backup; post smoke; rollback.
 - URL download path in `upgrade.rs`: `handle_update_url`, `MAX_DOWNLOAD_SIZE` (100 MiB), `check_supported_url_archive`, Ed25519 after extract.
-- FHS: `/opt/<package>` for add-on application software; `/usr/local/bin` for local admin commands on PATH.
+- FHS (Unix): `/opt/<package>` for add-on application software; `/usr/local/bin` for local admin commands on PATH.
+- Windows: `%ProgramFiles%` for application binaries; `%ProgramData%\Madmail` for config/state (`windows_madmail_root()` in install code). **No `/opt` on Windows.**
 - Sibling TDD: [`14-cli-tools.md`](14-cli-tools.md), [`13-configuration.md`](13-configuration.md), [`12-security.md`](12-security.md).
-- Deploy defaults: `scripts/deploy.defaults.sh` (`REMOTE_BIN`).
-- Example latest asset shape: `https://github.com/themadorg/madmail/releases/latest/download/madmail-linux-amd64.tar.gz`.
+- Deploy defaults: `scripts/deploy.defaults.sh` (`REMOTE_BIN`) — Linux-oriented; Windows uses service/PATH docs.
+- Example latest asset shapes:
+  - Linux: `https://github.com/themadorg/madmail/releases/latest/download/madmail-linux-amd64.tar.gz`
+  - Windows: publish-defined name under the same `…/releases/latest/download/` prefix.

--- a/docs/TDD/24-version-manager.md
+++ b/docs/TDD/24-version-manager.md
@@ -1,6 +1,6 @@
 # Version manager (platform install root)
 
-**Status:** design plan (not implemented)  
+**Status:** partially implemented (layout helpers, CLI `versions`, `update latest` URL resolve, upgrade archives into version tree; install-path migration / service-polish still open)  
 **Related code today:**
 
 | Area | Location | Current behavior |

--- a/docs/TDD/24-version-manager.md
+++ b/docs/TDD/24-version-manager.md
@@ -179,7 +179,7 @@ madmail versions path [version]     # print filesystem path
 | `list` | Enumerate **local** `{install_root}/versions/*` (Unix `/opt/madmail`, Windows `%ProgramFiles%\Madmail`); mark active; show size, mtime, meta |
 | `list --remote` | Query **GitHub Releases** (same project as `update latest`) and list remote version tags/assets available for this host; mark which are already installed locally and which is active; indicate remote `latest` |
 | `current` | Print active version id + resolved path |
-| `use V` | **Must** re-verify Ed25519 signature on `versions/V/madmail`, then preflight `version`, stop services, flip symlinks, start services; on smoke failure flip back. Refuse switch if signature fails (treat as tampered / unsigned archive). |
+| `use V` | **Must** re-verify Ed25519 signature on `versions/V/madmail`, then preflight `version` with **installed** exec mode (`0755` on Unix — not staging `0700`, so non-root service users can still exec after switch), stop services, flip symlinks, start services; on smoke failure flip back. Refuse switch if signature fails (treat as tampered / unsigned archive). Refuse non-regular files / symlinks under `versions/V/`. |
 | `prune --keep N` | Delete oldest non-active versions beyond N (default **N=5**). **Always requires `--yes`** (including with `--json`; never treat JSON as implicit confirm). No signature check (does not execute or activate). |
 | `remove V` | Error if V is active or only remaining version. **Always requires `--yes`** (including with `--json`). No signature check. |
 | `list` / `current` / `path` | Read-only; **no** binary signature check required (metadata only; `list --remote` does not download binaries) |
@@ -358,20 +358,22 @@ Do **not** store mailboxes or `chatmail.db` under the install/version root. Stat
 | `update latest` / URL download | Same size caps (`MAX_DOWNLOAD_SIZE`), archive allow-list, TLS defaults, then **mandatory Ed25519** + preflight; GitHub “latest” is **not** a trust shortcut and **never** waives signature verification |
 | Tampered archived binary activated via `use` | **Always** re-run Ed25519 verify on `versions/V/madmail` before stop/symlink flip; refuse if verify fails |
 | Inventory without crypto cost | `list` / `list --remote` / `current` / `path` / `prune` / `remove` do not verify binary signatures (remote list is metadata only; installing still requires sig) |
-| Symlink attacks | Create dirs as root; refuse to follow unexpected symlinks when writing DEST |
+| Symlink attacks | Create dirs as root; refuse to follow unexpected symlinks when writing DEST; `set_active` / `versions use` reject a symlink at `versions/V/madmail` |
 | PATH hijack | Unix: `/usr/local/bin/madmail` root:root 755 symlink; Windows: ACL so only Administrators write install root / `bin` |
 | Prune deletes active | Refuse remove/prune of active target |
+| Remove only remaining | `remove V` errors if V is the sole installed version (even with a broken active pointer); prune must not empty the tree |
 | Rollback window | Keep at least previous version until next successful upgrade + prune |
+| `versions use` chmod | Preflight/smoke on archived binaries uses **Installed** mode (`0755`); never apply staging `0700` to `versions/<id>/` (breaks `User=` service units) |
 
 ### Activation order for `versions use V`
 
 ```text
-1. resolve path = versions/V/madmail[.exe] (reject missing / not a regular file)
+1. resolve path = versions/V/madmail[.exe] (reject missing / not a regular file / symlink)
 2. verify_signature(path)  — hard fail if false (do not stop services)
-3. preflight path version
+3. preflight path version with Installed exec mode (0755)
 4. stop systemd units
-5. atomic symlink flip (current + /usr/local/bin/madmail)
-6. smoke preflight on resolved path
+5. atomic symlink flip (current + /usr/local/bin/madmail); set_active also rejects non-regular binary
+6. smoke preflight on resolved path (Installed mode again)
 7. on failure: restore previous symlink targets, start services, error
 8. on success: start services
 ```

--- a/docs/TDD/24-version-manager.md
+++ b/docs/TDD/24-version-manager.md
@@ -1,0 +1,384 @@
+# Version manager (`/opt/madmail`)
+
+**Status:** design plan (not implemented)  
+**Related code today:**
+
+| Area | Location | Current behavior |
+|------|----------|------------------|
+| Install binary | `crates/chatmail/src/ctl/install/system.rs` | Copies live exe → `/usr/local/bin/madmail` |
+| systemd unit | `crates/chatmail/src/ctl/install/systemd.rs` | `ExecStart=/usr/local/bin/madmail …` |
+| Signed upgrade | `crates/chatmail/src/upgrade.rs` | In-place replace of `current_exe`; sibling `*.prev` only |
+| Deploy scripts | `scripts/deploy.sh`, `scripts/deploy.defaults.sh` | `REMOTE_BIN=/usr/local/bin/madmail` |
+| Version stamp | `.version`, workspace `Cargo.toml` | e.g. `2.20.0` |
+
+**Operator CLI (planned):** [`../guide/cli/`](../guide/cli/README.md) — new `versions` / extend `upgrade` (see below).  
+**Parity matrix:** [`14-cli-tools.md`](14-cli-tools.md).
+
+---
+
+## Problem
+
+Upgrades keep **one** previous binary (`/usr/local/bin/madmail.prev`). That is enough for emergency rollback of the last step, but operators cannot:
+
+- Keep a **history** of N known-good releases on disk
+- Switch between versions without re-downloading
+- Inspect **which** build is live vs archived
+- Avoid filling `/usr/local/bin` with ad-hoc folders of old bins
+
+Putting archives under `/usr/local/bin/` is the wrong place: that directory is for **PATH commands**, not version trees.
+
+---
+
+## Goals
+
+1. Store versioned madmail binaries under **`/opt/madmail`** (FHS-friendly app root).
+2. Keep **`/usr/local/bin/madmail`** as a stable PATH entry (symlink → active version).
+3. On every successful **install** / **upgrade**, archive the previous binary with a **version id**.
+4. Support **list**, **use** (switch), **prune**, and **rollback** without re-fetch.
+5. Preserve existing safety: Ed25519 signature check, host preflight (`version`), systemd stop/start, automatic rollback if post-install smoke fails.
+6. **Signature on every activation path:** any install/upgrade that writes a binary into the version tree **must** verify Ed25519 first; `versions use` **must** re-verify the on-disk binary before flipping the active symlink. Inventory commands (`list`, `current`, `path`, `prune`, `remove`) do **not** need a signature check.
+7. **One-shot “get latest from GitHub”:** `madmail update latest` downloads the current release asset from GitHub Releases, then runs the **same** URL-upgrade security pipeline (TLS, size caps, archive rules, **mandatory Ed25519 signature check**, host preflight, version-tree install, smoke/rollback) as an explicit download URL. **GitHub does not replace signature verification** — unsigned or bad-signed assets must always abort.
+8. Migrate smoothly from the current single-file install.
+
+### Non-goals (v1)
+
+- Multi-arch side-by-side on one host (one primary arch per install tree).
+- Storing full release tarballs / Windows artifacts under `/opt` (Linux server binary only).
+- Replacing GitHub Releases / `publish.sh` as the distribution channel.
+- Per-user non-root installs (upgrade/install remain root-owned system tools).
+
+---
+
+## Layout
+
+```text
+/opt/madmail/
+  current -> versions/2.20.0          # symlink (optional convenience)
+  versions/
+    2.19.0/
+      madmail                        # executable (mode 0755)
+      meta.json                      # optional install metadata
+    2.20.0/
+      madmail
+      meta.json
+  state/                             # reserved; do NOT put maildir here
+                                     # (runtime state stays under InstallConfig.state_dir,
+                                     #  typically /var/lib/madmail)
+
+/usr/local/bin/madmail -> /opt/madmail/versions/2.20.0/madmail
+# or -> /opt/madmail/current/madmail
+```
+
+### Version directory naming
+
+| Rule | Detail |
+|------|--------|
+| Primary id | Semver from binary (`madmail version` / embedded package version), e.g. `2.20.0` |
+| Collision | Same semver rebuilt → use `2.20.0+YYYYMMDDHHMMSS` or `2.20.0+git.<shortsha>` if available |
+| Invalid chars | Reject path separators; only `[0-9A-Za-z._+-]` |
+| Active pointer | Atomic symlink replace for `current` and `/usr/local/bin/madmail` |
+
+### `meta.json` (optional but recommended)
+
+```json
+{
+  "version": "2.20.0",
+  "installed_at": "2026-08-03T12:00:00Z",
+  "source": "upgrade",
+  "source_url": "https://github.com/themadorg/madmail/releases/download/v2.20.0/madmail-linux-amd64",
+  "sha256": "…",
+  "variant": "linux-amd64",
+  "signature_ok": true
+}
+```
+
+---
+
+## Runtime and PATH contract
+
+| Consumer | Resolution |
+|----------|------------|
+| Shell / admin | `/usr/local/bin/madmail` on `PATH` |
+| systemd | Prefer **stable path** in unit file: either keep `ExecStart=/usr/local/bin/madmail` (symlink) **or** `ExecStart=/opt/madmail/current/madmail` |
+| `madmail upgrade` | Resolves **real** path via `current_exe` + canonicalize; installs new version **next to** version tree, then flips symlink |
+| `*.prev` | Deprecated after migration; keep one generation for compatibility or map to “previous version dir” |
+
+**Recommendation:** keep `ExecStart=/usr/local/bin/madmail` so existing units and `REMOTE_BIN` defaults keep working; only the symlink target changes.
+
+---
+
+## Commands (planned CLI)
+
+Surface either as top-level group or under `upgrade` — prefer a dedicated group for clarity:
+
+```text
+madmail versions list
+madmail versions current
+madmail versions use <version>
+madmail versions prune [--keep N] [--yes]
+madmail versions remove <version>   # refuse if active
+madmail versions path [version]     # print filesystem path
+```
+
+### Behavior sketch
+
+| Command | Behavior |
+|---------|----------|
+| `list` | Enumerate `/opt/madmail/versions/*`; mark active; show size, mtime, meta |
+| `current` | Print active version id + resolved path |
+| `use V` | **Must** re-verify Ed25519 signature on `versions/V/madmail`, then preflight `version`, stop services, flip symlinks, start services; on smoke failure flip back. Refuse switch if signature fails (treat as tampered / unsigned archive). |
+| `prune --keep N` | Delete oldest non-active versions beyond N (default **N=5**). No signature check (does not execute or activate). |
+| `remove V` | Error if V is active or only remaining version. No signature check. |
+| `list` / `current` / `path` | Read-only; **no** signature check required. |
+
+**Signature policy (activation vs inventory):**
+
+| Operation | Ed25519 signature |
+|-----------|-------------------|
+| Install new binary into the version tree (`install` / `upgrade` from path or URL) | **Always required** before write/activate (same as today — never skip) |
+| **`madmail update latest`** (and `upgrade latest`) | **Always required** after download/extract, **before** writing into `/opt/madmail/versions/` or stopping services. Same `verify_signature` as `perform_upgrade`. **Never skip** because the source is “official GitHub”. Fail closed: unsigned / invalid signature → abort, leave active version unchanged. |
+| `versions use <V>` (activate an already-archived binary) | **Always required** on that on-disk file before stop/symlink flip |
+| `versions list`, `current`, `path`, `prune`, `remove` | Not required (no execution / no new trust boundary) |
+
+**JSON:** all commands support `--json` for automation (same style as other ctl commands).
+
+### Upgrade / update UX
+
+```text
+madmail upgrade <path-or-url>     # install into versions/<new>, keep previous under versions/
+madmail upgrade --rollback        # optional alias → versions use <previous>
+madmail update <path-or-url>      # existing alias of upgrade (keep)
+madmail update latest             # NEW: fetch latest GitHub release asset, then same secure pipeline
+```
+
+#### `madmail update latest` (required)
+
+Resolve the **latest** published madmail binary from **GitHub Releases** and install it through the version manager — without the operator pasting a full asset URL.
+
+| Item | Spec |
+|------|------|
+| Intent | “Give me the newest signed release for this host” |
+| Source | GitHub only: `https://github.com/themadorg/madmail/releases` (not arbitrary mirrors) |
+| Default asset | Prefer host-appropriate Linux server asset, e.g. `madmail-linux-amd64.tar.gz` (or musl / arch variant if detection already exists); document exact name table in operator CLI docs |
+| Resolution strategy (v1) | Prefer stable redirect URL: `…/releases/latest/download/<asset>` (same family as existing test fixture URL). Optional later: GitHub Releases API for tag/metadata before download. |
+| Entry point | Clap: `update` subcommand accepts either a path/URL **or** the keyword `latest` (not a free-form path). `upgrade latest` should behave the same for parity. |
+| After resolve | Call the **identical** code path as `handle_update_url` → versioned `perform_upgrade` (no bypass of checks). |
+
+**Security pipeline for `update latest` (must match URL upgrade — no weaker path):**
+
+```text
+1. resolve asset URL under github.com/themadorg/madmail/releases/… only
+2. HTTPS download (default TLS verify; --accept-unsafe-https only if operator opts in — same as today)
+3. reject unsupported archive types (only .tar.gz / .tgz or raw signed binary — same check_supported_url_archive rules)
+4. enforce MAX_DOWNLOAD_SIZE (100 MiB today) on response body and on extracted member
+5. extract madmail from tar.gz when needed (owner-only temp; path safety)
+6. **verify Ed25519 signature on candidate (MANDATORY — refuse unsigned / invalid; do not proceed to install)**
+7. host preflight: candidate `version` (captures version id; aborts on exec/loader failure)
+8. install into /opt/madmail/versions/<VERSION>/, flip symlinks, smoke, rollback on failure
+9. optional prune --keep N after success
+```
+
+| Rule | Detail |
+|------|--------|
+| **Signature** | **Always required** for `update latest`. Call the same `verify_signature` used by `perform_upgrade` / URL upgrades. Order: download → (extract) → **sig check** → preflight → version-tree install. Never skip for GitHub. |
+| Binary / download size | Same caps as URL update (`MAX_DOWNLOAD_SIZE` on download stream and archive member) |
+| Host version preflight | Same as `perform_upgrade` (after signature passes) |
+| Already on latest | If active version id equals candidate’s version **and** content hash matches installed file, exit 0 with clear message (no service bounce). If same semver but different hash, install collision policy (`2.20.0+timestamp` or refuse — see version dir naming). Still run signature check on the downloaded candidate before deciding (do not trust GitHub alone). |
+| Offline / GitHub down | Fail with actionable error; do not fall back to unsigned cache |
+| `--json` | Report resolved URL (or tag), version id, previous version, **signature_ok**, success/rollback |
+
+**Not in scope for `latest` alone:** pinning an older GitHub tag (use explicit URL or `versions use` for local archive). Optional later: `update v2.20.0` tag syntax.
+
+---
+
+## Upgrade algorithm (target)
+
+Replace the current “overwrite file + `*.prev`” path in `perform_upgrade` with versioned install:
+
+```text
+1. verify Ed25519 signature on candidate
+2. preflight: candidate `version` (captures VERSION string)
+3. require root
+4. ensure /opt/madmail/versions exists (mode root-owned 0755)
+5. VERSION = parse from preflight output (fallback: meta / timestamp)
+6. DEST = /opt/madmail/versions/VERSION/
+   - if DEST exists and same content hash → skip copy or refuse
+   - else install candidate → DEST/madmail (atomic write via temp + rename)
+7. write meta.json
+8. PREV = resolve current symlink target (or legacy /usr/local/bin/madmail file)
+9. stop systemd units
+10. atomic symlink update:
+    - /opt/madmail/current → versions/VERSION
+    - /usr/local/bin/madmail → versions/VERSION/madmail
+11. smoke preflight on resolved path
+12. on failure: restore previous symlink targets, start services, error
+13. on success: start services; optional prune --keep N
+14. post-upgrade hooks (www migrate, docs refresh) unchanged
+```
+
+### Migration from legacy install
+
+| On-disk state | Action on first versioned upgrade/install |
+|---------------|-------------------------------------------|
+| Regular file `/usr/local/bin/madmail` | Copy into `versions/<oldver>/`, then convert PATH entry to symlink |
+| `/usr/local/bin/madmail.prev` | Import as `versions/<prevver>/` if version parseable; else `versions/prev-import-<ts>/` |
+| Already symlink into `/opt/madmail/…` | No-op migrate; continue versioned flow |
+| Unit still points at old path | Symlink keeps unit valid; optional `systemctl daemon-reload` only if unit text changes |
+
+---
+
+## Install path changes
+
+`InstallConfig.binary_path` today defaults to `/usr/local/bin/madmail`.
+
+| Phase | Install behavior |
+|-------|------------------|
+| v1 | Install into `/opt/madmail/versions/<ver>/madmail`, create `/usr/local/bin/madmail` symlink, leave `binary_path` as the **symlink path** for unit generation |
+| later | Optional flag `--binary-root /opt/madmail` for custom roots (test VMs, multi-instance) |
+
+Dry-run (`install --dry-run`) must print both the version dir and the symlink plan.
+
+---
+
+## Deploy / ops
+
+| Knob | Today | After |
+|------|-------|--------|
+| `REMOTE_BIN` | `/usr/local/bin/madmail` | Unchanged (symlink) |
+| Unsigned deploy | `install -m 755` overwrites file | Prefer `madmail upgrade` or a small helper that writes into `/opt/madmail/versions/…` |
+| Signed deploy | `madmail upgrade` | Same command; version manager is internal |
+| Disk | N/A | Document prune policy; default keep 5 |
+
+Local dev / CI: version manager is **production-install** concern; unit tests use a temp root via env, e.g. `MADMAIL_OPT_ROOT=/tmp/madmail-opt-test`.
+
+---
+
+## Configuration
+
+| Mechanism | Key / env | Default |
+|-----------|-----------|---------|
+| Env (test/override) | `MADMAIL_OPT_ROOT` | `/opt/madmail` |
+| Keep count | setting or flag `--keep` | `5` |
+| Config file | optional later in `madmail.conf` | not required for v1 |
+
+Do **not** store mailboxes or `chatmail.db` under `/opt/madmail`; state remains `/var/lib/madmail` (or configured `state_dir`).
+
+---
+
+## Security
+
+| Concern | Mitigation |
+|---------|------------|
+| Untrusted binaries entering versions/ | **Always** Ed25519-verify the candidate before writing into `/opt/madmail/versions/` on install/upgrade (same as today; never skip) |
+| `update latest` / URL download | Same size caps (`MAX_DOWNLOAD_SIZE`), archive allow-list, TLS defaults, then **mandatory Ed25519** + preflight; GitHub “latest” is **not** a trust shortcut and **never** waives signature verification |
+| Tampered archived binary activated via `use` | **Always** re-run Ed25519 verify on `versions/V/madmail` before stop/symlink flip; refuse if verify fails |
+| Inventory without crypto cost | `list` / `current` / `path` / `prune` / `remove` do not verify signatures |
+| Symlink attacks | Create dirs as root; refuse to follow unexpected symlinks when writing DEST |
+| PATH hijack | `/usr/local/bin/madmail` owned root:root, mode 755 symlink |
+| Prune deletes active | Refuse remove/prune of active target |
+| Rollback window | Keep at least previous version until next successful upgrade + prune |
+
+### Activation order for `versions use V`
+
+```text
+1. resolve path = versions/V/madmail (reject missing / not a regular file)
+2. verify_signature(path)  — hard fail if false (do not stop services)
+3. preflight path version
+4. stop systemd units
+5. atomic symlink flip (current + /usr/local/bin/madmail)
+6. smoke preflight on resolved path
+7. on failure: restore previous symlink targets, start services, error
+8. on success: start services
+```
+
+---
+
+## Testing plan
+
+| Layer | Cases |
+|-------|--------|
+| Unit | Version id sanitization; symlink atomic update helpers; meta parse; keep-N selection |
+| Unit (upgrade) | Extend `upgrade.rs` tests: install root via `MADMAIL_OPT_ROOT` temp dir; no real systemd; signature always required on install |
+| Unit (`use`) | Signed archive → switch OK; unsigned/tampered on-disk binary → refuse before service stop; no sig check on `list` |
+| Unit (`update latest`) | Resolves expected GitHub latest URL for arch; rejects non-GitHub resolution; oversize download aborted; **unsigned / bad-signature payload fails after download and never flips symlink or stops services**; already-latest short-circuit still only after successful sig check on candidate |
+| Integration | Legacy file → versioned tree migration; `use` switches active only after sig + preflight; failed smoke restores previous |
+| E2E / manual | VM or docker: install → upgrade twice → `versions list` → `use` older → service healthy; optional `update latest` against real/mock GitHub |
+| Deploy script | `REMOTE_BIN` still works when symlink |
+
+---
+
+## Implementation plan (PRs)
+
+### PR1 — Layout helpers + docs
+
+- Add module e.g. `crates/chatmail/src/ctl/versions.rs` (or `version_manager.rs`): paths, ensure dirs, read/write meta, list, resolve active.
+- Env `MADMAIL_OPT_ROOT` for tests.
+- This TDD file + stub operator page under `docs/guide/cli/versions.md` (can land with PR3).
+- Unit tests for pure path logic.
+
+### PR2 — Install writes version tree
+
+- `install_binary`: copy into `/opt/madmail/versions/<ver>/madmail`, point `/usr/local/bin/madmail` symlink.
+- systemd unit generation unchanged (`ExecStart` still symlink path).
+- Migration: if existing real file at binary_path, import into versions first.
+
+### PR3 — Upgrade uses version tree
+
+- Change `perform_upgrade` to install-to-versions + flip symlink (algorithm above).
+- Map rollback to previous version dir (keep `*.prev` import for one release if needed).
+- CLI: `madmail versions list|current|use|prune|remove|path`.
+- `versions use`: call same `verify_signature` as `perform_upgrade` **before** stop/preflight-activate; fail closed if unsigned/bad signature.
+- Wire clap + `--json`; update parity matrix in `14-cli-tools.md`.
+
+### PR4 — `update latest` (GitHub)
+
+- Clap: `madmail update latest` and `madmail upgrade latest` resolve GitHub Releases latest asset for this host.
+- Implement resolver → call existing `handle_update_url` / shared download helper → **`perform_upgrade` (or shared install that always calls `verify_signature`)** — **no** separate install path that skips size/sig/preflight.
+- Hard requirement: signature failure aborts with the same class of error as a bad local upgrade (`INVALID SIGNATURE` / equivalent); active binary and services untouched.
+- Unit tests with mock HTTP for size limit + **signature failure must be covered**; fixture URL shape matching `…/releases/latest/download/…`.
+- Operator docs: preferred asset names, signature always verified, `--accept-unsafe-https` note (TLS only — **does not** skip Ed25519), “already latest” behavior.
+
+### PR5 — Ops polish
+
+- Default prune after upgrade (`--keep 5`, disable with `--keep 0` or `--no-prune`).
+- `deploy.sh` notes / optional call path; document `madmail update latest` for signed remote updates.
+- `upgrade-safety.sh` / smoke scripts assert version dirs when present.
+- CHANGELOG + install guide blurb.
+
+---
+
+## Acceptance criteria
+
+- [ ] Fresh `madmail install` produces `/opt/madmail/versions/<v>/madmail` and `/usr/local/bin/madmail` → that file.
+- [ ] `madmail upgrade` adds a new version directory without deleting the previous one (until prune).
+- [ ] Failed post-install smoke restores previous active version and services recover (same guarantees as today).
+- [ ] `madmail versions list` / `use` work with `--json`.
+- [ ] Install/upgrade **never** places a binary under `versions/` without a successful Ed25519 check.
+- [ ] `versions use` **always** re-verifies signature; fails before stopping services if verify fails; `list`/`path`/etc. do not require it.
+- [ ] `madmail update latest` fetches from GitHub Releases latest for this host and applies **full** URL-upgrade security (size cap, archive rules, **mandatory Ed25519 signature**, preflight, smoke/rollback) into the version tree.
+- [ ] `madmail update latest` **never** activates or archives a binary that failed `verify_signature`; GitHub origin does not waive the check.
+- [ ] Existing systemd units with `ExecStart=/usr/local/bin/madmail` need no edit for v1.
+- [ ] Tests pass with `MADMAIL_OPT_ROOT` under tmp; no requirement to write real `/opt` in CI.
+
+---
+
+## Open questions
+
+1. **Exact CLI name:** `versions` vs `version` vs `bin`?
+2. **Keep count default:** 5 vs 3 vs unlimited until explicit prune?
+3. **Should `current` symlink under `/opt` be required**, or only `/usr/local/bin/madmail`?
+4. **Import policy for `madmail.prev`:** always import, or only when version string is recoverable?
+5. **Multi-instance hosts:** one `/opt/madmail` vs `/opt/madmail-<instance>` (out of scope unless needed).
+6. **`update latest` asset selection:** hardcode `madmail-linux-amd64.tar.gz` vs auto-detect arch/musl (prefer auto if reliable; document fallback).
+7. **`update latest` vs Releases API:** redirect URL only (v1) vs API for tag display / multi-asset pick.
+
+---
+
+## References
+
+- Current upgrade safety (issue #114 notes in `upgrade.rs`): preflight before stop; backup; post smoke; rollback.
+- URL download path in `upgrade.rs`: `handle_update_url`, `MAX_DOWNLOAD_SIZE` (100 MiB), `check_supported_url_archive`, Ed25519 after extract.
+- FHS: `/opt/<package>` for add-on application software; `/usr/local/bin` for local admin commands on PATH.
+- Sibling TDD: [`14-cli-tools.md`](14-cli-tools.md), [`13-configuration.md`](13-configuration.md), [`12-security.md`](12-security.md).
+- Deploy defaults: `scripts/deploy.defaults.sh` (`REMOTE_BIN`).
+- Example latest asset shape: `https://github.com/themadorg/madmail/releases/latest/download/madmail-linux-amd64.tar.gz`.

--- a/docs/TDD/24-version-manager.md
+++ b/docs/TDD/24-version-manager.md
@@ -112,7 +112,7 @@ Putting archives under `/usr/local/bin/` is the wrong place: that directory is f
 Surface either as top-level group or under `upgrade` — prefer a dedicated group for clarity:
 
 ```text
-madmail versions list
+madmail versions list [--remote]
 madmail versions current
 madmail versions use <version>
 madmail versions prune [--keep N] [--yes]
@@ -124,12 +124,37 @@ madmail versions path [version]     # print filesystem path
 
 | Command | Behavior |
 |---------|----------|
-| `list` | Enumerate `/opt/madmail/versions/*`; mark active; show size, mtime, meta |
+| `list` | Enumerate **local** `/opt/madmail/versions/*`; mark active; show size, mtime, meta |
+| `list --remote` | Query **GitHub Releases** (same project as `update latest`) and list remote version tags/assets available for this host; mark which are already installed locally and which is active; indicate remote `latest` |
 | `current` | Print active version id + resolved path |
 | `use V` | **Must** re-verify Ed25519 signature on `versions/V/madmail`, then preflight `version`, stop services, flip symlinks, start services; on smoke failure flip back. Refuse switch if signature fails (treat as tampered / unsigned archive). |
 | `prune --keep N` | Delete oldest non-active versions beyond N (default **N=5**). No signature check (does not execute or activate). |
 | `remove V` | Error if V is active or only remaining version. No signature check. |
-| `list` / `current` / `path` | Read-only; **no** signature check required. |
+| `list` / `current` / `path` | Read-only; **no** binary signature check required (metadata only; `list --remote` does not download binaries) |
+
+#### `versions list --remote`
+
+| Item | Spec |
+|------|------|
+| Intent | “What releases exist upstream, and how do they compare to what I have installed?” |
+| Source | GitHub only: `themadorg/madmail` Releases (HTTPS; default TLS verify; honor `--accept-unsafe-https` if the parent CLI already exposes it for network ops) |
+| Default (no flag) | **Local only** — no network |
+| With `--remote` | Fetch release **metadata** (tags, published_at, asset names/sizes for host-matching assets). **Do not** download full binaries; **no** Ed25519 check on list (nothing to verify until install/`update`) |
+| Compare | Annotate each remote entry: `installed` / `active` / `available` (not on disk) / `latest` |
+| Local rows | Still show local-only versions (e.g. custom builds) that are not on GitHub, clearly labeled `local-only` |
+| Failure | Network/API error → non-zero exit with clear message; do not pretend local list is remote |
+| Rate limits | Prefer GitHub Releases API with modest page size; document unauthenticated limit; optional later: `GH_TOKEN` / `GITHUB_TOKEN` for higher limits |
+| `--json` | Array of objects with at least: `version`, `source` (`local` \| `remote` \| `both`), `active`, `installed`, `remote_latest`, optional `published_at`, `asset`, `asset_size` |
+
+Example human output (illustrative):
+
+```text
+VERSION     SOURCE   ACTIVE  NOTES
+2.20.1      both     *       remote latest; installed
+2.20.0      both             installed
+2.19.0      local            local-only (not on GitHub)
+2.18.0      remote           available (not installed)
+```
 
 **Signature policy (activation vs inventory):**
 
@@ -138,7 +163,7 @@ madmail versions path [version]     # print filesystem path
 | Install new binary into the version tree (`install` / `upgrade` from path or URL) | **Always required** before write/activate (same as today — never skip) |
 | **`madmail update latest`** (and `upgrade latest`) | **Always required** after download/extract, **before** writing into `/opt/madmail/versions/` or stopping services. Same `verify_signature` as `perform_upgrade`. **Never skip** because the source is “official GitHub”. Fail closed: unsigned / invalid signature → abort, leave active version unchanged. |
 | `versions use <V>` (activate an already-archived binary) | **Always required** on that on-disk file before stop/symlink flip |
-| `versions list`, `current`, `path`, `prune`, `remove` | Not required (no execution / no new trust boundary) |
+| `versions list` (local), `list --remote`, `current`, `path`, `prune`, `remove` | Not required — inventory/metadata only; remote list does **not** download or activate binaries |
 
 **JSON:** all commands support `--json` for automation (same style as other ctl commands).
 
@@ -272,7 +297,7 @@ Do **not** store mailboxes or `chatmail.db` under `/opt/madmail`; state remains 
 | Untrusted binaries entering versions/ | **Always** Ed25519-verify the candidate before writing into `/opt/madmail/versions/` on install/upgrade (same as today; never skip) |
 | `update latest` / URL download | Same size caps (`MAX_DOWNLOAD_SIZE`), archive allow-list, TLS defaults, then **mandatory Ed25519** + preflight; GitHub “latest” is **not** a trust shortcut and **never** waives signature verification |
 | Tampered archived binary activated via `use` | **Always** re-run Ed25519 verify on `versions/V/madmail` before stop/symlink flip; refuse if verify fails |
-| Inventory without crypto cost | `list` / `current` / `path` / `prune` / `remove` do not verify signatures |
+| Inventory without crypto cost | `list` / `list --remote` / `current` / `path` / `prune` / `remove` do not verify binary signatures (remote list is metadata only; installing still requires sig) |
 | Symlink attacks | Create dirs as root; refuse to follow unexpected symlinks when writing DEST |
 | PATH hijack | `/usr/local/bin/madmail` owned root:root, mode 755 symlink |
 | Prune deletes active | Refuse remove/prune of active target |
@@ -300,6 +325,7 @@ Do **not** store mailboxes or `chatmail.db` under `/opt/madmail`; state remains 
 | Unit | Version id sanitization; symlink atomic update helpers; meta parse; keep-N selection |
 | Unit (upgrade) | Extend `upgrade.rs` tests: install root via `MADMAIL_OPT_ROOT` temp dir; no real systemd; signature always required on install |
 | Unit (`use`) | Signed archive → switch OK; unsigned/tampered on-disk binary → refuse before service stop; no sig check on `list` |
+| Unit (`list --remote`) | Mock GitHub API: merge remote tags with local tree; mark active/installed/latest; offline/error path; local-only rows preserved |
 | Unit (`update latest`) | Resolves expected GitHub latest URL for arch; rejects non-GitHub resolution; oversize download aborted; **unsigned / bad-signature payload fails after download and never flips symlink or stops services**; already-latest short-circuit still only after successful sig check on candidate |
 | Integration | Legacy file → versioned tree migration; `use` switches active only after sig + preflight; failed smoke restores previous |
 | E2E / manual | VM or docker: install → upgrade twice → `versions list` → `use` older → service healthy; optional `update latest` against real/mock GitHub |
@@ -326,7 +352,8 @@ Do **not** store mailboxes or `chatmail.db` under `/opt/madmail`; state remains 
 
 - Change `perform_upgrade` to install-to-versions + flip symlink (algorithm above).
 - Map rollback to previous version dir (keep `*.prev` import for one release if needed).
-- CLI: `madmail versions list|current|use|prune|remove|path`.
+- CLI: `madmail versions list [--remote]|current|use|prune|remove|path`.
+- `versions list --remote`: GitHub Releases metadata client; merge with local `/opt/madmail/versions`; no binary download.
 - `versions use`: call same `verify_signature` as `perform_upgrade` **before** stop/preflight-activate; fail closed if unsigned/bad signature.
 - Wire clap + `--json`; update parity matrix in `14-cli-tools.md`.
 
@@ -353,6 +380,7 @@ Do **not** store mailboxes or `chatmail.db` under `/opt/madmail`; state remains 
 - [ ] `madmail upgrade` adds a new version directory without deleting the previous one (until prune).
 - [ ] Failed post-install smoke restores previous active version and services recover (same guarantees as today).
 - [ ] `madmail versions list` / `use` work with `--json`.
+- [ ] `madmail versions list --remote` shows GitHub releases plus local install state (active/installed/available/latest); default `list` stays local-only and offline.
 - [ ] Install/upgrade **never** places a binary under `versions/` without a successful Ed25519 check.
 - [ ] `versions use` **always** re-verifies signature; fails before stopping services if verify fails; `list`/`path`/etc. do not require it.
 - [ ] `madmail update latest` fetches from GitHub Releases latest for this host and applies **full** URL-upgrade security (size cap, archive rules, **mandatory Ed25519 signature**, preflight, smoke/rollback) into the version tree.
@@ -370,7 +398,8 @@ Do **not** store mailboxes or `chatmail.db` under `/opt/madmail`; state remains 
 4. **Import policy for `madmail.prev`:** always import, or only when version string is recoverable?
 5. **Multi-instance hosts:** one `/opt/madmail` vs `/opt/madmail-<instance>` (out of scope unless needed).
 6. **`update latest` asset selection:** hardcode `madmail-linux-amd64.tar.gz` vs auto-detect arch/musl (prefer auto if reliable; document fallback).
-7. **`update latest` vs Releases API:** redirect URL only (v1) vs API for tag display / multi-asset pick.
+7. **`update latest` vs Releases API:** redirect URL only (v1) vs API for tag display / multi-asset pick. Note: `versions list --remote` **needs** the Releases API (or equivalent) even if `update latest` uses the redirect URL.
+8. **`list --remote` depth:** all releases vs last N (e.g. 20) vs only latest; default suggest last **20** non-prerelease unless `--all`.
 
 ---
 

--- a/docs/TDD/24-version-manager.md
+++ b/docs/TDD/24-version-manager.md
@@ -180,8 +180,8 @@ madmail versions path [version]     # print filesystem path
 | `list --remote` | Query **GitHub Releases** (same project as `update latest`) and list remote version tags/assets available for this host; mark which are already installed locally and which is active; indicate remote `latest` |
 | `current` | Print active version id + resolved path |
 | `use V` | **Must** re-verify Ed25519 signature on `versions/V/madmail`, then preflight `version`, stop services, flip symlinks, start services; on smoke failure flip back. Refuse switch if signature fails (treat as tampered / unsigned archive). |
-| `prune --keep N` | Delete oldest non-active versions beyond N (default **N=5**). No signature check (does not execute or activate). |
-| `remove V` | Error if V is active or only remaining version. No signature check. |
+| `prune --keep N` | Delete oldest non-active versions beyond N (default **N=5**). **Always requires `--yes`** (including with `--json`; never treat JSON as implicit confirm). No signature check (does not execute or activate). |
+| `remove V` | Error if V is active or only remaining version. **Always requires `--yes`** (including with `--json`). No signature check. |
 | `list` / `current` / `path` | Read-only; **no** binary signature check required (metadata only; `list --remote` does not download binaries) |
 
 #### `versions list --remote`
@@ -270,7 +270,7 @@ Resolve the **latest** published madmail binary from **GitHub Releases** and ins
 
 ## Upgrade algorithm (target)
 
-Replace the current “overwrite file + `*.prev`” path in `perform_upgrade` with versioned install:
+Prefer versioned install over “overwrite file + `*.prev`”. After the first successful versioned upgrade the stable PATH entry is a symlink into `versions/<id>/`; **never** `canonicalize` that path and write into `versions/<old>/` (that clobbers archive history while signatures still verify).
 
 ```text
 1. verify Ed25519 signature on candidate
@@ -279,18 +279,18 @@ Replace the current “overwrite file + `*.prev`” path in `perform_upgrade` wi
 4. ensure `{install_root}/versions` exists (Unix: root-owned 0755; Windows: Administrators / appropriate ACLs)
 5. VERSION = parse from preflight output (fallback: meta / timestamp)
 6. DEST = `{install_root}/versions/VERSION/`
-   - if DEST exists and same content hash → skip copy or refuse
-   - else install candidate → `DEST/madmail` or `DEST/madmail.exe` (atomic write via temp + rename)
+   - install via install_candidate only (atomic write via temp + rename; refuse symlink dest)
 7. write meta.json
 8. PREV = resolve current active pointer (or legacy single-file install path)
 9. stop services (systemd **or** Windows service)
-10. atomic active-pointer update:
+10. atomic active-pointer update only (no in-place replace of any path under versions/):
     - `{install_root}/current` → `versions/VERSION`
-    - stable PATH entry → active binary (Unix symlink; Windows junction/symlink/replace)
-11. smoke preflight on resolved path
-12. on failure: restore previous active pointer, start services, error
+    - stable PATH entry → active binary (Unix: rename temp symlink over existing; Windows: remove+rename)
+11. smoke preflight on versions/VERSION binary (regular file)
+12. on failure: restore previous active pointer (report honestly if restore fails), start services, error
 13. on success: start services; optional prune --keep N
 14. post-upgrade hooks (www migrate, docs refresh) unchanged where applicable
+15. if install root is not writable: legacy single-file replace of a path **outside** versions/; refuse to clobber version-tree targets
 ```
 
 ### Migration from legacy install

--- a/docs/TDD/README.md
+++ b/docs/TDD/README.md
@@ -53,6 +53,7 @@ Twenty-three library crates under `crates/` plus integration tests in `tests/`. 
 | `21-scheduled-maintenance.md` | Retention, dormant accounts (`chatmail-tasks`) |
 | `22-bandwidth-monitoring.md` | Bandwidth spec (planned) |
 | `23-push-notifications.md` | XDELTAPUSH, `notifications.delta.chat`, modes, CLI `madmail push` |
+| `24-version-manager.md` | **Plan:** `/opt/madmail` versioned binaries, PATH symlink, upgrade/rollback |
 
 ## RFC reference library
 

--- a/docs/TDD/README.md
+++ b/docs/TDD/README.md
@@ -53,7 +53,7 @@ Twenty-three library crates under `crates/` plus integration tests in `tests/`. 
 | `21-scheduled-maintenance.md` | Retention, dormant accounts (`chatmail-tasks`) |
 | `22-bandwidth-monitoring.md` | Bandwidth spec (planned) |
 | `23-push-notifications.md` | XDELTAPUSH, `notifications.delta.chat`, modes, CLI `madmail push` |
-| `24-version-manager.md` | **Plan:** `/opt/madmail` versioned binaries, PATH symlink, upgrade/rollback |
+| `24-version-manager.md` | **Plan:** versioned binaries (`/opt/madmail` Unix, `%ProgramFiles%\Madmail` Windows), stable PATH entry, upgrade/rollback |
 
 ## RFC reference library
 

--- a/tests/version-manager-docker-smoke.sh
+++ b/tests/version-manager-docker-smoke.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+# Docker smoke for version manager dual-upgrade (PR #136 / TDD 24).
+#
+# Host usage:
+#   ./tests/version-manager-docker-smoke.sh
+#   MADMAIL_BIN=./target/release/madmail ./tests/version-manager-docker-smoke.sh
+#   ./tests/version-manager-docker-smoke.sh --inner   # already inside container
+#
+# Verifies:
+#   - signed v2.18.2 then v2.20.0 upgrades leave versions/2.18.2 bit-identical
+#   - PATH entry is a symlink into the version tree after first upgrade
+#   - versions list / current / path / use / prune / remove --yes
+#   - unsigned binary cannot be activated
+#   - --json prune/remove still require --yes
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+IMAGE="${MADMAIL_DOCKER_SMOKE_IMAGE:-ubuntu:24.04}"
+MADMAIL_BIN="${MADMAIL_BIN:-$ROOT/target/release/madmail}"
+V1_TAG="${V1_TAG:-v2.18.2}"
+V2_TAG="${V2_TAG:-v2.20.0}"
+ASSET="${ASSET:-madmail-linux-amd64.tar.gz}"
+
+red() { printf '\033[31m%s\033[0m\n' "$*" >&2; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+info() { printf '\033[36m==> %s\033[0m\n' "$*"; }
+
+die() {
+  red "FAIL: $*"
+  exit 1
+}
+
+assert_eq() {
+  local want="$1" got="$2" msg="$3"
+  if [[ "$want" != "$got" ]]; then
+    die "$msg (want=$want got=$got)"
+  fi
+}
+
+sha256_file() {
+  sha256sum "$1" | awk '{print $1}'
+}
+
+run_host() {
+  command -v docker >/dev/null || die "docker is required on PATH"
+  [[ -x "$MADMAIL_BIN" ]] || die "madmail binary not found/executable: $MADMAIL_BIN (build with: cargo build -p chatmail --release)"
+
+  info "Checking binary runs on host: $MADMAIL_BIN"
+  "$MADMAIL_BIN" version >/dev/null
+
+  info "Pulling $IMAGE..."
+  docker pull -q "$IMAGE" >/dev/null
+
+  info "Starting container smoke ($IMAGE) with $MADMAIL_BIN"
+  docker run --rm \
+    --name "madmail-vm-smoke-$$" \
+    -v "$ROOT:/src:ro" \
+    -v "$MADMAIL_BIN:/binaries/madmail:ro" \
+    -e MADMAIL_BIN=/binaries/madmail \
+    -e V1_TAG="$V1_TAG" \
+    -e V2_TAG="$V2_TAG" \
+    -e ASSET="$ASSET" \
+    "$IMAGE" \
+    bash /src/tests/version-manager-docker-smoke.sh --inner
+}
+
+run_inner() {
+  export DEBIAN_FRONTEND=noninteractive
+  info "Installing curl, ca-certificates, file..."
+  apt-get update -qq
+  apt-get install -y -qq curl ca-certificates file python3 >/dev/null
+
+  # Always invoke the PR/under-test binary by absolute path. After upgrade #1 the
+  # PATH entry may point at an *older* archived release that lacks the version
+  # manager dual-upgrade fix — calling `madmail` on PATH would reintroduce clobber.
+  local tool="${MADMAIL_BIN:-/binaries/madmail}"
+  [[ -x "$tool" ]] || die "binary missing in container: $tool"
+  # Keep a private copy so current_exe() is not the read-only mount.
+  mkdir -p /opt/madmail-tool
+  cp -f "$tool" /opt/madmail-tool/madmail
+  chmod 755 /opt/madmail-tool/madmail
+  tool=/opt/madmail-tool/madmail
+
+  info "Under-test tool: $($tool version 2>&1 | head -1) ($tool)"
+  if ! "$tool" versions --help >/dev/null 2>&1; then
+    die "binary does not implement 'madmail versions' — rebuild from PR branch"
+  fi
+
+  # Stable PATH layout used by version manager on Unix.
+  mkdir -p /usr/local/bin /opt/madmail /tmp/vm-smoke
+  # Seed PATH with the under-test tool so first boot looks like a normal install.
+  cp -f "$tool" /usr/local/bin/madmail
+  chmod 755 /usr/local/bin/madmail
+  hash -r 2>/dev/null || true
+
+  # Skip real systemd unit churn for versions use; pointer flips still run.
+  export MADMAIL_VERSION_MANAGER_NO_SERVICE=1
+  export MADMAIL_INSTALL_ROOT=/opt/madmail
+
+  info "Downloading signed release assets ${V1_TAG} + ${V2_TAG}..."
+  local v1_url="https://github.com/themadorg/madmail/releases/download/${V1_TAG}/${ASSET}"
+  local v2_url="https://github.com/themadorg/madmail/releases/download/${V2_TAG}/${ASSET}"
+  curl -fsSL --retry 3 -o /tmp/vm-smoke/v1.tar.gz "$v1_url"
+  curl -fsSL --retry 3 -o /tmp/vm-smoke/v2.tar.gz "$v2_url"
+
+  mkdir -p /tmp/vm-smoke/v1 /tmp/vm-smoke/v2
+  tar -xzf /tmp/vm-smoke/v1.tar.gz -C /tmp/vm-smoke/v1
+  tar -xzf /tmp/vm-smoke/v2.tar.gz -C /tmp/vm-smoke/v2
+
+  # Locate madmail payload (top-level or nested).
+  local v1_bin v2_bin
+  v1_bin="$(find /tmp/vm-smoke/v1 -type f -name 'madmail' | head -1)"
+  v2_bin="$(find /tmp/vm-smoke/v2 -type f -name 'madmail' | head -1)"
+  [[ -n "$v1_bin" && -f "$v1_bin" ]] || die "no madmail member in ${V1_TAG} archive"
+  [[ -n "$v2_bin" && -f "$v2_bin" ]] || die "no madmail member in ${V2_TAG} archive"
+  chmod 755 "$v1_bin" "$v2_bin"
+
+  info "v1 asset version: $($v1_bin version 2>&1 | head -1)"
+  info "v2 asset version: $($v2_bin version 2>&1 | head -1)"
+
+  local v1_sha
+  v1_sha="$(sha256_file "$v1_bin")"
+  info "v1 payload sha256=$v1_sha"
+
+  local id1="${V1_TAG#v}"
+  local id2="${V2_TAG#v}"
+
+  # --- Upgrade #1: seed version tree + PATH symlink (always via $tool) ---
+  info "Upgrade #1 → ${V1_TAG} (tool=$tool)"
+  "$tool" upgrade "$v1_bin" 2>&1 | tail -40
+
+  local archived1="/opt/madmail/versions/${id1}/madmail"
+  [[ -f "$archived1" ]] || die "missing archived binary after upgrade #1: $archived1"
+  assert_eq "$v1_sha" "$(sha256_file "$archived1")" "archived v1 sha must match payload"
+
+  if [[ -L /usr/local/bin/madmail ]]; then
+    green "PATH entry is symlink after upgrade #1 → $(readlink /usr/local/bin/madmail)"
+  else
+    die "expected /usr/local/bin/madmail to be a symlink into the version tree after upgrade #1 (file type=$(file /usr/local/bin/madmail))"
+  fi
+
+  local resolved1
+  resolved1="$(readlink -f /usr/local/bin/madmail)"
+  [[ "$resolved1" == *"/versions/${id1}/"* ]] || die "PATH resolves to $resolved1, expected versions/${id1}"
+
+  # Sanity: PATH madmail is the *old* release; upgrading via PATH would clobber.
+  # We deliberately keep using $tool (PR binary) for upgrade #2.
+  if /usr/local/bin/madmail versions --help >/dev/null 2>&1; then
+    info "Note: active PATH binary also has versions CLI"
+  else
+    info "Note: active PATH binary is older release without versions CLI (expected for ${id1})"
+  fi
+
+  # --- Upgrade #2: must NOT clobber versions/<v1> ---
+  info "Upgrade #2 → ${V2_TAG} (tool=$tool; PATH currently → $resolved1)"
+  "$tool" upgrade "$v2_bin" 2>&1 | tee /tmp/vm-upgrade2.log | tail -40
+
+  # Must take the versioned path, not legacy in-place into versions/2.18.2.
+  if grep -q "Target binary (legacy in-place):.*/versions/" /tmp/vm-upgrade2.log; then
+    die "upgrade #2 fell back to legacy replace under versions/ — dual-upgrade unsafe"
+  fi
+  if grep -qE "Target binary: /opt/madmail/versions/" /tmp/vm-upgrade2.log; then
+    die "upgrade #2 used old in-place Target binary under versions/ (wrong binary/tool?)"
+  fi
+  grep -q "Installed candidate under\|Versioned activate\|Active version ${id2}" /tmp/vm-upgrade2.log \
+    || die "upgrade #2 did not look like a versioned install (see /tmp/vm-upgrade2.log)"
+
+  local archived2="/opt/madmail/versions/${id2}/madmail"
+  [[ -f "$archived2" ]] || die "missing archived binary after upgrade #2: $archived2"
+  assert_eq "$v1_sha" "$(sha256_file "$archived1")" \
+    "CRITICAL: versions/${id1}/madmail clobbered by upgrade #2 (dual-upgrade regression)"
+
+  local v2_sha
+  v2_sha="$(sha256_file "$v2_bin")"
+  assert_eq "$v2_sha" "$(sha256_file "$archived2")" "archived v2 sha must match payload"
+
+  local resolved2
+  resolved2="$(readlink -f /usr/local/bin/madmail)"
+  [[ "$resolved2" == *"/versions/${id2}/"* ]] || die "PATH resolves to $resolved2, expected versions/${id2}"
+
+  green "Dual-upgrade: versions/${id1} unchanged; active → ${id2}"
+
+  # --- CLI: list / current / path (via $tool — always has versions CLI) ---
+  info "CLI: versions list / current / path"
+  "$tool" versions list
+  "$tool" versions current
+  "$tool" versions path
+  "$tool" versions path "$id1"
+
+  json_version() {
+    "$tool" --json versions current | python3 -c \
+      'import sys,json; d=json.load(sys.stdin); print(d.get("data",d).get("version") or "")'
+  }
+
+  local cur
+  cur="$(json_version)"
+  assert_eq "$id2" "$cur" "active version after dual upgrade"
+
+  # --- versions use: switch back to v1 (signed) ---
+  info "CLI: versions use ${id1}"
+  MADMAIL_VERSION_MANAGER_NO_SERVICE=1 "$tool" versions use "$id1" 2>&1 | tail -15
+  cur="$(json_version)"
+  assert_eq "$id1" "$cur" "active after versions use ${id1}"
+  assert_eq "$v1_sha" "$(sha256_file "$(readlink -f /usr/local/bin/madmail)")" "active file is still v1 bytes"
+
+  # switch back to v2
+  MADMAIL_VERSION_MANAGER_NO_SERVICE=1 "$tool" versions use "$id2" 2>&1 | tail -10
+  cur="$(json_version)"
+  assert_eq "$id2" "$cur" "active after versions use ${id2}"
+
+  # --- unsigned reject ---
+  info "CLI: unsigned activation must fail"
+  mkdir -p "/opt/madmail/versions/9.9.9-unsigned"
+  printf '#!/bin/sh\necho madmail-v2 9.9.9-unsigned\n' >"/opt/madmail/versions/9.9.9-unsigned/madmail"
+  chmod 755 "/opt/madmail/versions/9.9.9-unsigned/madmail"
+  if MADMAIL_VERSION_MANAGER_NO_SERVICE=1 "$tool" versions use 9.9.9-unsigned 2>/tmp/vm-unsigned.err; then
+    die "unsigned versions use should have failed"
+  fi
+  grep -qiE 'signature|INVALID|refusing' /tmp/vm-unsigned.err \
+    || die "unsigned use error should mention signature (got: $(cat /tmp/vm-unsigned.err))"
+  green "unsigned versions use rejected"
+
+  # --- --yes required even with --json ---
+  info "CLI: --json prune/remove require --yes"
+  if "$tool" --json versions remove 9.9.9-unsigned 2>/tmp/vm-yes.err; then
+    die "--json versions remove without --yes should fail"
+  fi
+  grep -qi 'requires --yes' /tmp/vm-yes.err || die "expected requires --yes (got: $(cat /tmp/vm-yes.err))"
+
+  if "$tool" --json versions prune --keep 0 2>/tmp/vm-prune.err; then
+    die "--json versions prune without --yes should fail"
+  fi
+  grep -qi 'requires --yes' /tmp/vm-prune.err || die "expected prune requires --yes"
+
+  "$tool" versions remove 9.9.9-unsigned --yes
+  [[ ! -d /opt/madmail/versions/9.9.9-unsigned ]] || die "unsigned version dir still present"
+
+  # prune should not remove active; keep 0 non-active → remove only non-active
+  "$tool" versions prune --keep 0 --yes
+  [[ -f "$archived2" ]] || die "prune removed active ${id2}"
+  # v1 may be pruned (non-active) — that is OK; dual-upgrade already checked
+
+  # --- remote list (network) ---
+  info "CLI: versions list --remote (metadata only)"
+  if "$tool" versions list --remote 2>&1 | tee /tmp/vm-remote.out | grep -qE '2\.[0-9]'; then
+    green "versions list --remote returned release tags"
+  else
+    # Network flakes should not hard-fail the dual-upgrade proof.
+    red "WARN: versions list --remote returned no version-looking lines (network?)"
+    cat /tmp/vm-remote.out || true
+  fi
+
+  green "ALL DOCKER SMOKE CHECKS PASSED"
+  echo
+  echo "Summary:"
+  echo "  tool binary:   $tool"
+  echo "  install root:  /opt/madmail"
+  echo "  dual-upgrade:  ${id1} sha preserved across upgrade to ${id2}"
+  echo "  versions use:  signed switch ok; unsigned rejected"
+  echo "  --yes:         required for prune/remove even with --json"
+}
+
+case "${1:-}" in
+  --inner) run_inner ;;
+  *) run_host ;;
+esac


### PR DESCRIPTION
## Summary

- Add platform version tree (`/opt/madmail` on Unix, `%ProgramFiles%\Madmail` on Windows) with `MADMAIL_INSTALL_ROOT` override.
- New CLI: `madmail versions list [--remote] | current | use | prune | remove | path` (JSON supported).
- `versions use` always re-verifies Ed25519 before switching.
- `madmail update latest` / `upgrade latest` resolves GitHub Releases latest asset and uses the existing download pipeline (size caps, archive rules, mandatory signature, preflight).
- Successful upgrades archive into the version tree and set the active pointer when the install root is writable.
- TDD: `docs/TDD/24-version-manager.md`.

## Security

- No private signing keys are included; only the existing public verify key remains in-tree.
- GitHub “latest” is not a trust shortcut — signature verification still runs.

## Test plan

- [x] `cargo test -p chatmail version_manager` (35)
- [x] `cargo test -p chatmail upgrade::`
- [x] `cargo test -p chatmail-config --lib cli::`
- [x] Docker smoke on Ubuntu 24.04: list/use(unsigned reject)/prune/remove, `list --remote`, `update latest` (sig + archive under install root)
- [ ] CI green
- [ ] Manual root install path on a real host (optional)