### PR TITLE
fix(storage): generation-guard maildir list cache (#115)

### DIFF
--- a/crates/chatmail-delivery/src/router.rs
+++ b/crates/chatmail-delivery/src/router.rs
@@ -181,6 +181,25 @@ impl DeliveryContext {
                     failed = outcome.failed.len(),
                     "partial local fan-out: some recipients did not receive the message"
                 );
+                // Do not report SMTP/WebSMTP success when any local recipient missed the
+                // message (#115). The client can retry; delivered recipients keep their copy.
+                info!(
+                    total_rcpts,
+                    local_n,
+                    remote_enqueued,
+                    delivered = outcome.delivered.len(),
+                    failed = outcome.failed.len(),
+                    rcpt_phase_ms = rcpt_phase.as_millis(),
+                    deliver_ms = deliver_ms.as_millis(),
+                    notify_ms = notify_start.elapsed().as_millis(),
+                    ingest_ms = ingest_start.elapsed().as_millis(),
+                    "authenticated submission fan-out timing"
+                );
+                return Err(ChatmailError::storage(format!(
+                    "local delivery failed for {} of {} recipient(s)",
+                    outcome.failed.len(),
+                    local_n
+                )));
             }
             info!(
                 total_rcpts,
@@ -291,6 +310,12 @@ impl DeliveryContext {
                     failed = outcome.failed.len(),
                     "partial local fan-out: some recipients did not receive the message"
                 );
+                // Match authenticated path: never accept after a partial local miss (#115).
+                return Err(ChatmailError::storage(format!(
+                    "local delivery failed for {} of {} recipient(s)",
+                    outcome.failed.len(),
+                    outcome.delivered.len() + outcome.failed.len()
+                )));
             }
         }
         chatmail_db::record_inbound_delivery();

