### PR TITLE
fix(federation): normalize IP addresses on mxdeliv and preserve host:port in endpoint-cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -161,7 +161,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1549,7 +1549,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1699,7 +1699,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2244,9 +2244,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2512,7 +2512,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2727,7 +2727,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3287,7 +3287,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4248,7 +4248,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4286,7 +4286,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4680,7 +4680,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4746,7 +4746,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5129,7 +5129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5504,7 +5504,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6337,7 +6337,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -844,6 +844,7 @@ name = "chatmail-fed"
 version = "2.23.3"
 dependencies = [
  "axum",
+ "chatmail-auth",
  "chatmail-config",
  "chatmail-db",
  "chatmail-pgp",

--- a/crates/chatmail-delivery/src/transport.rs
+++ b/crates/chatmail-delivery/src/transport.rs
@@ -253,13 +253,29 @@ fn record_failure(ctx: &DeliveryContext, domain: &str, method: &str) {
     ctx.state.federation_tracker.decrement_queue(domain);
 }
 
-/// Host suitable for `https://HOST/mxdeliv` (bare IPv4, bracketed IPv6, DNS names unchanged).
+/// Host suitable for `https://HOST/mxdeliv` (bare IPv4, optional `:port`, bracketed IPv6, DNS).
 pub fn mxdeliv_host_for_url(host: &str) -> String {
-    let bare = host.trim().trim_matches(|c| c == '[' || c == ']');
+    let host = host.trim();
+    // IPv4 with optional port — must NOT be wrapped as IPv6 (`[127.0.0.1:19080]` is invalid).
+    if !host.starts_with('[') {
+        if let Some((h, port)) = host.rsplit_once(':') {
+            if is_ipv4_literal(h) && !port.is_empty() && port.chars().all(|c| c.is_ascii_digit()) {
+                return format!("{h}:{port}");
+            }
+        }
+        if is_ipv4_literal(host) {
+            return host.to_string();
+        }
+    }
+    let bare = host.trim_matches(|c| c == '[' || c == ']');
     if is_ipv4_literal(bare) {
         return bare.to_string();
     }
     if bare.contains(':') {
+        // IPv6 (optionally already bracketed)
+        if host.starts_with('[') {
+            return host.to_string();
+        }
         return format!("[{bare}]");
     }
     bare.to_string()
@@ -343,6 +359,16 @@ mod tests {
         assert_eq!(
             normalize_rewrite_url("https://relay.example.com"),
             "https://relay.example.com/mxdeliv"
+        );
+    }
+
+    #[test]
+    fn ipv4_with_port_not_wrapped_as_ipv6() {
+        assert_eq!(mxdeliv_host_for_url("127.0.0.1:19080"), "127.0.0.1:19080");
+        assert_eq!(mxdeliv_host_for_url("127.0.0.1"), "127.0.0.1");
+        assert_eq!(
+            mxdeliv_host_for_url("2001:db8::1"),
+            "[2001:db8::1]"
         );
     }
 }

--- a/crates/chatmail-delivery/src/transport.rs
+++ b/crates/chatmail-delivery/src/transport.rs
@@ -254,25 +254,61 @@ fn record_failure(ctx: &DeliveryContext, domain: &str, method: &str) {
 }
 
 /// Host suitable for `https://HOST/mxdeliv` (bare IPv4, optional `:port`, bracketed IPv6, DNS).
+///
+/// Rules:
+/// - `host:digits` where `host` has no `:` → keep as-is (IPv4 or DNS name + port)
+/// - `[1.2.3.4]:port` → peel to `1.2.3.4:port`
+/// - bare IPv4 → bare IPv4
+/// - unbracketed IPv6 → `[ipv6]`
+/// - `[ipv6]:port` / already-bracketed IPv6 → keep as-is
 pub fn mxdeliv_host_for_url(host: &str) -> String {
     let host = host.trim();
-    // IPv4 with optional port — must NOT be wrapped as IPv6 (`[127.0.0.1:19080]` is invalid).
-    if !host.starts_with('[') {
-        if let Some((h, port)) = host.rsplit_once(':') {
-            if is_ipv4_literal(h) && !port.is_empty() && port.chars().all(|c| c.is_ascii_digit()) {
-                return format!("{h}:{port}");
+    if host.is_empty() {
+        return String::new();
+    }
+
+    // `[addr]:port` — peel brackets only for IPv4; keep IPv6 bracketed form.
+    if host.starts_with('[') {
+        if let Some(end) = host.find(']') {
+            let inner = &host[1..end];
+            let rest = &host[end + 1..];
+            if let Some(port) = rest.strip_prefix(':') {
+                if !port.is_empty()
+                    && port.chars().all(|c| c.is_ascii_digit())
+                    && is_ipv4_literal(inner)
+                {
+                    return format!("{inner}:{port}");
+                }
             }
-        }
-        if is_ipv4_literal(host) {
+            // Bracketed IPv6 (± port) or bare bracketed IPv4 without port handling below.
+            if is_ipv4_literal(inner) && rest.is_empty() {
+                return inner.to_string();
+            }
             return host.to_string();
         }
     }
+
+    // Unbracketed `left:port` where left has no colon → host (IPv4 or DNS) + numeric port.
+    if let Some((left, port)) = host.rsplit_once(':') {
+        if !left.is_empty()
+            && !left.contains(':')
+            && !port.is_empty()
+            && port.chars().all(|c| c.is_ascii_digit())
+        {
+            return format!("{left}:{port}");
+        }
+    }
+
+    if is_ipv4_literal(host) {
+        return host.to_string();
+    }
+
     let bare = host.trim_matches(|c| c == '[' || c == ']');
     if is_ipv4_literal(bare) {
         return bare.to_string();
     }
     if bare.contains(':') {
-        // IPv6 (optionally already bracketed)
+        // Unbracketed IPv6 (no port form handled above only for single-colon host:port).
         if host.starts_with('[') {
             return host.to_string();
         }
@@ -370,5 +406,23 @@ mod tests {
             mxdeliv_host_for_url("2001:db8::1"),
             "[2001:db8::1]"
         );
+    }
+
+    #[test]
+    fn host_port_forms_for_exchanger_and_dns() {
+        assert_eq!(mxdeliv_host_for_url("localhost:19080"), "localhost:19080");
+        assert_eq!(
+            mxdeliv_host_for_url("relay.example:19080"),
+            "relay.example:19080"
+        );
+        assert_eq!(
+            mxdeliv_host_for_url("[127.0.0.1]:19080"),
+            "127.0.0.1:19080"
+        );
+        assert_eq!(
+            mxdeliv_host_for_url("[2001:db8::1]:19080"),
+            "[2001:db8::1]:19080"
+        );
+        assert_eq!(mxdeliv_host_for_url("[127.0.0.1]"), "127.0.0.1");
     }
 }

--- a/crates/chatmail-delivery/src/transport.rs
+++ b/crates/chatmail-delivery/src/transport.rs
@@ -402,10 +402,7 @@ mod tests {
     fn ipv4_with_port_not_wrapped_as_ipv6() {
         assert_eq!(mxdeliv_host_for_url("127.0.0.1:19080"), "127.0.0.1:19080");
         assert_eq!(mxdeliv_host_for_url("127.0.0.1"), "127.0.0.1");
-        assert_eq!(
-            mxdeliv_host_for_url("2001:db8::1"),
-            "[2001:db8::1]"
-        );
+        assert_eq!(mxdeliv_host_for_url("2001:db8::1"), "[2001:db8::1]");
     }
 
     #[test]
@@ -415,10 +412,7 @@ mod tests {
             mxdeliv_host_for_url("relay.example:19080"),
             "relay.example:19080"
         );
-        assert_eq!(
-            mxdeliv_host_for_url("[127.0.0.1]:19080"),
-            "127.0.0.1:19080"
-        );
+        assert_eq!(mxdeliv_host_for_url("[127.0.0.1]:19080"), "127.0.0.1:19080");
         assert_eq!(
             mxdeliv_host_for_url("[2001:db8::1]:19080"),
             "[2001:db8::1]:19080"

--- a/crates/chatmail-fed/Cargo.toml
+++ b/crates/chatmail-fed/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 axum = { workspace = true }
+chatmail-auth = { workspace = true }
 chatmail-db = { workspace = true }
 chatmail-pgp = { workspace = true }
 chatmail-state = { workspace = true }

--- a/crates/chatmail-fed/src/mxdeliv.rs
+++ b/crates/chatmail-fed/src/mxdeliv.rs
@@ -21,27 +21,22 @@ use axum::body::Bytes;
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
+use chatmail_auth::normalize_username;
 use chatmail_db::{is_federation_sender_blocked, DbPool};
 use chatmail_pgp::{enforce_encryption, EnforceOptions};
 use chatmail_state::AppState;
 use chatmail_storage::deliver_local_messages;
-use chatmail_types::{wrap_ip_domain, ChatmailError};
+use chatmail_types::ChatmailError;
 
 use crate::security::recipient_matches_server;
 
-/// Case-fold localpart and wrap bare IPv4 domains in brackets so lookups match
-/// `passwords.username` / maildir paths created at registration.
+/// Normalize envelope addresses for /mxdeliv (same rules as SMTP login).
+///
+/// Uses [`chatmail_auth::normalize_username`] so bare IPv4 domains become
+/// `user@[1.2.3.4]` and match registration / maildir paths. Malformed values
+/// become `None` and are dropped by the caller.
 fn normalize_addr(raw: &str) -> Option<String> {
-    let trimmed = raw.trim();
-    let (local, domain) = trimmed.rsplit_once('@')?;
-    if local.is_empty() || domain.is_empty() {
-        return None;
-    }
-    Some(format!(
-        "{}@{}",
-        local.to_ascii_lowercase(),
-        wrap_ip_domain(domain).to_ascii_lowercase()
-    ))
+    normalize_username(raw).ok()
 }
 
 #[derive(Clone)]
@@ -369,6 +364,61 @@ mod tests {
 
         handle_mxdeliv(&st, &headers, pgp).await.unwrap();
         assert_eq!(app.quota.used_bytes("user@example.org"), pgp.len() as u64);
+    }
+
+    /// Bare `X-Mail-To: alice@1.2.3.4` must deliver when the account is
+    /// registered as `alice@[1.2.3.4]` (IP-mode silent-drop regression).
+    #[tokio::test]
+    async fn p7_delivers_bare_ip_x_mail_to_bracketed_account() {
+        let pool = init_memory_db().await.unwrap();
+        chatmail_db::passwords::create_user(&pool, "alice@[1.2.3.4]", "hash")
+            .await
+            .unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let app = Arc::new(AppState::new(dir.path(), pool.clone()));
+        app.federation_policy.hydrate(&pool).await.unwrap();
+        app.auth.hydrate(&pool).await.unwrap();
+
+        let st = FedState {
+            pool,
+            app: Arc::clone(&app),
+            primary_domain: "[1.2.3.4]".into(),
+            local_domains: chatmail_types::build_local_domains("[1.2.3.4]", None),
+        };
+
+        let pgp = b"From: a@peer.test\r\nTo: alice@1.2.3.4\r\nContent-Type: multipart/encrypted; boundary=b\r\n\r\n--b\r\nContent-Type: application/pgp-encrypted\r\n\r\nv\r\n--b--\r\n";
+        let mut headers = HeaderMap::new();
+        headers.insert("x-mail-from", "sender@peer.test".parse().unwrap());
+        headers.insert("x-mail-to", "alice@1.2.3.4".parse().unwrap());
+
+        handle_mxdeliv(&st, &headers, pgp).await.unwrap();
+        // Delivery is charged under the normalized bracketed key.
+        assert_eq!(app.quota.used_bytes("alice@[1.2.3.4]"), pgp.len() as u64);
+        assert_eq!(app.quota.used_bytes("alice@1.2.3.4"), 0);
+    }
+
+    #[tokio::test]
+    async fn p7_all_malformed_x_mail_to_is_protocol_error() {
+        let pool = init_memory_db().await.unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let app = Arc::new(AppState::new(dir.path(), pool.clone()));
+        app.federation_policy.hydrate(&pool).await.unwrap();
+
+        let st = FedState {
+            pool,
+            app,
+            primary_domain: "example.org".into(),
+            local_domains: chatmail_types::build_local_domains("example.org", None),
+        };
+
+        let pgp = b"From: a@peer.test\r\nTo: x\r\nContent-Type: multipart/encrypted; boundary=b\r\n\r\n--b\r\nContent-Type: application/pgp-encrypted\r\n\r\nv\r\n--b--\r\n";
+        let mut headers = HeaderMap::new();
+        headers.insert("x-mail-from", "sender@peer.test".parse().unwrap());
+        headers.insert("x-mail-to", "not-an-email".parse().unwrap());
+
+        let err = handle_mxdeliv(&st, &headers, pgp).await.unwrap_err();
+        assert!(matches!(err, ChatmailError::Protocol(_)));
+        assert_eq!(mxdeliv_http_status(&err), StatusCode::BAD_REQUEST);
     }
 
     /// One POST with several X-Mail-To headers (TDD 07-federation.md) must

--- a/crates/chatmail-fed/src/mxdeliv.rs
+++ b/crates/chatmail-fed/src/mxdeliv.rs
@@ -25,9 +25,24 @@ use chatmail_db::{is_federation_sender_blocked, DbPool};
 use chatmail_pgp::{enforce_encryption, EnforceOptions};
 use chatmail_state::AppState;
 use chatmail_storage::deliver_local_messages;
-use chatmail_types::ChatmailError;
+use chatmail_types::{wrap_ip_domain, ChatmailError};
 
 use crate::security::recipient_matches_server;
+
+/// Case-fold localpart and wrap bare IPv4 domains in brackets so lookups match
+/// `passwords.username` / maildir paths created at registration.
+fn normalize_addr(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    let (local, domain) = trimmed.rsplit_once('@')?;
+    if local.is_empty() || domain.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "{}@{}",
+        local.to_ascii_lowercase(),
+        wrap_ip_domain(domain).to_ascii_lowercase()
+    ))
+}
 
 #[derive(Clone)]
 pub struct FedState {
@@ -76,10 +91,16 @@ async fn handle_mxdeliv(
     headers: &HeaderMap,
     body: &[u8],
 ) -> chatmail_types::Result<()> {
-    let mail_from = header_str(headers, "x-mail-from").unwrap_or_default();
+    let mail_from = header_str(headers, "x-mail-from")
+        .and_then(|s| normalize_addr(&s))
+        .unwrap_or_default();
     // One POST carries one X-Mail-To header per recipient on this server
     // (TDD 07-federation.md); deliver to each of them.
-    let mut rcpts = header_strs(headers, "x-mail-to");
+    // Normalize so bare `user@1.2.3.4` matches registered `user@[1.2.3.4]`.
+    let mut rcpts: Vec<String> = header_strs(headers, "x-mail-to")
+        .into_iter()
+        .filter_map(|r| normalize_addr(&r))
+        .collect();
     if rcpts.is_empty() {
         return Err(ChatmailError::protocol("missing X-Mail-To"));
     }

--- a/crates/chatmail-state/src/auth.rs
+++ b/crates/chatmail-state/src/auth.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 use chatmail_db::{
     blocklist, get_bool_setting, is_federation_rcpt_blocked, passwords, settings_keys, DbPool,
 };
-use chatmail_types::{wrap_ip_domain, Result};
+use chatmail_types::{is_ipv4_literal, wrap_ip_domain, Result};
 use dashmap::DashMap;
 
 /// How long a successful password verification is trusted before bcrypt re-runs.
@@ -117,8 +117,11 @@ impl AuthCache {
 
     /// Whether inbound mail may be delivered locally (reserved rcpt + account exists).
     ///
-    /// Looks up both the raw address and the IP-literal-normalized form so that
-    /// `user@1.2.3.4` matches a registered `user@[1.2.3.4]` (and vice versa).
+    /// For IPv4-literal domains, looks up both the bracketed form (`user@[1.2.3.4]`)
+    /// and the bare form (`user@1.2.3.4`) so either registration spelling works.
+    /// Prefer canonical delivery under the key that actually exists in the cache
+    /// (callers that need a storage key should normalize via
+    /// [`chatmail_auth::normalize_username`] first, which wraps bare IPv4).
     pub fn local_recipient_allowed(&self, rcpt: &str) -> bool {
         if is_federation_rcpt_blocked(rcpt) {
             return false;
@@ -127,13 +130,23 @@ impl AuthCache {
             return true;
         }
         if let Some((local, domain)) = rcpt.rsplit_once('@') {
-            let norm = format!(
+            let local = local.to_ascii_lowercase();
+            let domain_l = domain.to_ascii_lowercase();
+            let wrapped = format!(
                 "{}@{}",
-                local.to_ascii_lowercase(),
-                wrap_ip_domain(domain).to_ascii_lowercase()
+                local,
+                wrap_ip_domain(&domain_l).to_ascii_lowercase()
             );
-            if norm != rcpt && self.user_exists(&norm) {
+            if wrapped != rcpt && self.user_exists(&wrapped) {
                 return true;
+            }
+            // Reverse: rcpt is bracketed but account was stored bare (rare).
+            let bare_dom = domain_l.trim_matches(|c| c == '[' || c == ']');
+            if is_ipv4_literal(bare_dom) {
+                let bare = format!("{local}@{bare_dom}");
+                if bare != rcpt && bare != wrapped && self.user_exists(&bare) {
+                    return true;
+                }
             }
         }
         false
@@ -229,6 +242,20 @@ mod tests {
         assert!(!cache.local_recipient_allowed("admin@test"));
         assert!(!cache.local_recipient_allowed("ghost@test"));
         assert!(cache.local_recipient_allowed("u@test"));
+    }
+
+    #[test]
+    fn local_recipient_matches_bare_and_bracketed_ipv4() {
+        let cache = AuthCache::new();
+        cache.insert("u@[1.2.3.4]", "h");
+        assert!(cache.local_recipient_allowed("u@[1.2.3.4]"));
+        assert!(cache.local_recipient_allowed("u@1.2.3.4"));
+        assert!(cache.local_recipient_allowed("U@1.2.3.4"));
+
+        let bare = AuthCache::new();
+        bare.insert("v@1.2.3.4", "h");
+        assert!(bare.local_recipient_allowed("v@1.2.3.4"));
+        assert!(bare.local_recipient_allowed("v@[1.2.3.4]"));
     }
 
     #[test]

--- a/crates/chatmail-state/src/auth.rs
+++ b/crates/chatmail-state/src/auth.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 use chatmail_db::{
     blocklist, get_bool_setting, is_federation_rcpt_blocked, passwords, settings_keys, DbPool,
 };
-use chatmail_types::Result;
+use chatmail_types::{wrap_ip_domain, Result};
 use dashmap::DashMap;
 
 /// How long a successful password verification is trusted before bcrypt re-runs.
@@ -116,11 +116,27 @@ impl AuthCache {
     }
 
     /// Whether inbound mail may be delivered locally (reserved rcpt + account exists).
+    ///
+    /// Looks up both the raw address and the IP-literal-normalized form so that
+    /// `user@1.2.3.4` matches a registered `user@[1.2.3.4]` (and vice versa).
     pub fn local_recipient_allowed(&self, rcpt: &str) -> bool {
         if is_federation_rcpt_blocked(rcpt) {
             return false;
         }
-        self.user_exists(rcpt)
+        if self.user_exists(rcpt) {
+            return true;
+        }
+        if let Some((local, domain)) = rcpt.rsplit_once('@') {
+            let norm = format!(
+                "{}@{}",
+                local.to_ascii_lowercase(),
+                wrap_ip_domain(domain).to_ascii_lowercase()
+            );
+            if norm != rcpt && self.user_exists(&norm) {
+                return true;
+            }
+        }
+        false
     }
 
     pub fn len(&self) -> usize {

--- a/docs/TDD/07-federation.md
+++ b/docs/TDD/07-federation.md
@@ -76,6 +76,16 @@ Used to:
 
 CLI: [`madmail endpoint-cache set`](../guide/cli/endpoint-cache-set.md) (alias `dns-cache`); federation policy: [`madmail federation`](../guide/cli/federation.md) including `dismiss` / `undismiss` for silent-dismiss cache (`chatmail-state::silent_dismiss`)
 
+### TARGET_HOST parsing (`chatmail-delivery::transport`)
+
+- Full URL (`http://…` / `https://…`) → `FederationTarget::MxdelivUrl` (optional path; defaults to `/mxdeliv`).
+- Hostname / bare IPv4 / `ipv4:port` → `FederationTarget::Host` → `https://{host}/mxdeliv` then HTTP.
+- **IPv4 with port** must stay as `a.b.c.d:port` (not wrapped as `[a.b.c.d:port]`). See [problems/federation-ip-normalize-and-endpoint-port.md](../problems/federation-ip-normalize-and-endpoint-port.md).
+
+### Inbound address normalize (`chatmail-fed::mxdeliv`)
+
+Envelope `X-Mail-From` / `X-Mail-To` are normalized (case-fold localpart + `wrap_ip_domain`) before policy, account lookup, and maildir delivery so `user@1.2.3.4` matches registered `user@[1.2.3.4]`.
+
 ## FederationTracker (In-Memory)
 Critical for diagnostics:
 - Per-domain queue depth

--- a/docs/guide/cli/endpoint-cache-set.md
+++ b/docs/guide/cli/endpoint-cache-set.md
@@ -13,8 +13,28 @@ madmail endpoint-cache set [OPTIONS] <LOOKUP_KEY> <TARGET_HOST> [COMMENT]
 ## Examples
 
 ```bash
+# Rewrite DNS name → another hostname (HTTPS then HTTP to /mxdeliv)
 madmail endpoint-cache set a.com b.com "via partner"
+
+# Route via madexchanger / local tunnel (prefer full URL)
+madmail endpoint-cache set peer.example.org "http://127.0.0.1:19080/mxdeliv" "via madexchanger"
+
+# IP-literal peers (register both bare and bracketed lookup keys if needed)
+madmail endpoint-cache set 203.0.113.50 "http://127.0.0.1:19080/mxdeliv"
+madmail endpoint-cache set "[203.0.113.50]" "http://127.0.0.1:19080/mxdeliv"
 ```
+
+### `TARGET_HOST` forms
+
+| Form | Behavior |
+|------|----------|
+| `hostname` or `1.2.3.4` | Deliver with `https://HOST/mxdeliv` then `http://HOST/mxdeliv` |
+| `1.2.3.4:19080` | Same, with explicit port (IPv4+port must not be treated as IPv6) |
+| `http://…` / `https://…` | Use as full rewrite URL (path defaults to `/mxdeliv` if omitted) |
+
+For intermediate relays (madexchanger), **full URL** is the safest operator form.
+
+See also: [federation IP / endpoint-port bugs](../../problems/federation-ip-normalize-and-endpoint-port.md).
 
 ## JSON output (`--json`)
 

--- a/docs/problems/federation-ip-normalize-and-endpoint-port.md
+++ b/docs/problems/federation-ip-normalize-and-endpoint-port.md
@@ -1,0 +1,133 @@
+# Federation bugs: IP address normalize + endpoint-cache host:port
+
+**Status:** fixed on branch `fix/federation-ip-normalize-endpoint-port`  
+**Affects:** IP-literal chatmail domains (`user@[1.2.3.4]`), madexchanger / endpoint-cache relays on non-443 ports  
+**Crates:** `chatmail-fed`, `chatmail-state`, `chatmail-delivery`
+
+## Summary
+
+Two independent bugs broke (or silently dropped) federation between IP-based Madmail servers and/or when routing via an intermediate **madexchanger** on a custom port:
+
+1. **Inbound `/mxdeliv` did not normalize addresses** before account lookup and maildir delivery.
+2. **Outbound `endpoint-cache` treated `host:port` as IPv6**, producing invalid rewrite targets.
+
+Both returned outcomes that looked “healthy” (HTTP 200 from peers / successful relay counters) while mail never reached the correct mailbox or never used the intended HTTP path.
+
+---
+
+## Bug 1 — Bare IP vs bracketed IP on inbound `/mxdeliv`
+
+### Symptom
+
+- Peer (or madexchanger) POSTs `/mxdeliv` and receives **HTTP 200 OK**.
+- Recipient maildir stays empty.
+- Logs (when enabled) may show: `mxdeliv: silently dropped (no account or reserved rcpt)`.
+
+### Root cause
+
+Accounts on IP-mode installs are registered as RFC 5321 address-literals:
+
+```text
+alice@[203.0.113.50]
+```
+
+Auth cache / `passwords.username` / maildir paths use that **exact** string.
+
+Inbound federation only did an **exact** `user_exists(rcpt)` check on the raw `X-Mail-To` header. Clients, relays, or peers may send either:
+
+| Form | Typical source |
+|------|----------------|
+| `alice@[203.0.113.50]` | Delta Chat / registration canonical form |
+| `alice@203.0.113.50` | Some relays, manual tests, non-normalized peers |
+
+`alice@203.0.113.50` failed the exact match → recipient list emptied → handler returned **`Ok(())` → HTTP 200** (anti-enumeration style silent drop). The remote server and madexchanger both treat this as successful delivery.
+
+### Fix
+
+1. **`chatmail-fed` / `mxdeliv.rs`**  
+   Normalize every `X-Mail-From` / `X-Mail-To` with case-fold localpart + `wrap_ip_domain()` before domain checks, account lookup, and local delivery so storage paths match registration.
+
+2. **`chatmail-state` / `auth.rs` — `local_recipient_allowed`**  
+   Also try the IP-literal-normalized form if the raw key is missing (defense in depth for other callers).
+
+### Operator note
+
+Prefer documenting contacts as `user@[ip]` for IP servers. After this fix, bare `user@ip` is accepted and stored under the bracketed mailbox.
+
+---
+
+## Bug 2 — `endpoint-cache` `host:port` rewritten as fake IPv6
+
+### Symptom
+
+- Operator sets:  
+  `madmail endpoint-cache set peer.example.org 127.0.0.1:19080`
+- Outbound federation does **not** hit the madexchanger (or hits a nonsense URL).
+- Traffic falls through to SMTP / direct IP and fails when the direct path is firewalled (isolation / NAT tests).
+- Federation stats may show only **Failed (SMTP)** for the peer domain.
+
+### Root cause
+
+`mxdeliv_host_for_url()` did:
+
+1. Strip brackets.
+2. If not a pure IPv4 literal and the string **contains `:`**, wrap as IPv6: `[…]`.
+
+So `127.0.0.1:19080` became **`[127.0.0.1:19080]`**, then:
+
+```text
+https://[127.0.0.1:19080]/mxdeliv
+```
+
+which is invalid for IPv4+port. HTTPS/HTTP to the exchanger failed; SMTP fallback targeted the wrong host.
+
+When `TARGET_HOST` is a full URL (`http://127.0.0.1:19080/mxdeliv`), the `MxdelivUrl` path already worked — only the bare `host:port` form was broken.
+
+### Fix
+
+**`chatmail-delivery` / `transport.rs` — `mxdeliv_host_for_url`**
+
+- Detect **IPv4 + numeric port** (`a.b.c.d:port`) and keep it as-is for URL construction (`https://127.0.0.1:19080/mxdeliv`).
+- Still wrap bare IPv6 with brackets.
+- Unit test: `ipv4_with_port_not_wrapped_as_ipv6`.
+
+### Operator recommendation
+
+Prefer full URL overrides for relays:
+
+```bash
+madmail endpoint-cache set peer.example.org "http://127.0.0.1:19080/mxdeliv" "via madexchanger tunnel"
+madmail endpoint-cache set 203.0.113.50 "http://127.0.0.1:19080/mxdeliv"
+madmail endpoint-cache set "[203.0.113.50]" "http://127.0.0.1:19080/mxdeliv"
+```
+
+After this fix, `127.0.0.1:19080` (without scheme) is also valid as a Host target.
+
+---
+
+## How we validated (field)
+
+Setup: internal DNS chatmail (`delta.example`) ↔ external IP chatmail (`[203.0.113.50]`) with **madexchanger** on a third host, reverse SSH tunnels to `127.0.0.1:19080`, and iptables blocking direct host↔host reachability.
+
+| Check | Result after fix |
+|-------|------------------|
+| Direct HTTPS between servers | Blocked (by design) |
+| POST via tunnel → madexchanger → peer `/mxdeliv` | Forward success |
+| Outbound queue → endpoint rewrite → exchanger | Delivered (HTTP) |
+| `user@ip` and `user@[ip]` inbound store | Both land in bracketed maildir |
+
+---
+
+## Related docs
+
+- TDD: [`docs/TDD/07-federation.md`](../TDD/07-federation.md)
+- CLI: [`docs/guide/cli/endpoint-cache-set.md`](../guide/cli/endpoint-cache-set.md)
+- CLI: [`docs/guide/cli/endpoint-cache.md`](../guide/cli/endpoint-cache.md)
+
+## Code touch points
+
+| File | Change |
+|------|--------|
+| `crates/chatmail-fed/src/mxdeliv.rs` | `normalize_addr` on envelope headers |
+| `crates/chatmail-state/src/auth.rs` | IP-normalized `local_recipient_allowed` |
+| `crates/chatmail-delivery/src/transport.rs` | `mxdeliv_host_for_url` host:port + tests |

--- a/docs/problems/federation-ip-normalize-and-endpoint-port.md
+++ b/docs/problems/federation-ip-normalize-and-endpoint-port.md
@@ -130,4 +130,6 @@ Setup: internal DNS chatmail (`delta.example`) ↔ external IP chatmail (`[203.0
 |------|--------|
 | `crates/chatmail-fed/src/mxdeliv.rs` | `normalize_addr` on envelope headers |
 | `crates/chatmail-state/src/auth.rs` | IP-normalized `local_recipient_allowed` |
-| `crates/chatmail-delivery/src/transport.rs` | `mxdeliv_host_for_url` host:port + tests |
+| `crates/chatmail-delivery/src/transport.rs` | `mxdeliv_host_for_url` host:port (IPv4, DNS, peel `[ipv4]:port`) + tests |
+| `crates/chatmail-fed/src/mxdeliv.rs` | reuse `normalize_username`; bare-IP delivery test |
+| `crates/chatmail-state/src/auth.rs` | bare↔bracketed IPv4 account lookup |


### PR DESCRIPTION
## Summary

Federation connectivity bugs when madmail servers exchange over raw IPs / dual-homed endpoints (Iran national internet + exchanger path).

## Fixes

- **mxdeliv**: normalize IP address forms used in federation/auth so bare IP and bracketed IPv6 variants match consistently
- **endpoint-cache**: preserve `host:port` correctly (avoid treating `host:port` as IPv6 or stripping the port)
- Related transport/auth path updates so endpoints with non-default ports work

## Test plan

- [x] Lab federation path between Server1 and Server2 via exchanger
- [ ] CI on themadorg/madmail
- [ ] Manual: endpoint-cache round-trip with host:port and bare IPv4

Opened from **13sizdahom** fork.