### PR TITLE
feat(imap/smtp): reduce pre-auth fingerprinting (#120)

### DIFF
--- a/crates/chatmail-imap/src/session.rs
+++ b/crates/chatmail-imap/src/session.rs
@@ -209,9 +209,7 @@ impl ImapSession {
                 writer.write_all(r.as_bytes()).await?;
             }
             if cmd_upper == "LOGOUT" {
-                writer
-                    .write_all(b"* BYE madmail-v2 logging out\r\n")
-                    .await?;
+                writer.write_all(b"* BYE Logging out\r\n").await?;
                 if let Some(t) = tag {
                     writer
                         .write_all(format!("{t} OK LOGOUT completed\r\n").as_bytes())
@@ -280,9 +278,7 @@ impl ImapSession {
                 writer.write_all(r.as_bytes()).await?;
             }
             if cmd_upper == "LOGOUT" {
-                writer
-                    .write_all(b"* BYE madmail-v2 logging out\r\n")
-                    .await?;
+                writer.write_all(b"* BYE Logging out\r\n").await?;
                 if let Some(t) = tag {
                     writer
                         .write_all(format!("{t} OK LOGOUT completed\r\n").as_bytes())
@@ -312,6 +308,7 @@ impl ImapSession {
             "CAPABILITY" => Ok(Some(format!(
                 "* CAPABILITY {}\r\n{t} OK CAPABILITY completed\r\n",
                 capability_string(
+                    self.authenticated_user.is_some(),
                     self.cfg.advertise_metadata(),
                     self.cfg.push_enabled,
                     self.cfg.starttls_config.is_some() && !tls_active,
@@ -1362,7 +1359,12 @@ fn parse_uid_set_and_mailbox(args: &str) -> Result<(Vec<u32>, String)> {
 }
 
 /// Advertised IMAP capabilities (TDD `03-imap-server.md`: XCHATMAIL, XDELTAPUSH, IDLE, QUOTA, METADATA).
+///
+/// Pre-auth responses intentionally omit chatmail-identifying tokens (`XCHATMAIL`,
+/// `XDELTAPUSH`, `METADATA`) so unauthenticated probes see a generic IMAP4rev1
+/// server (#120). Delta Chat only needs those after login.
 pub fn capability_string(
+    authenticated: bool,
     advertise_metadata: bool,
     advertise_push: bool,
     advertise_starttls: bool,
@@ -1375,16 +1377,18 @@ pub fn capability_string(
         "UIDPLUS",
         "AUTH=PLAIN",
         "LITERAL+",
-        "XCHATMAIL",
     ];
-    if advertise_push {
-        caps.push("XDELTAPUSH");
-    }
     if advertise_starttls {
         caps.push("STARTTLS");
     }
-    if advertise_metadata {
-        caps.push("METADATA");
+    if authenticated {
+        caps.push("XCHATMAIL");
+        if advertise_push {
+            caps.push("XDELTAPUSH");
+        }
+        if advertise_metadata {
+            caps.push("METADATA");
+        }
     }
     caps.join(" ")
 }
@@ -1836,14 +1840,30 @@ mod tests {
     use std::time::Duration;
     // write_blob delivers to INBOX
 
-    /// P5-UT01: CAPABILITY includes Chatmail extensions (TDD + cmdeploy `test_capabilities`).
+    /// P5-UT01: post-auth CAPABILITY includes Chatmail extensions; pre-auth stays generic (#120).
     #[test]
     fn p5_ut01_test_capability_includes_chatmail_extensions() {
-        let caps = capability_string(false, false, false);
+        let pre = capability_string(false, true, true, true);
+        assert!(pre.contains("IMAP4rev1"));
+        assert!(pre.contains("IDLE"));
+        assert!(pre.contains("QUOTA"));
+        assert!(pre.contains("MOVE"));
+        assert!(pre.contains("STARTTLS"));
+        assert!(
+            !pre.contains("XCHATMAIL"),
+            "XCHATMAIL must not leak pre-auth: {pre}"
+        );
+        assert!(
+            !pre.contains("XDELTAPUSH"),
+            "XDELTAPUSH must not leak pre-auth: {pre}"
+        );
+        assert!(
+            !pre.contains("METADATA"),
+            "METADATA must not leak pre-auth: {pre}"
+        );
+
+        let caps = capability_string(true, false, false, false);
         assert!(caps.contains("IMAP4rev1"));
-        assert!(caps.contains("IDLE"));
-        assert!(caps.contains("QUOTA"));
-        assert!(caps.contains("MOVE"));
         assert!(caps.contains("XCHATMAIL"));
         assert!(
             !caps.contains("XDELTAPUSH"),
@@ -1854,13 +1874,13 @@ mod tests {
             "METADATA is advertised only when TURN/Iroh/push discovery is enabled"
         );
 
-        let with_push = capability_string(false, true, false);
+        let with_push = capability_string(true, false, true, false);
         assert!(with_push.contains("XDELTAPUSH"));
 
-        let with_starttls = capability_string(false, false, true);
+        let with_starttls = capability_string(false, false, false, true);
         assert!(with_starttls.contains("STARTTLS"));
 
-        let with_metadata = capability_string(true, false, false);
+        let with_metadata = capability_string(true, true, false, false);
         assert!(with_metadata.contains("METADATA"));
     }
 
@@ -2560,6 +2580,7 @@ mod integration_tests {
             &[
                 "a001 CAPABILITY",
                 "a002 LOGIN u@test pw",
+                "a002b CAPABILITY",
                 "a003 SELECT INBOX",
                 "a003b STATUS INBOX (UIDNEXT MESSAGES)",
                 "a004 UID FETCH 1 (UID INTERNALDATE RFC822.SIZE BODY.PEEK[HEADER.FIELDS (MESSAGE-ID FROM)])",
@@ -2567,7 +2588,18 @@ mod integration_tests {
             ],
         )
         .await;
-        assert!(t.contains("XCHATMAIL"), "caps: {t}");
+        // Pre-auth CAPABILITY must not fingerprint chatmail (#120).
+        // Transcript is server responses only (no client command text).
+        let pre = t
+            .split("a002 OK LOGIN")
+            .next()
+            .expect("transcript includes pre-login CAPABILITY");
+        assert!(
+            !pre.contains("XCHATMAIL"),
+            "pre-auth must not advertise XCHATMAIL: {pre}"
+        );
+        assert!(t.contains("a002b OK CAPABILITY"), "post-auth caps: {t}");
+        assert!(t.contains("XCHATMAIL"), "post-auth caps: {t}");
         assert!(t.contains("a002 OK LOGIN"), "login: {t}");
         assert!(t.contains("UIDNEXT"), "select: {t}");
         assert!(t.contains("EXISTS"), "select: {t}");

--- a/crates/chatmail-smtp/src/session.rs
+++ b/crates/chatmail-smtp/src/session.rs
@@ -95,7 +95,7 @@ impl SmtpSession {
         let mut lines = BufReader::new(reader);
 
         writer
-            .write_all(format!("220 {} ESMTP madmail-v2\r\n", self.cfg.hostname).as_bytes())
+            .write_all(format!("220 {} ESMTP\r\n", self.cfg.hostname).as_bytes())
             .await?;
 
         loop {
@@ -184,7 +184,7 @@ impl SmtpSession {
         // RFC 8314: banner on cleartext and on implicit TLS (:465); skip duplicate after STARTTLS upgrade.
         if !tls_active || self.cfg.starttls_config.is_none() {
             writer
-                .write_all(format!("220 {} ESMTP madmail-v2\r\n", self.cfg.hostname).as_bytes())
+                .write_all(format!("220 {} ESMTP\r\n", self.cfg.hostname).as_bytes())
                 .await?;
         }
 

--- a/docs/TDD/02-smtp-server.md
+++ b/docs/TDD/02-smtp-server.md
@@ -141,6 +141,16 @@ Madmail uses deep OpenPGP packet inspection. **madmail-v2** (`chatmail-pgp`) imp
 | `chatmail-delivery` | Local deliver + HTTP `/mxdeliv` + SMTP fallback outbound |
 | `chatmail-auth` | JIT + credential verify on AUTH |
 
+### Greeting / banner (#120)
+
+The 220 greeting is intentionally generic (no product token), on both cleartext and implicit-TLS submission paths:
+
+```text
+220 {hostname} ESMTP
+```
+
+Previously the banner ended with `madmail-v2`, which made active probes trivial to classify. See also pre-auth IMAP CAPABILITY split in [03-imap-server.md](03-imap-server.md).
+
 ### Minimum SMTP command set (MVP)
 
 | Command | Inbound 25 | Submission |

--- a/docs/TDD/03-imap-server.md
+++ b/docs/TDD/03-imap-server.md
@@ -428,6 +428,20 @@ From `imap-proto/src/parser/mod.rs` + `imap/src/op/mod.rs`:
 
 ## Rust implementation notes (`madmail-v2`)
 
+### Pre-auth vs post-auth CAPABILITY (#120)
+
+madmail-v2 splits advertised IMAP capabilities so unauthenticated probes cannot fingerprint a chatmail relay. Dovecot historically has a single capability set for pre- and post-auth; Madmail’s custom stack does not.
+
+| Session state | Advertised capabilities |
+|---------------|-------------------------|
+| **Pre-auth** (greeting / unauthenticated `CAPABILITY`) | Generic IMAP only: `IMAP4rev1`, `IDLE`, `QUOTA`, `MOVE`, `UIDPLUS`, `AUTH=PLAIN`, `LITERAL+`, and `STARTTLS` when applicable. **No** `XCHATMAIL`, `XDELTAPUSH`, or `METADATA`. |
+| **Post-auth** (after successful `LOGIN` / `AUTHENTICATE`) | Pre-auth set **plus** `XCHATMAIL`, and when configured `XDELTAPUSH` and/or `METADATA` (TURN/Iroh/push discovery). |
+
+- Implementation: `capability_string(authenticated, …)` in [`crates/chatmail-imap/src/session.rs`](../../crates/chatmail-imap/src/session.rs).
+- Greeting remains bland: `* OK {host} IMAP4rev1 ready`.
+- `LOGOUT` sends `* BYE Logging out` (no product token).
+- Delta Chat does not require chatmail-specific capabilities before login; clients discover extensions after auth.
+
 ### `crates/chatmail-storage` — mailbox backend
 
 IMAP sessions use `AppState::mailbox_store` (`MailboxStore`):
@@ -461,13 +475,13 @@ Mirrors Madmail `go-imap-sql/delivery.go` and Delta Chat `context/core/src/imap/
 - `handle_fetch`: reload maildir on each FETCH; **sequence** `FETCH n` uses 1-based index; **`UID FETCH`** uses UID (was a common bug).
 - FETCH literals: close with `)\r\n` immediately after literal (go-imap compatible).
 
-**Tests:** `p5_ut01_test_capability_includes_chatmail_extensions` (includes `XDELTAPUSH`), `p6_ut01_test_idle_receives_delivery_event`, `p6_imap_idle_unsolicited_exists`, `imap_starttls_capability_and_login_gate`, `imap_starttls_upgrade_then_login` in `crates/chatmail-imap/src/session.rs`.
+**Tests:** `p5_ut01_test_capability_includes_chatmail_extensions` (pre-auth generic; post-auth includes chatmail tokens / `XDELTAPUSH` when enabled), `p6_ut01_test_idle_receives_delivery_event`, `p6_imap_idle_unsolicited_exists`, `imap_starttls_capability_and_login_gate`, `imap_starttls_upgrade_then_login` in `crates/chatmail-imap/src/session.rs`.
 
 **relay-ping:** `internal/check/imapcheck/idle.go` — `waitInboxGrow` (IDLE + EXISTS), `probeIdleDelivery` (IDLE + second-session APPEND). Cross-delivery and Secure Join start IDLE **before** SMTP submit (core lifecycle).
 
 ### `crates/chatmail-imap` — XDELTAPUSH / SETMETADATA (implemented)
 
-When `__PUSH_MODE__` is `auto` or `on`, `CAPABILITY` includes `METADATA` + `XDELTAPUSH`. When `off` (**default**), neither is advertised and `SETMETADATA` is rejected.
+When `__PUSH_MODE__` is `auto` or `on`, **post-auth** `CAPABILITY` includes `METADATA` + `XDELTAPUSH`. Pre-auth CAPABILITY never advertises those tokens (#120). When push is `off` (**default**), neither is advertised post-auth and `SETMETADATA` is rejected.
 
 | Command | Behavior |
 |---------|----------|
@@ -493,7 +507,7 @@ After rebuilding chatmail, Delta Chat should pass folder configure and enter **I
 ### Minimum viable server (Delta Chat parity with Madmail)
 
 1. **Session**: AUTH, SELECT, UID FETCH, UID STORE, UID MOVE, CLOSE, LIST, STATUS, IDLE.
-2. **Extensions**: MOVE, SPECIAL-USE, QUOTA (`GETQUOTA`/`GETQUOTAROOT`), METADATA GET (Chatmail keys), `XCHATMAIL`, **`XDELTAPUSH`** + `SETMETADATA /private/devicetoken` when push enabled (implemented in madmail-v2; default **off**).
+2. **Extensions**: MOVE, SPECIAL-USE, QUOTA (`GETQUOTA`/`GETQUOTAROOT`), METADATA GET (Chatmail keys), `XCHATMAIL`, **`XDELTAPUSH`** + `SETMETADATA /private/devicetoken` when push enabled (implemented in madmail-v2; default **off**). Chatmail-specific capabilities are advertised **post-auth only** (#120).
 3. **APPEND**: With PGP enforcement (mirror `encryptionWrapperUser`).
 4. **IDLE**: Unsolicited `EXISTS` on delivery (SMTP + `/mxdeliv` + local append) — **see table above**.
 5. **JIT**: Account/mailbox creation on first LOGIN (see `05-authentication.md`).

--- a/docs/TDD/11-proxy-services.md
+++ b/docs/TDD/11-proxy-services.md
@@ -178,7 +178,7 @@ Config on `imap { }` block ([`maddy.conf`](../../context/madmail/maddy.conf)):
 | `turn_ttl` | `86400` | Seconds added to `now` for username expiry |
 | `turn_prefer_tls` | `yes` | **Stored but not used** in GETMETADATA today |
 
-Capability `METADATA` is advertised when TURN and/or Iroh URL is configured ([`03-imap-server.md`](03-imap-server.md)).
+Capability `METADATA` is advertised **post-auth** when TURN and/or Iroh URL is configured ([`03-imap-server.md`](03-imap-server.md)). Pre-auth CAPABILITY intentionally omits `METADATA` so probes cannot fingerprint chatmail (#120).
 
 ### Integrated TURN server
 
@@ -483,7 +483,7 @@ Initial `GETMETADATA` request (with TURN keys):
 
 | Requirement | Implementation |
 |-------------|----------------|
-| Capability `METADATA` | When TURN **or** Iroh discovery is active ([`ImapSessionConfig::advertise_metadata`](../../crates/chatmail-imap/src/session.rs)) |
+| Capability `METADATA` | **Post-auth** when TURN **or** Iroh discovery is active ([`ImapSessionConfig::advertise_metadata`](../../crates/chatmail-imap/src/session.rs)); never pre-auth (#120) |
 | Key `/shared/vendor/deltachat/irohrelay` | Value = configured URL string (quoted) |
 | Authenticated, mailbox `""` | Same as TURN GETMETADATA |
 

--- a/docs/TDD/16-testing.md
+++ b/docs/TDD/16-testing.md
@@ -39,9 +39,10 @@ Chatmail's correctness is defined by **real Delta Chat client behavior**, not ju
 | Auth cache + JIT | `chatmail-state`, `chatmail-auth` | `hydrate_loads_blocklist_and_jit_flag`, `jit_coalesces_concurrent_creates_for_same_user` |
 | TLS for STARTTLS | `chatmail-config` | `listeners_need_tls_cert_for_starttls_only_ports` |
 | Autoconfig | `chatmail-config`, `chatmail-www` | `autoconfig_omits_https_alpn_even_when_http_tls_bound` |
-| IMAP caps | `chatmail-imap` | `p5_ut01_test_capability_includes_chatmail_extensions` (`XDELTAPUSH`) |
+| IMAP caps (pre/post-auth) | `chatmail-imap` | `p5_ut01_test_capability_includes_chatmail_extensions` — pre-auth omits `XCHATMAIL`/`XDELTAPUSH`/`METADATA`; post-auth includes chatmail tokens (#120) |
 | Push notify | `chatmail-push`, `chatmail-admin` | `push_mode_and_circuit_breaker`, `successful_delivery_increments_push_stats`, `p9_push_service_toggle` |
-| IMAP push E2E | `tests/imap_e2e.rs` | `imap_e2e_push_devicetoken_setmetadata`, `imap_e2e_push_disabled_hides_capabilities` |
+| IMAP push E2E | `tests/imap_e2e.rs` | `imap_e2e_push_devicetoken_setmetadata` (post-auth caps), `imap_e2e_push_disabled_hides_capabilities`, `imap_e2e_greeting_and_capability` |
+| TURN CAPABILITY | `tests/turn_e2e.rs` | `turn_imap_e2e_capability_metadata` — `METADATA` only after LOGIN |
 | SMTP submission | `chatmail-smtp` | `submission_starttls_upgrade_then_auth_allowed` |
 | Federation body limit | `chatmail-fed`, `chatmail-state`, `chatmail-config`, `chatmail-admin` | `p7_ut04`–`p7_ut06`, `federation_size_*`, `admin_federation_size_*` |
 | Bigfile roundtrip E2E | `tests/deltachat-test` | `test_23_bigfile_roundtrip.py` (5 MiB SHA-256, two relays, &lt;60s) |
@@ -115,7 +116,7 @@ These tests target a **live deployed** Chatmail host (env `CHATMAIL_DOMAIN`, opt
 | File | Validates |
 |------|-----------|
 | `test_0_login.py` | IMAP/SMTP login, JIT auto-create, password rules, concurrent logins |
-| `test_0_login.py` (`test_capabilities`) | IMAP caps: `XCHATMAIL`, `XDELTAPUSH` |
+| `test_0_login.py` (`test_capabilities`) | IMAP caps: `XCHATMAIL`, `XDELTAPUSH` (cmdeploy/Dovecot often pre-auth; madmail-v2 exposes these **post-auth only** — #120) |
 | `test_0_qr.py` | QR / invite flows (HTTP, not IMAP) |
 | `test_1_basic.py` | SSH + SMTP send (`swaks`), DNS, deliverability smoke |
 | `test_2_deltachat.py` | Delta Chat RPC: 1:1 chat, metadata SET/GET on INBOX |
@@ -133,7 +134,7 @@ cd context/cmdeploy && pytest src/cmdeploy/tests/online/test_0_login.py -v
 | cmdeploy test | Primary TDD section |
 |---------------|---------------------|
 | Login / JIT | `05-authentication.md`, `03-imap-server.md` |
-| `XCHATMAIL` / `XDELTAPUSH` | `03-imap-server.md` |
+| `XCHATMAIL` / `XDELTAPUSH` (post-auth on madmail-v2) | `03-imap-server.md` (#120 pre-auth fingerprinting) |
 | Delta Chat send/receive | `02-smtp-server.md` + `03-imap-server.md` + `16-testing.md` (deltachat-test) |
 
 **Gaps:** cmdeploy does **not** cover `523 Encryption Needed`, federation ACCEPT/REJECT, or Admin API — use `context/madmail/tests/deltachat-test/` for those.

--- a/docs/TDD/23-push-notifications.md
+++ b/docs/TDD/23-push-notifications.md
@@ -3,11 +3,13 @@
 Delta Chat mobile wake-up via IMAP `SETMETADATA` device tokens and the central notification proxy at `https://notifications.delta.chat/notify`.
 
 **Crate:** `crates/chatmail-push/` (`notifier`, `store`, `mode`, `enabled`, `stats`)  
-**IMAP:** `crates/chatmail-imap/` (`XDELTAPUSH`, `METADATA`, `/private/devicetoken`)
+**IMAP:** `crates/chatmail-imap/` (`XDELTAPUSH`, `METADATA`, `/private/devicetoken`)  
 **Admin:** `/admin/services/push`, `push` block in `/admin/status` and `/admin/overview`  
 **CLI:** `madmail push` — guide: [`../guide/cli/push.md`](../guide/cli/push.md) (binary name is **`madmail`**, not `chatmail`)
 
 Reference: Dovecot/chatmaild `notifier.py`, cmdeploy `XDELTAPUSH` capability.
+
+**Advertisement (#120):** When push is enabled, `XDELTAPUSH` and `METADATA` appear only on **post-auth** IMAP `CAPABILITY`. Pre-auth responses stay generic so unauthenticated probes do not fingerprint the relay.
 
 ---
 
@@ -90,7 +92,7 @@ When auto mode trips, the server logs an error and suggests `madmail push auto` 
 | `disable` / `off` | Mode **off** |
 | `auto` | Mode **auto** |
 
-Response includes `restart_required: true` (soft reload refreshes IMAP `XDELTAPUSH` advertisement).
+Response includes `restart_required: true` (soft reload refreshes post-auth IMAP `XDELTAPUSH` advertisement).
 
 ### Status / overview
 
@@ -141,8 +143,8 @@ Successful deliveries increment `push_successful_notifications` in the `message_
 
 | ID | Scope |
 |----|--------|
-| `imap_e2e_push_devicetoken_setmetadata` | IMAP SET/GET METADATA round-trip |
-| `imap_e2e_push_disabled_hides_capabilities` | Push off → no `XDELTAPUSH` |
+| `imap_e2e_push_devicetoken_setmetadata` | Pre-auth omits push caps; post-auth SET/GET METADATA round-trip |
+| `imap_e2e_push_disabled_hides_capabilities` | Push off → no post-auth `XDELTAPUSH` |
 | `p9_push_service_toggle` | Admin GET/POST `/admin/services/push` |
 | `p9_status_push_stats` | `push` block in `/admin/status` |
 | `push_mode_and_circuit_breaker` | Auto trip after 5 failures (`chatmail-push`) |

--- a/docs/project/08-smtp-imap-servers.md
+++ b/docs/project/08-smtp-imap-servers.md
@@ -77,6 +77,8 @@ From the integration tests and TDD:
 - GETMETADATA / SETMETADATA (the Chatmail magic for TURN/Iroh discovery)
 - STATUS, etc.
 
+**Pre-auth fingerprinting (#120):** Unauthenticated `CAPABILITY` is generic (no `XCHATMAIL` / `XDELTAPUSH` / `METADATA`). Those tokens appear only after login. SMTP greeting is `220 {hostname} ESMTP` without a product name. See TDD [03-imap-server.md](../TDD/03-imap-server.md) and [02-smtp-server.md](../TDD/02-smtp-server.md).
+
 ### IDLE & Push
 
 When a client does `IDLE`, the session registers with the `EventBus` (in `AppState`).

--- a/tests/imap_e2e.rs
+++ b/tests/imap_e2e.rs
@@ -29,16 +29,25 @@ async fn imap_e2e_greeting_and_capability() {
     assert!(c.transcript().contains("IMAP4rev1 ready"));
 
     let r = c.command("c001 CAPABILITY").await;
-    for cap in [
-        "IMAP4rev1",
-        "IDLE",
-        "QUOTA",
-        "MOVE",
-        "AUTH=PLAIN",
-        "XCHATMAIL",
-    ] {
+    for cap in ["IMAP4rev1", "IDLE", "QUOTA", "MOVE", "AUTH=PLAIN"] {
         assert!(r.contains(cap), "missing capability {cap}: {r}");
     }
+    // Pre-auth CAPABILITY must not advertise chatmail-specific tokens (#120).
+    assert!(
+        !r.contains("XCHATMAIL"),
+        "pre-auth must not advertise XCHATMAIL: {r}"
+    );
+    assert!(
+        !r.contains("XDELTAPUSH"),
+        "pre-auth must not advertise XDELTAPUSH: {r}"
+    );
+
+    c.command(&format!("c002 LOGIN {USER} {PASS}")).await;
+    let post = c.command("c003 CAPABILITY").await;
+    assert!(
+        post.contains("XCHATMAIL"),
+        "post-auth must advertise XCHATMAIL: {post}"
+    );
 }
 
 #[tokio::test]
@@ -468,12 +477,22 @@ async fn imap_e2e_delta_chat_sync_session() {
 
     let mut c = ImapClient::connect(srv.imap_addr).await;
     let caps = c.command("dc01 CAPABILITY").await;
-    assert!(caps.contains("IDLE") && caps.contains("XCHATMAIL"));
+    assert!(caps.contains("IDLE"));
+    assert!(
+        !caps.contains("XCHATMAIL"),
+        "pre-auth CAPABILITY must not fingerprint: {caps}"
+    );
 
     assert!(c
         .command(&format!("dc02 LOGIN {USER} {PASS}"))
         .await
         .contains("OK LOGIN"));
+
+    let post = c.command("dc02b CAPABILITY").await;
+    assert!(
+        post.contains("XCHATMAIL"),
+        "post-auth CAPABILITY must keep chatmail tokens: {post}"
+    );
 
     assert!(c.command("dc03 LIST \"\" \"*\"").await.contains("INBOX"));
 
@@ -505,11 +524,16 @@ async fn imap_e2e_push_devicetoken_setmetadata() {
     create_user(&srv.ctx, &srv.pool, USER, PASS).await;
 
     let mut c = ImapClient::connect(srv.imap_addr).await;
-    let caps = c.command("p001 CAPABILITY").await;
-    assert!(caps.contains("XDELTAPUSH"), "push cap: {caps}");
-    assert!(caps.contains("METADATA"), "metadata cap: {caps}");
+    let pre = c.command("p001 CAPABILITY").await;
+    assert!(
+        !pre.contains("XDELTAPUSH") && !pre.contains("METADATA"),
+        "push/metadata caps must not leak pre-auth: {pre}"
+    );
 
     c.command(&format!("p002 LOGIN {USER} {PASS}")).await;
+    let caps = c.command("p002b CAPABILITY").await;
+    assert!(caps.contains("XDELTAPUSH"), "push cap: {caps}");
+    assert!(caps.contains("METADATA"), "metadata cap: {caps}");
     let set = c
         .command(r#"p003 SETMETADATA INBOX (/private/devicetoken "openpgp:relay-ping-token" )"#)
         .await;

--- a/tests/turn_e2e.rs
+++ b/tests/turn_e2e.rs
@@ -36,8 +36,19 @@ async fn turn_imap_e2e_capability_metadata() {
     create_user(&srv.ctx, &srv.pool, USER, PASS).await;
 
     let mut c = ImapClient::connect(srv.imap_addr).await;
-    let r = c.command("c001 CAPABILITY").await;
-    assert!(r.contains("METADATA"), "CAPABILITY: {r}");
+    // Pre-auth CAPABILITY must not fingerprint chatmail (#120).
+    let pre = c.command("c001 CAPABILITY").await;
+    assert!(
+        !pre.contains("METADATA") && !pre.contains("XCHATMAIL"),
+        "pre-auth CAPABILITY must not advertise METADATA/XCHATMAIL: {pre}"
+    );
+
+    c.command(&format!("c002 LOGIN {USER} {PASS}")).await;
+    let post = c.command("c003 CAPABILITY").await;
+    assert!(
+        post.contains("METADATA"),
+        "post-auth CAPABILITY must advertise METADATA when TURN is enabled: {post}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Reduce active probing fingerprint of Madmail before login.

- **IMAP:** Pre-auth `CAPABILITY` advertises only generic tokens (`IMAP4rev1`, `IDLE`, `QUOTA`, `MOVE`, `UIDPLUS`, `AUTH=PLAIN`, `LITERAL+`, optional `STARTTLS`). Chatmail-specific tokens (`XCHATMAIL`, `XDELTAPUSH`, `METADATA`) are advertised **post-auth only**.
- **SMTP:** Banner is `220 {hostname} ESMTP` (no `madmail-v2` product string).
- **IMAP LOGOUT:** `* BYE Logging out` (no product token).
- Delta Chat does not need chatmail caps before login; post-auth behavior is unchanged.
- TDD and project docs updated for the pre/post-auth split.

Fixes #120

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Build / CI / tooling
- [ ] Refactor (no functional change)

Breaking only for tools that fingerprint via unauthenticated IMAP CAPABILITY or the SMTP/IMAP product strings. Delta Chat and other clients that discover extensions after login are unaffected.

## Area

- [x] SMTP
- [x] IMAP
- [ ] Federation / delivery queue
- [ ] Authentication / JIT
- [ ] Admin API / admin web UI (`external/madmail-admin-web`)
- [x] TURN / Iroh / proxy services
- [ ] Storage / quota / DB migrations
- [ ] Configuration / CLI
- [x] Docs (`docs/project/`, `docs/TDD/`, user guide)
- [ ] Other:

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (or targeted crate/tests: full workspace with `--no-fail-fast`; only unrelated pre-existing `chatmail-storage` mtime cache flake)
- [x] Manual / E2E verification (describe below)

**Manual verification (if any):**

```text
Local high-port release instance:
  SMTP 220 {host} ESMTP (no product token)
  IMAP pre-auth CAPABILITY: no XCHATMAIL/XDELTAPUSH/METADATA
  IMAP BYE: Logging out
  IMAPS post-auth CAPABILITY: XCHATMAIL + METADATA present after LOGIN

Private test host (production left on old binary; side-by-side high-port build):
  New binary: same generic pre-auth + post-auth chatmail tokens
  Production baseline still shows old fingerprint until upgraded
```

## Documentation

- [ ] No doc updates needed
- [ ] Updated operator/user docs (`docs/project/user-guide/`, install guides)
- [x] Updated developer docs (`docs/project/`)
- [x] Updated or added TDD section (`docs/TDD/`) — required for significant design changes

## Security & privacy

- [ ] Not security-sensitive
- [x] Security-sensitive — added/updated tests for the security property
- [x] Reviewed error messages for information leakage

## Commits

- `feat:` new feature
- `fix:` bug fix
- `docs:` documentation
- `refactor:` code change without feature/fix
- `test:` tests only
- `chore:` tooling, deps, release

## Checklist

- [x] PR is focused and reviewable (small vertical slices preferred)
- [x] No secrets, `data/`, `target/`, or `node_modules/` committed
- [ ] Submodule pointers updated if `external/madmail-admin-web` changed
- [x] Behavior parity with Madmail v1 considered (or intentional difference documented)