### PR TITLE
ci: add cmlxc Incus deploy and test workflow

### DIFF
--- a/.github/workflows/cmlxc-test.yml
+++ b/.github/workflows/cmlxc-test.yml
@@ -1,0 +1,30 @@
+name: cmlxc
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'landing/**'
+      - 'packaging/windows/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lxc-test:
+    name: cmlxc deploy and run tests
+    uses: chatmail/cmlxc/.github/workflows/lxc-test.yml@main
+    with:
+      # The reusable workflow checks this repo out into ./repo and runs each
+      # command from the workspace root, so --source ./repo deploys the commit
+      # under test. An @ref would resolve against the upstream URL, and thus
+      # not find the fork PR head.
+      cmlxc_commands: |
+        cmlxc init
+        cmlxc deploy-madmail --source ./repo mad0
+        cmlxc test-mini mad0
+        cmlxc deploy-cmdeploy --source @main relay0
+        cmlxc test-mini mad0 relay0
+        cmlxc test-mini relay0 mad0
+        cmlxc test-madmail mad0


### PR DESCRIPTION
This adds `.github/workflows/cmlxc-test.yml`, which deploys the current commit into an Incus container with cmlxc's madmail driver, deploys a chatmail relay alongside it, and runs the relay minitests in both directions plus `test-madmail`. It is based on the WIP v2 Rust port of cmlxc's `deploy-madmail` in chatmail/cmlxc#31.

Once #31 merges, this can come out of draft and the final changes can be made:
- [x] `uses:` and `cmlxc_version` are pinned to `j4n/madmail-main` and need to be flipped to `main` once #31 lands.
- [ ] The `push:` trigger is temporary, for running this on the fork before the PR  is ready.
- [x] `tests/cmlxc` submodule is still pinned at `9fb7664`, and can follow main from there
