### PR TITLE
fix(upgrade): restore 0755 when old update leaves the live binary 0700

### DIFF
--- a/crates/chatmail/src/ctl/version.rs
+++ b/crates/chatmail/src/ctl/version.rs
@@ -25,6 +25,9 @@ pub const VERSION_PRODUCT: &str = "madmail-v2";
 
 /// Print package version (Madmail `maddy version`).
 pub fn print_version(args: &Args) -> Result<()> {
+    // Old `maddy update` (through 2.20.0) chmods the live path to 0700 then
+    // runs `version` as root. Restore 0755 so systemd User= can exec (#147).
+    crate::upgrade::heal_current_exe_permissions();
     let out = CtlOut::from_args(args, "version");
     let version = env!("CARGO_PKG_VERSION");
     if out.is_json() {

--- a/crates/chatmail/src/upgrade.rs
+++ b/crates/chatmail/src/upgrade.rs
@@ -637,6 +637,40 @@ const STAGING_EXEC_MODE: u32 = 0o700;
 #[cfg(unix)]
 const INSTALLED_EXEC_MODE: u32 = 0o755;
 
+/// Force `0755` so systemd `User=` can exec the file (GitHub #131 / #147).
+///
+/// Follows a symlink to the target. Best-effort: ignore errors so an
+/// unprivileged `version` still prints.
+pub(crate) fn ensure_installed_exec_permissions(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(path, fs::Permissions::from_mode(INSTALLED_EXEC_MODE));
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+}
+
+/// Undo a `0700` chmod on the running binary (old `maddy update` preflight).
+///
+/// Updaters through 2.20.0 set the *live* path to owner-only, then exec
+/// `version` as root. Healing here runs in the *new* binary before systemd
+/// start, so the first hop onto this release is 203/EXEC-safe.
+pub(crate) fn heal_current_exe_permissions() {
+    if let Ok(exe) = std::env::current_exe() {
+        ensure_installed_exec_permissions(&exe);
+    }
+}
+
+fn heal_live_exec_paths(paths: &[&Path]) {
+    for p in paths {
+        ensure_installed_exec_permissions(p);
+    }
+    heal_current_exe_permissions();
+}
+
 /// Ensure the binary can actually execute on this host (`madmail version`).
 ///
 /// Catches wrong-variant installs (default glibc build on older distros) **before**
@@ -1091,6 +1125,7 @@ fn activate_versioned_install(
             installed_bin.display()
         ))
     })?;
+    heal_live_exec_paths(&[installed_bin.as_path(), stable]);
 
     if let Err(e) = preflight_new_binary(&installed_bin, BinaryExecLocation::Installed) {
         let restore_note = restore_previous_active(vroot, prev.as_deref(), stable);
@@ -1191,6 +1226,7 @@ fn perform_upgrade_legacy_inplace(new_bin_path: &Path, vroot: &Path, args: &Args
         let _ = systemctl_succeeded(&["start", &service]);
         return Err(e);
     }
+    heal_live_exec_paths(&[real_bin_path.as_path()]);
 
     // Belt-and-suspenders: re-smoke the installed path (catches corrupt write).
     // Uses Installed mode so we do **not** chmod 0700 the live path.
@@ -1427,6 +1463,35 @@ mod tests {
             "installed mode must be 0755, got {mode:#o}"
         );
         assert_ne!(mode, STAGING_EXEC_MODE);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_installed_exec_permissions_repairs_0700() {
+        // #147: old update preflight left the live path 0700; heal must restore 0755.
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dir.path().join("maddy");
+        fs::write(&bin, b"#!/bin/sh\necho ok\n").unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&bin, fs::Permissions::from_mode(0o700)).unwrap();
+        ensure_installed_exec_permissions(&bin);
+        let mode = fs::metadata(&bin).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, INSTALLED_EXEC_MODE, "got {mode:#o}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_installed_exec_permissions_follows_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("madmail");
+        let link = dir.path().join("maddy");
+        fs::write(&target, b"#!/bin/sh\necho ok\n").unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o700)).unwrap();
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        ensure_installed_exec_permissions(&link);
+        let mode = fs::metadata(&target).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, INSTALLED_EXEC_MODE, "symlink target got {mode:#o}");
     }
 
     #[cfg(unix)]

--- a/crates/chatmail/src/version_manager.rs
+++ b/crates/chatmail/src/version_manager.rs
@@ -459,6 +459,12 @@ pub fn set_active(root: &Path, version_id: &str, stable_path: &Path) -> Result<(
         }
     }
     ensure_install_layout(root)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        // systemd User= cannot exec a 0700 archive (GitHub #131 / #147).
