### PR TITLE
fix: support fetching legacy RFC822 items

### DIFF
--- a/crates/chatmail-imap/src/session.rs
+++ b/crates/chatmail-imap/src/session.rs
@@ -1661,7 +1661,10 @@ fn fetch_response_mode(args: &str) -> FetchResponseMode {
     {
         return FetchResponseMode::Headers;
     }
-    if args.split_whitespace().any(|w| w == "RFC822") {
+    if args
+        .split_whitespace()
+        .any(|w| w.trim_matches(['(', ')']) == "RFC822")
+    {
         return FetchResponseMode::FullBody;
     }
     FetchResponseMode::Metadata
@@ -1963,6 +1966,16 @@ mod tests {
             fetch_response_mode("1 (UID RFC822.SIZE BODY.PEEK[])"),
             FetchResponseMode::FullBody
         );
+    }
+
+    #[test]
+    fn test_fetch_rfc822_is_full_body() {
+        // Clients send the item parenthesized (`FETCH 1:* (RFC822)`).
+        assert_eq!(
+            fetch_response_mode("1:* (RFC822)"),
+            FetchResponseMode::FullBody
+        );
+        assert_eq!(fetch_response_mode("1 RFC822"), FetchResponseMode::FullBody);
     }
 
     #[test]

--- a/crates/chatmail-www/src/handlers.rs
+++ b/crates/chatmail-www/src/handlers.rs
@@ -516,6 +516,9 @@ pub async fn websmtp_deliver(
     delivery.submit_authenticated(user, to, raw).await
 }
 
+// The Err variant is the very response we hand back to the client,
+// so boxing it would only add a deref at every call site.
+#[allow(clippy::result_large_err)]
 pub(crate) async fn webimap_authenticate(
     app: &chatmail_state::AppState,
     pool: &chatmail_db::DbPool,

--- a/crates/chatmail-www/src/webimap.rs
+++ b/crates/chatmail-www/src/webimap.rs
@@ -264,6 +264,9 @@ pub(crate) async fn find_entry(entries: &[InboxEntry], uid: u32) -> Option<Inbox
     entries.iter().find(|e| e.uid == uid).cloned()
 }
 
+// The Err variant is the very response we hand back to the client,
+// so boxing it would only add a deref at every call site.
+#[allow(clippy::result_large_err)]
 pub(crate) async fn build_detail(
     st: &WwwState,
     user: &str,

--- a/tests/imap_e2e.rs
+++ b/tests/imap_e2e.rs
@@ -157,6 +157,25 @@ async fn imap_e2e_fetch_header_fields_and_body() {
 }
 
 #[tokio::test]
+async fn imap_e2e_fetch_rfc822_returns_full_message() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let srv = spawn_mail_servers(dir.path()).await;
+    create_user(&srv.ctx, &srv.pool, USER, PASS).await;
+    deliver_message(&srv.ctx, USER, "m1", PGP_MIME_BODY).await;
+
+    let mut c = ImapClient::connect(srv.imap_addr).await;
+    c.command(&format!("r001 LOGIN {USER} {PASS}")).await;
+    c.command("r002 SELECT INBOX").await;
+
+    // Legacy RFC822 item is mandatory in IMAP4rev1 and equivalent to BODY[].
+    let full = c.command("r003 FETCH 1:* (RFC822)").await;
+    assert!(
+        full.contains("application/pgp-encrypted") || full.contains("multipart/encrypted"),
+        "RFC822 fetch must return the full message: {full}"
+    );
+}
+
+#[tokio::test]
 async fn imap_e2e_fetch_sequence_set() {
     let dir = tempfile::tempdir().expect("tempdir");
     let srv = spawn_mail_servers(dir.path()).await;


### PR DESCRIPTION
also fix a clippy issue that is on main in a separate commit. 