--- a/crates/chatmail-fed/src/mxdeliv.rs
+++ b/crates/chatmail-fed/src/mxdeliv.rs
@@ -170,6 +170,14 @@ async fn handle_mxdeliv(
     for (rcpt, _msg_id, err) in &outcome.failed {
         tracing::warn!(rcpt = %rcpt, error = %err, "mxdeliv: local delivery failed for recipient");
     }
+    if !outcome.failed.is_empty() {
+        // Same contract as SMTP AUTH: do not 200-OK when some locals missed the body (#115).
+        return Err(ChatmailError::storage(format!(
+            "mxdeliv: local delivery failed for {} of {} recipient(s)",
+            outcome.failed.len(),
+            outcome.delivered.len() + outcome.failed.len()
+        )));
+    }
 
     chatmail_db::record_inbound_delivery();
     Ok(())

--- a/crates/chatmail-smtp/src/session.rs
+++ b/crates/chatmail-smtp/src/session.rs
@@ -696,6 +696,23 @@ impl SmtpSession {
                     failed = outcome.failed.len(),
                     "partial local fan-out: some recipients did not receive the message"
                 );
+                tracing::info!(
+                    total_rcpts,
+                    local_n,
+                    delivered = outcome.delivered.len(),
+                    failed = outcome.failed.len(),
+                    rcpt_phase_ms = rcpt_phase.as_millis(),
+                    deliver_ms = deliver_ms.as_millis(),
+                    notify_ms = notify_start.elapsed().as_millis(),
+                    ingest_ms = ingest_start.elapsed().as_millis(),
+                    "SMTP local fan-out timing"
+                );
+                // Inbound DATA must not 250 when some local recipients missed the body (#115).
+                return Err(ChatmailError::storage(format!(
+                    "local delivery failed for {} of {} recipient(s)",
+                    outcome.failed.len(),
+                    local_n
+                )));
             }
             tracing::info!(
                 total_rcpts,

--- a/crates/chatmail-storage/src/blob.rs
+++ b/crates/chatmail-storage/src/blob.rs
@@ -151,6 +151,28 @@ pub(crate) async fn link_into_inbox(
             tokio::fs::copy(canonical, &dest).await?;
             store.fsync().commit_directory(&new_dir).await?;
             store.invalidate_mailbox_listing(user, "INBOX");
+            // Match the hard_link success path: eager uidlist registration so IMAP does not
+            // depend solely on the next readdir to discover the copy (#115 visibility).
+            let internal_secs = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            let size = tokio::fs::metadata(&dest)
+                .await
+                .map(|m| m.len())
+                .unwrap_or(0);
+            let _ = store
+                .uidlist()
+                .pre_register(
+                    user,
+                    "INBOX",
+                    &store.maildir_for_mailbox(user, "INBOX"),
+                    msg_id,
+                    size,
+                    internal_secs,
+                    store.policy().fsync_mode,
+                )
+                .await;
             Ok(dest)
         }
         Err(e) => Err(ChatmailError::from(e)),
@@ -318,6 +340,22 @@ async fn commit_mailbox_blob(
     tokio::fs::rename(&tmp_path, &new_path).await?;
     store.fsync().commit_directory(&paths.new).await?;
     store.invalidate_mailbox_listing(user, mailbox);
+    let internal_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let _ = store
+        .uidlist()
+        .pre_register(
+            user,
+            mailbox,
+            &paths,
+            msg_id,
+            body.len() as u64,
+            internal_secs,
+            store.policy().fsync_mode,
+        )
+        .await;
     Ok(new_path)
 }
 
@@ -358,19 +396,21 @@ async fn finalize_from_tmp(
                 tokio::fs::rename(&tmp.path, &dest).await?;
             }
 
-            // Under Never (the benchmark path), submit the final "make visible"
-            // work to the per-mailbox batcher. This is the key "Dovecot LMTP" trick:
-            // instead of 15 independent tasks all doing uidlist + dir metadata at once,
-            // we funnel them so the work happens in fewer, batched steps.
+            // Under Never (the benchmark path), submit uidlist/dir work to the per-mailbox
+            // batcher so concurrent APPENDs do not all hammer metadata at once. The file is
+            // already in `new/` — we must still invalidate the listing cache immediately so
+            // IMAP cannot keep serving a same-second-mtime stale listing (#115).
+            let internal_secs = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
             if store.policy().fsync_mode == FsyncMode::Never {
+                store.invalidate_mailbox_listing(user, mailbox);
                 let pending = PendingDelivery {
                     msg_id: msg_id.to_string(),
                     final_path: dest.clone(),
                     size: tmp.size,
-                    internal_secs: std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .map(|d| d.as_secs())
-                        .unwrap_or(0),
+                    internal_secs,
                 };
                 never_batcher()
                     .submit_for_never(user, mailbox, pending)
@@ -379,10 +419,6 @@ async fn finalize_from_tmp(
                 store.fsync().commit_directory(&paths.new).await?;
                 store.invalidate_mailbox_listing(user, mailbox);
 
-                let internal_secs = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .map(|d| d.as_secs())
-                    .unwrap_or(0);
                 let _ = store
                     .uidlist()
                     .pre_register(

--- a/crates/chatmail-storage/src/maildir_cache.rs
+++ b/crates/chatmail-storage/src/maildir_cache.rs
@@ -15,9 +15,23 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-//! Maildir listing cache keyed on directory mtimes (Dovecot `DIR_MTIME_CHANGED` fast path).
+//! Maildir listing cache keyed on directory mtimes (Dovecot `DIR_MTIME_CHANGED` fast path)
+//! plus a per-mailbox generation counter so concurrent delivery cannot re-poison the cache.
+//!
+//! ## Why a generation?
+//!
+//! Directory mtime alone is not enough:
+//! 1. Some filesystems only update mtime at 1-second resolution — two deliveries in the same
+//!    second can leave the cached listing missing the newer message while mtime still "matches".
+//! 2. A concurrent `list_mailbox_messages` that started before a delivery can finish its
+//!    `uidlist::sync` *after* `invalidate`, then `store` an incomplete listing under the new
+//!    mtime. Subsequent hits serve that incomplete set until the next invalidate (#115).
+//!
+//! Every invalidate bumps the generation. `store` only inserts when the caller's generation
+//! still matches, so a listing that raced with delivery never becomes the cached view.
 
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::SystemTime;
 
 use dashmap::DashMap;
@@ -42,21 +56,41 @@ impl DirMtime {
 
 #[derive(Debug, Clone)]
 struct CachedListing {
+    /// Generation observed when this entry was written; must match current gen on hit.
+    generation: u64,
     new_mtime: Option<DirMtime>,
     cur_mtime: Option<DirMtime>,
     messages: Vec<StoredMessage>,
 }
 
-/// Per-mailbox listing cache invalidated when `new/` or `cur/` mtimes change.
+/// Per-mailbox listing cache invalidated when `new/` or `cur/` change (or on explicit bump).
 #[derive(Debug, Default)]
 pub struct MaildirListCache {
     entries: DashMap<(String, String), CachedListing>,
+    /// Monotonic per-mailbox epoch; bumped on every [`Self::invalidate`].
+    generations: DashMap<(String, String), AtomicU64>,
 }
 
 impl MaildirListCache {
+    fn key(user: &str, mailbox: &str) -> (String, String) {
+        (user.to_string(), mailbox.to_string())
+    }
+
+    /// Current generation for `(user, mailbox)` (0 if never invalidated).
+    pub fn generation(&self, user: &str, mailbox: &str) -> u64 {
+        self.generations
+            .get(&Self::key(user, mailbox))
+            .map(|g| g.load(Ordering::Acquire))
+            .unwrap_or(0)
+    }
+
     pub fn invalidate(&self, user: &str, mailbox: &str) {
-        self.entries
-            .remove(&(user.to_string(), mailbox.to_string()));
+        let key = Self::key(user, mailbox);
+        self.generations
+            .entry(key.clone())
+            .or_insert_with(|| AtomicU64::new(0))
+            .fetch_add(1, Ordering::AcqRel);
+        self.entries.remove(&key);
     }
 
     pub(crate) async fn dir_mtime(path: &Path) -> Option<DirMtime> {
@@ -80,26 +114,38 @@ impl MaildirListCache {
         // Read mtimes before locking the shard: never hold a DashMap guard across `.await`.
         let new_mtime = Self::dir_mtime(new_dir).await;
         let cur_mtime = Self::dir_mtime(cur_dir).await;
-        let key = (user.to_string(), mailbox.to_string());
+        let gen = self.generation(user, mailbox);
+        let key = Self::key(user, mailbox);
         let cached = self.entries.get(&key)?;
-        if cached.new_mtime == new_mtime && cached.cur_mtime == cur_mtime {
+        if cached.generation == gen
+            && cached.new_mtime == new_mtime
+            && cached.cur_mtime == cur_mtime
+        {
             Some(cached.messages.clone())
         } else {
             None
         }
     }
 
+    /// Cache `messages` only if `expected_generation` is still the live generation for this
+    /// mailbox. Callers snapshot the generation *before* a slow `uidlist::sync` so a concurrent
+    /// delivery's invalidate discards the incomplete listing.
     pub(crate) fn store(
         &self,
         user: &str,
         mailbox: &str,
+        expected_generation: u64,
         new_mtime: Option<DirMtime>,
         cur_mtime: Option<DirMtime>,
         messages: Vec<StoredMessage>,
     ) {
+        if self.generation(user, mailbox) != expected_generation {
+            return;
+        }
         self.entries.insert(
-            (user.to_string(), mailbox.to_string()),
+            Self::key(user, mailbox),
             CachedListing {
+                generation: expected_generation,
                 new_mtime,
                 cur_mtime,
                 messages,
@@ -135,10 +181,11 @@ mod tests {
         tokio::fs::create_dir_all(&cur_dir).await.unwrap();
 
         let cache = MaildirListCache::default();
+        let gen = cache.generation("u@test", "INBOX");
         let new_mtime = MaildirListCache::dir_mtime(&new_dir).await;
         let cur_mtime = MaildirListCache::dir_mtime(&cur_dir).await;
         let msgs = vec![sample_msg("a")];
-        cache.store("u@test", "INBOX", new_mtime, cur_mtime, msgs.clone());
+        cache.store("u@test", "INBOX", gen, new_mtime, cur_mtime, msgs.clone());
 
         let hit = cache
             .get_if_fresh("u@test", "INBOX", &new_dir, &cur_dir)
@@ -158,18 +205,101 @@ mod tests {
         tokio::fs::create_dir_all(&cur_dir).await.unwrap();
 
         let cache = MaildirListCache::default();
+        let gen = cache.generation("u@test", "INBOX");
         let new_mtime = MaildirListCache::dir_mtime(&new_dir).await;
         let cur_mtime = MaildirListCache::dir_mtime(&cur_dir).await;
         cache.store(
             "u@test",
             "INBOX",
+            gen,
             new_mtime,
             cur_mtime,
             vec![sample_msg("old")],
         );
 
         tokio::fs::write(new_dir.join("msg"), b"x").await.unwrap();
+        // Some filesystems keep the same second-granularity mtime; invalidate is the
+        // production signal. Mimic a delivery that also bumps generation.
+        cache.invalidate("u@test", "INBOX");
 
+        assert!(cache
+            .get_if_fresh("u@test", "INBOX", &new_dir, &cur_dir)
+            .await
+            .is_none());
+    }
+
+    /// Issue #115: a listing that races with delivery must not re-poison the cache after
+    /// invalidate (stale incomplete listing under a matching mtime).
+    #[tokio::test]
+    async fn store_after_invalidate_is_discarded() {
+        let tmp = tempfile::tempdir().unwrap();
+        let new_dir = tmp.path().join("new");
+        let cur_dir = tmp.path().join("cur");
+        tokio::fs::create_dir_all(&new_dir).await.unwrap();
+        tokio::fs::create_dir_all(&cur_dir).await.unwrap();
+
+        let cache = MaildirListCache::default();
+        let gen_before = cache.generation("u@test", "INBOX");
+        let m = MaildirListCache::dir_mtime(&new_dir).await;
+
+        // Delivery lands and invalidates while a concurrent list still holds gen_before.
+        cache.invalidate("u@test", "INBOX");
+        assert_ne!(cache.generation("u@test", "INBOX"), gen_before);
+
+        // Incomplete listing tries to publish under the old generation — must be ignored.
+        cache.store(
+            "u@test",
+            "INBOX",
+            gen_before,
+            m,
+            m,
+            vec![sample_msg("stale-only")],
+        );
+        assert!(
+            cache
+                .entries
+                .get(&("u@test".into(), "INBOX".into()))
+                .is_none(),
+            "store with stale generation must not insert"
+        );
+
+        // A correct post-delivery listing uses the new generation.
+        let gen_after = cache.generation("u@test", "INBOX");
+        cache.store(
+            "u@test",
+            "INBOX",
+            gen_after,
+            m,
+            m,
+            vec![sample_msg("fresh")],
+        );
+        let hit = cache
+            .get_if_fresh("u@test", "INBOX", &new_dir, &cur_dir)
+            .await
+            .expect("fresh listing should hit");
+        assert_eq!(hit.len(), 1);
+        assert_eq!(hit[0].base_id, "fresh");
+    }
+
+    /// Same-second mtime: invalidate alone must force a miss even when dir mtime is unchanged.
+    #[tokio::test]
+    async fn invalidate_misses_even_when_mtime_unchanged() {
+        let tmp = tempfile::tempdir().unwrap();
+        let new_dir = tmp.path().join("new");
+        let cur_dir = tmp.path().join("cur");
+        tokio::fs::create_dir_all(&new_dir).await.unwrap();
+        tokio::fs::create_dir_all(&cur_dir).await.unwrap();
+
+        let cache = MaildirListCache::default();
+        let gen = cache.generation("u@test", "INBOX");
+        let m = MaildirListCache::dir_mtime(&new_dir).await;
+        cache.store("u@test", "INBOX", gen, m, m, vec![sample_msg("a")]);
+        assert!(cache
+            .get_if_fresh("u@test", "INBOX", &new_dir, &cur_dir)
+            .await
+            .is_some());
+
+        cache.invalidate("u@test", "INBOX");
         assert!(cache
             .get_if_fresh("u@test", "INBOX", &new_dir, &cur_dir)
             .await
@@ -196,10 +326,9 @@ mod tests {
 
                 let cache = std::sync::Arc::new(MaildirListCache::default());
                 let m = MaildirListCache::dir_mtime(&new_dir).await;
-                cache.store("u@test", "INBOX", m, m, vec![sample_msg("a")]);
+                let gen = cache.generation("u@test", "INBOX");
+                cache.store("u@test", "INBOX", gen, m, m, vec![sample_msg("a")]);
 
-                // Reader suspends inside get_if_fresh (at the mtime .await); the single worker then
-                // runs the writer, whose store() takes the same shard's write lock.
                 let reader = {
                     let cache = cache.clone();
                     let new_dir = new_dir.clone();
@@ -214,7 +343,8 @@ mod tests {
                     let cache = cache.clone();
                     tokio::spawn(async move {
                         for i in 0..50 {
-                            cache.store("u@test", "INBOX", None, None, vec![sample_msg("b")]);
+                            let g = cache.generation("u@test", "INBOX");
+                            cache.store("u@test", "INBOX", g, None, None, vec![sample_msg("b")]);
                             cache.invalidate("u@test", "INBOX");
                             if i % 7 == 0 {
                                 tokio::task::yield_now().await;
@@ -227,8 +357,6 @@ mod tests {
             });
         });
 
-        // Watchdog: a runtime-internal timeout can't fire once the worker deadlocks in futex, so
-        // poll thread completion from outside the runtime.
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
         while !worker.is_finished() {
             if std::time::Instant::now() > deadline {
@@ -243,7 +371,8 @@ mod tests {
     #[tokio::test]
     async fn p11_ut06_invalidate_clears_entry() {
         let cache = MaildirListCache::default();
-        cache.store("u@test", "INBOX", None, None, vec![sample_msg("x")]);
+        let gen = cache.generation("u@test", "INBOX");
+        cache.store("u@test", "INBOX", gen, None, None, vec![sample_msg("x")]);
         cache.invalidate("u@test", "INBOX");
         assert!(cache
             .entries

--- a/crates/chatmail-storage/src/maildir_message.rs
+++ b/crates/chatmail-storage/src/maildir_message.rs
@@ -111,12 +111,37 @@ pub async fn list_mailbox_messages(
         return Ok(cached);
     }
 
+    // Snapshot generation before the slow sync so a concurrent delivery's invalidate
+    // discards any incomplete listing we might try to publish (#115).
+    let gen = store.list_cache().generation(user, mailbox);
     let new_mtime = crate::maildir_cache::MaildirListCache::dir_mtime(&paths.new).await;
     let cur_mtime = crate::maildir_cache::MaildirListCache::dir_mtime(&paths.cur).await;
-    let messages = store.uidlist().sync(user, mailbox, &paths).await?;
+    let mut messages = store.uidlist().sync(user, mailbox, &paths).await?;
+
+    // If the directory changed while we were scanning (or generation advanced), re-sync once
+    // so we do not return a half-complete view to IMAP IDLE / FETCH.
+    let new_mtime_after = crate::maildir_cache::MaildirListCache::dir_mtime(&paths.new).await;
+    let cur_mtime_after = crate::maildir_cache::MaildirListCache::dir_mtime(&paths.cur).await;
+    let gen_after = store.list_cache().generation(user, mailbox);
+    if gen_after != gen || new_mtime_after != new_mtime || cur_mtime_after != cur_mtime {
+        messages = store.uidlist().sync(user, mailbox, &paths).await?;
+        let gen_final = store.list_cache().generation(user, mailbox);
+        let new_final = crate::maildir_cache::MaildirListCache::dir_mtime(&paths.new).await;
+        let cur_final = crate::maildir_cache::MaildirListCache::dir_mtime(&paths.cur).await;
+        store.list_cache().store(
+            user,
+            mailbox,
+            gen_final,
+            new_final,
+            cur_final,
+            messages.clone(),
+        );
+        return Ok(messages);
+    }
+
     store
         .list_cache()
-        .store(user, mailbox, new_mtime, cur_mtime, messages.clone());
+        .store(user, mailbox, gen, new_mtime, cur_mtime, messages.clone());
     Ok(messages)
 }
 
@@ -343,5 +368,54 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(after.len(), 2);
+    }
+
+    /// Issue #115: concurrent delivery while listing must not leave IMAP serving a permanently
+    /// incomplete cached listing (generation-guarded store + invalidate on write).
+    #[tokio::test]
+    async fn issue115_concurrent_deliver_and_list_never_loses_message() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = std::sync::Arc::new(MailboxStore::new(tmp.path()));
+
+        // Seed one message so the cache is warm.
+        write_blob(&store, "u@test", "seed", b"seed").await.unwrap();
+        assert_eq!(
+            list_mailbox_messages(&store, "u@test", "INBOX")
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+
+        let store_w = store.clone();
+        let writer = tokio::spawn(async move {
+            for i in 0..20 {
+                write_blob(&store_w, "u@test", &format!("m{i}"), b"body")
+                    .await
+                    .unwrap();
+            }
+        });
+        let store_r = store.clone();
+        let reader = tokio::spawn(async move {
+            for _ in 0..40 {
+                let _ = list_mailbox_messages(&store_r, "u@test", "INBOX").await;
+                tokio::task::yield_now().await;
+            }
+        });
+        writer.await.unwrap();
+        reader.await.unwrap();
+
+        let final_list = list_mailbox_messages(&store, "u@test", "INBOX")
+            .await
+            .unwrap();
+        assert_eq!(
+            final_list.len(),
+            21,
+            "all delivered messages must be visible after concurrent list; got {:?}",
+            final_list
+                .iter()
+                .map(|m| m.base_id.as_str())
+                .collect::<Vec<_>>()
+        );
     }
 }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -65,3 +65,7 @@ path = "ctl_ops_e2e.rs"
 [[test]]
 name = "openmetrics_e2e"
 path = "openmetrics_e2e.rs"
+
+[[test]]
+name = "issue115_list_cache_e2e"
+path = "issue115_list_cache_e2e.rs"

--- a/tests/issue115_list_cache_e2e.rs
+++ b/tests/issue115_list_cache_e2e.rs
@@ -1,0 +1,120 @@
+//! Issue #115: concurrent local delivery + IMAP listing must not lose messages.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use chatmail_storage::list_mailbox_messages;
+
+mod support;
+use support::{create_user, deliver_message, spawn_mail_servers, ImapClient, PGP_MIME_BODY};
+
+const BOB: &str = "bobsmith@test";
+const PASS: &str = "longpassword1";
+
+#[tokio::test]
+async fn issue115_concurrent_deliver_and_list_sees_all() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let srv = spawn_mail_servers(dir.path()).await;
+    create_user(&srv.ctx, &srv.pool, "alice123@test", PASS).await;
+    create_user(&srv.ctx, &srv.pool, BOB, PASS).await;
+
+    let n = 40usize;
+    let ctx = Arc::clone(&srv.ctx);
+
+    let writer = {
+        let ctx = Arc::clone(&ctx);
+        tokio::spawn(async move {
+            for i in 0..n {
+                deliver_message(&ctx, BOB, &format!("m{i}"), PGP_MIME_BODY).await;
+                if i % 3 == 0 {
+                    tokio::task::yield_now().await;
+                }
+            }
+        })
+    };
+
+    let readers: Vec<_> = (0..6)
+        .map(|_| {
+            let ctx = Arc::clone(&ctx);
+            tokio::spawn(async move {
+                for _ in 0..80 {
+                    let _ = list_mailbox_messages(&ctx.mailbox_store, BOB, "INBOX").await;
+                    tokio::task::yield_now().await;
+                }
+            })
+        })
+        .collect();
+
+    writer.await.expect("writer");
+    for r in readers {
+        r.await.expect("reader");
+    }
+
+    let listed = list_mailbox_messages(&srv.ctx.mailbox_store, BOB, "INBOX")
+        .await
+        .expect("list");
+    assert_eq!(
+        listed.len(),
+        n,
+        "all delivered messages must be listed; got {:?}",
+        listed.iter().map(|m| m.base_id.as_str()).collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+async fn issue115_imap_search_sees_all_after_concurrent_deliver() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let srv = spawn_mail_servers(dir.path()).await;
+    create_user(&srv.ctx, &srv.pool, "alice123@test", PASS).await;
+    create_user(&srv.ctx, &srv.pool, BOB, PASS).await;
+
+    let n = 25usize;
+    let ctx = Arc::clone(&srv.ctx);
+    let writer = {
+        let ctx = Arc::clone(&ctx);
+        tokio::spawn(async move {
+            for i in 0..n {
+                deliver_message(&ctx, BOB, &format!("imap-{i}"), PGP_MIME_BODY).await;
+            }
+        })
+    };
+    let reader = {
+        let addr = srv.imap_addr;
+        tokio::spawn(async move {
+            for _ in 0..30 {
+                let mut c = ImapClient::connect(addr).await;
+                let _ = c
+                    .command(&format!("a LOGIN {BOB} {PASS}"))
+                    .await;
+                let _ = c.command("a SELECT INBOX").await;
+                let _ = c.command("a SEARCH ALL").await;
+                let _ = c.command("a LOGOUT").await;
+                tokio::time::sleep(Duration::from_millis(2)).await;
+            }
+        })
+    };
+    writer.await.expect("writer");
+    let _ = reader.await;
+
+    let mut client = ImapClient::connect(srv.imap_addr).await;
+    let login = client.command(&format!("a LOGIN {BOB} {PASS}")).await;
+    assert!(login.contains("OK"), "login: {login}");
+    let select = client.command("a SELECT INBOX").await;
+    assert!(select.contains("OK"), "select: {select}");
+    // * N EXISTS
+    let exists = select
+        .lines()
+        .find_map(|l| {
+            let parts: Vec<_> = l.split_whitespace().collect();
+            if parts.len() == 3 && parts[0] == "*" && parts[2] == "EXISTS" {
+                parts[1].parse::<usize>().ok()
+            } else {
+                None
+            }
+        })
+        .unwrap_or(0);
+    assert_eq!(
+        exists, n,
+        "IMAP SELECT EXISTS must match delivered count; response:\n{select}"
+    );
+}

--- a/tests/issue115_list_cache_e2e.rs
+++ b/tests/issue115_list_cache_e2e.rs
@@ -57,7 +57,10 @@ async fn issue115_concurrent_deliver_and_list_sees_all() {
         listed.len(),
         n,
         "all delivered messages must be listed; got {:?}",
-        listed.iter().map(|m| m.base_id.as_str()).collect::<Vec<_>>()
+        listed
+            .iter()
+            .map(|m| m.base_id.as_str())
+            .collect::<Vec<_>>()
     );
 }
 
@@ -83,9 +86,7 @@ async fn issue115_imap_search_sees_all_after_concurrent_deliver() {
         tokio::spawn(async move {
             for _ in 0..30 {
                 let mut c = ImapClient::connect(addr).await;
-                let _ = c
-                    .command(&format!("a LOGIN {BOB} {PASS}"))
-                    .await;
+                let _ = c.command(&format!("a LOGIN {BOB} {PASS}")).await;
                 let _ = c.command("a SELECT INBOX").await;
                 let _ = c.command("a SEARCH ALL").await;
                 let _ = c.command("a LOGOUT").await;


### PR DESCRIPTION
## Summary

Fixes intermittent same-server “sent but missing” mail ([#115](https://github.com/themadorg/madmail/issues/115)): sender sees success while concurrent IMAP listing can miss messages that are already on disk.

**Root cause:** The maildir listing cache was keyed only on directory mtimes. A concurrent `list_mailbox_messages` that started before (or during) delivery could finish its slow `uidlist::sync` *after* `invalidate`, then `store` an incomplete listing. With same-second mtime resolution (or `mail_fsync=never` paths that did not invalidate promptly), that incomplete view could stick until the next invalidate.

**Fix:**
- Per-mailbox **generation counter**: every `invalidate` bumps gen; `store` only accepts if the caller’s snapshot gen still matches (discards racing incomplete re-stores).
- After scan, **re-sync once** if mtime or generation advanced mid-list so IMAP does not return a half-complete view.
- Always **invalidate** the listing cache on `mail_fsync=never` first-write visibility; **pre_register** on cross-device copy and non-CAS commit paths for parity with hardlink delivery.
- **Do not 250 / 200-OK** on partial local fan-out (SMTP AUTH, inbound SMTP, mxdeliv) so clients can retry when any local recipient missed the body.

Fixes #115

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Build / CI / tooling
- [ ] Refactor (no functional change)

## Area

- [x] SMTP
- [x] IMAP
- [x] Federation / delivery queue
- [ ] Authentication / JIT
- [ ] Admin API / admin web UI (`external/madmail-admin-web`)
- [ ] TURN / Iroh / proxy services
- [x] Storage / quota / DB migrations
- [ ] Configuration / CLI
- [ ] Docs (`docs/project/`, `docs/TDD/`, user guide)
- [ ] Other:

## Testing

- [x] `cargo fmt --all -- --check` *(sources cleaned in prior edit cycles)*
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — **912 passed, 0 failed, 3 ignored**
- [x] Manual / E2E verification (describe below)

**Automated / unit / e2e:**
- Full workspace suite on this branch: **912 pass / 0 fail**.
- New integration test `tests/issue115_list_cache_e2e.rs` (concurrent deliver + list; IMAP EXISTS after concurrent deliver).
- Storage cache unit tests for generation discard (`store_after_invalidate_is_discarded`, mtime-unchanged invalidate miss, existing P11 list-cache tests).
- Multiple targeted e2e/storage runs during development (issue115 concurrent list, maildir_cache suite, delivery/router paths).

**Manual verification:**

```text
# Against unfixed v2.20.0 (local high-port instance, mail_fsync=never):
# - Deterministic list-cache poison: late incomplete re-store after invalidate
#   sticks → IMAP would serve incomplete listing.
# - Concurrent write_blob + list_mailbox_messages: sticky shortfall observed
#   (e.g. disk=201 listed=200; disk=237 listed=236).
# - Live SMTP submission + concurrent IMAP SELECT: 7500 messages sent;
#   3387 mid-flight samples of disk > IMAP EXISTS under concurrent readers
#   (race visible as “on disk but not listed yet”); after freeze EXISTS
#   recovered in that run (sticky end-to-end is intermittent).

# Against this fix branch:
# - Same concurrent list race ends with disk == listed (no final sticky lag).
# - Generation-guarded store discards incomplete re-store after invalidate.
# - cargo test --workspace: 912 passed, 0 failed.
```

## Documentation

- [x] No doc updates needed
- [ ] Updated operator/user docs (`docs/project/user-guide/`, install guides)
- [ ] Updated developer docs (`docs/project/`)
- [ ] Updated or added TDD section (`docs/TDD/`) — required for significant design changes

## Security & privacy

- [x] Not security-sensitive
- [ ] Security-sensitive — added/updated tests for the security property
- [ ] Reviewed error messages for information leakage

## Commits

- `fix:` bug fix (conventional commit for semantic-release)

## Checklist

- [x] PR is focused and reviewable (small vertical slices preferred)
- [x] No secrets, `data/`, `target/`, or `node_modules/` committed
- [ ] Submodule pointers updated if `external/madmail-admin-web` changed
- [x] Behavior parity with Madmail v1 considered (or intentional difference documented)