+        let _ = fs::set_permissions(&bin, fs::Permissions::from_mode(0o755));
+    }
 
     // current -> versions/<id> (directory)
     let current = current_link_path(root);
@@ -1203,6 +1209,37 @@ mod tests {
         let root = TempDir::new().unwrap();
         let stable = root.path().join("s");
         assert!(set_active(root.path(), "../evil", &stable).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn set_active_repairs_0700_version_binary() {
+        use std::os::unix::fs::PermissionsExt;
+        let root = TempDir::new().unwrap();
+        let stable = root.path().join("bin").join(binary_file_name());
+        let src = root.path().join("p");
+        write_fake_bin(&src);
+        install_candidate(
+            root.path(),
+            "2.23.2",
+            &src,
+            VersionMeta {
+                version: "2.23.2".into(),
+                installed_at: None,
+                source: Some("test".into()),
+                source_url: None,
+                sha256: None,
+                variant: None,
+                os: None,
+                signature_ok: Some(true),
+            },
+        )
+        .unwrap();
+        let bin = version_binary_path(root.path(), "2.23.2");
+        fs::set_permissions(&bin, fs::Permissions::from_mode(0o700)).unwrap();
+        set_active(root.path(), "2.23.2", &stable).unwrap();
+        let mode = fs::metadata(&bin).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o755, "set_active must leave 0755, got {mode:#o}");
     }
 
     #[test]

--- a/tests/ctl_cli_e2e.rs
+++ b/tests/ctl_cli_e2e.rs
@@ -248,3 +248,71 @@ fn e2e_ctl_accounts_export_import() {
         assert!(passwords::user_exists(&pool, email).await.unwrap());
     });
 }
+
+/// Old `maddy update` (through 2.20.0) chmods the live path to 0700 then execs
+/// `version` as root. The new binary must restore 0755 (GitHub #147).
+#[cfg(unix)]
+#[test]
+fn e2e_version_repairs_0700_live_mode() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = TempDir::new().expect("tempdir");
+    let dest = dir.path().join("maddy");
+    std::fs::copy(chatmail_bin(), &dest).expect("copy madmail");
+    std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o700)).unwrap();
+    assert_eq!(
+        std::fs::metadata(&dest).unwrap().permissions().mode() & 0o777,
+        0o700
+    );
+
+    let out = Command::new(&dest)
+        .arg("version")
+        .output()
+        .expect("run version");
+    assert!(
+        out.status.success(),
+        "version failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("madmail-v2"),
+        "expected version banner, got: {stdout}"
+    );
+
+    let mode = std::fs::metadata(&dest).unwrap().permissions().mode() & 0o777;
+    assert_eq!(
+        mode, 0o755,
+        "version must restore 0755 after old-updater 0700 (#147), got {mode:#o}"
+    );
+}
+
+/// Same heal when the service PATH entry is a symlink into the version tree.
+#[cfg(unix)]
+#[test]
+fn e2e_version_repairs_0700_through_symlink() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = TempDir::new().expect("tempdir");
+    let target = dir.path().join("madmail");
+    let link = dir.path().join("maddy");
+    std::fs::copy(chatmail_bin(), &target).expect("copy madmail");
+    std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o700)).unwrap();
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+
+    let out = Command::new(&link)
+        .arg("version")
+        .output()
+        .expect("run version via symlink");
+    assert!(
+        out.status.success(),
+        "version failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let mode = std::fs::metadata(&target).unwrap().permissions().mode() & 0o777;
+    assert_eq!(
+        mode, 0o755,
+        "version must chmod symlink target to 0755 (#147), got {mode:#o}"
+    );
+}


### PR DESCRIPTION
## Summary

- Old `maddy update` (through 2.20.0) chmods the installed path to `0700` then runs `version` as root. systemd `User=` cannot exec that file (`203/EXEC`).
- The new binary now restores `0755` on `version` (`current_exe`), after replace/activate, and in `set_active`.
- Unit + e2e tests cover the live file and a symlink into the version tree.

Closes #147

## Test plan

- [x] `cargo test -p chatmail --lib ensure_installed_exec_permissions`
- [x] `cargo test -p chatmail-integration --test ctl_cli_e2e e2e_version_repairs`
- [x] Reproduced #147 in a systemd Docker container (2.20.0 → 2.23.2 left `700`); this heal is what the old updater invokes after replace.