### PR TITLE
feat(tls): load SEC1 EC keys and report certificate algorithm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,6 +1073,7 @@ dependencies = [
  "chatmail-types",
  "rustls",
  "rustls-pemfile",
+ "tempfile",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -339,7 +339,7 @@ run-debug: build ensure-dev-config
 dev-certs:
 	@mkdir -p $(STATE_DIR)/certs
 	@if [ ! -f $(STATE_DIR)/certs/fullchain.pem ]; then \
-		openssl req -x509 -newkey rsa:2048 -nodes \
+		openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:P-256 -nodes \
 			-keyout $(STATE_DIR)/certs/privkey.pem \
 			-out $(STATE_DIR)/certs/fullchain.pem \
 			-days 3650 \

--- a/crates/chatmail-acme/src/lib.rs
+++ b/crates/chatmail-acme/src/lib.rs
@@ -17,7 +17,7 @@
 
 //! TLS certificate issuance for madmail-v2 (Madmail-compatible paths).
 //!
-//! - **self_signed** — local/IP testing (`/var/lib/<binary>/certs/`)
+//! - **self_signed** — local/IP testing (`/var/lib/<binary>/certs/`), ECDSA P-256
 //! - **autocert** — Let's Encrypt via HTTP-01 (`madmail certificate get|regenerate`)
 //! - **IP autocert** — Let's Encrypt short-lived profile (~6 days) for public IPs
 

--- a/crates/chatmail-acme/src/self_signed.rs
+++ b/crates/chatmail-acme/src/self_signed.rs
@@ -20,9 +20,9 @@
 use std::path::Path;
 
 use chatmail_types::{ChatmailError, Result};
-use rcgen::generate_simple_self_signed;
+use rcgen::{CertificateParams, KeyPair, PKCS_ECDSA_P256_SHA256};
 
-/// Generate and write a self-signed cert/key pair (~1 year via rcgen defaults).
+/// Generate and write a self-signed ECDSA P-256 cert/key pair.
 pub fn generate_self_signed(
     primary_domain: &str,
     hostname: &str,
@@ -39,14 +39,18 @@ pub fn generate_self_signed(
     names.sort();
     names.dedup();
 
-    let cert =
-        generate_simple_self_signed(names).map_err(|e| ChatmailError::config(e.to_string()))?;
+    let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256)
+        .map_err(|e| ChatmailError::config(format!("generate ECDSA P-256 key: {e}")))?;
+    let cert = CertificateParams::new(names)
+        .map_err(|e| ChatmailError::config(e.to_string()))?
+        .self_signed(&key_pair)
+        .map_err(|e| ChatmailError::config(e.to_string()))?;
 
     write_pem_pair(
         cert_path,
         key_path,
-        cert.cert.pem().as_bytes(),
-        cert.key_pair.serialize_pem().as_bytes(),
+        cert.pem().as_bytes(),
+        key_pair.serialize_pem().as_bytes(),
     )
 }
 

--- a/crates/chatmail-acme/src/status.rs
+++ b/crates/chatmail-acme/src/status.rs
@@ -40,6 +40,8 @@ pub struct CertificateInfo {
     pub days_remaining: i64,
     pub subject_alt_names: Vec<String>,
     pub issuer_kind: CertIssuerKind,
+    /// Public-key algorithm (`ecdsa-p256`, `rsa-2048`, …).
+    pub key_algorithm: String,
 }
 
 pub fn read_certificate_info(cert_path: &Path) -> Result<Option<CertificateInfo>> {
@@ -55,6 +57,7 @@ pub fn read_certificate_info(cert_path: &Path) -> Result<Option<CertificateInfo>
     let days_remaining = days_until(cert.not_after())?;
     let subject_alt_names = extract_subject_alt_names(&cert);
     let issuer_kind = classify_issuer(&issuer, &subject);
+    let key_algorithm = describe_key_algorithm(&cert);
     Ok(Some(CertificateInfo {
         issuer,
         subject,
@@ -63,6 +66,7 @@ pub fn read_certificate_info(cert_path: &Path) -> Result<Option<CertificateInfo>
         days_remaining,
         subject_alt_names,
         issuer_kind,
+        key_algorithm,
     }))
 }
 
@@ -101,6 +105,30 @@ fn ip_to_string(bytes: &[u8]) -> Option<String> {
             Some(std::net::IpAddr::from(octets).to_string())
         }
         _ => None,
+    }
+}
+
+fn describe_key_algorithm(cert: &X509) -> String {
+    let Ok(pkey) = cert.public_key() else {
+        return "unknown".into();
+    };
+    match pkey.id() {
+        openssl::pkey::Id::RSA => format!("rsa-{}", pkey.bits()),
+        openssl::pkey::Id::EC => match pkey.ec_key() {
+            Ok(ec) => match ec.group().curve_name() {
+                Some(openssl::nid::Nid::X9_62_PRIME256V1) => "ecdsa-p256".into(),
+                Some(openssl::nid::Nid::SECP384R1) => "ecdsa-p384".into(),
+                Some(openssl::nid::Nid::SECP521R1) => "ecdsa-p521".into(),
+                Some(nid) => format!(
+                    "ecdsa-{}",
+                    nid.short_name().unwrap_or("unknown").to_ascii_lowercase()
+                ),
+                None => format!("ecdsa-{}", pkey.bits()),
+            },
+            Err(_) => "ecdsa".into(),
+        },
+        openssl::pkey::Id::ED25519 => "ed25519".into(),
+        other => format!("id-{}", other.as_raw()),
     }
 }
 
@@ -144,6 +172,20 @@ mod tests {
         generate_self_signed("[1.2.3.4]", "1.2.3.4", "1.2.3.4", &cert, &key).unwrap();
         let info = read_certificate_info(&cert).unwrap().unwrap();
         assert_eq!(info.issuer_kind, CertIssuerKind::SelfSigned);
+        assert_eq!(info.key_algorithm, "ecdsa-p256");
         assert!(info.days_remaining > 0);
+        let key_pem = std::fs::read_to_string(&key).unwrap();
+        assert!(
+            key_pem.contains("-----BEGIN PRIVATE KEY-----"),
+            "self-signed key should be PKCS#8: {key_pem}"
+        );
+        assert!(
+            !key_pem.contains("BEGIN EC PRIVATE KEY"),
+            "self-signed key must not be SEC1 EC: {key_pem}"
+        );
+        assert!(
+            !key_pem.contains("BEGIN RSA PRIVATE KEY"),
+            "self-signed key must not be RSA PKCS#1"
+        );
     }
 }

--- a/crates/chatmail-tls/Cargo.toml
+++ b/crates/chatmail-tls/Cargo.toml
@@ -8,3 +8,6 @@ license.workspace = true
 chatmail-types = { workspace = true }
 rustls = { workspace = true }
 rustls-pemfile = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/chatmail-tls/src/lib.rs
+++ b/crates/chatmail-tls/src/lib.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 use chatmail_types::{ChatmailError, Result};
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use rustls::ServerConfig;
-use rustls_pemfile::{certs, pkcs8_private_keys, rsa_private_keys};
+use rustls_pemfile::{certs, private_key};
 
 pub fn load_server_config(cert_path: &Path, key_path: &Path) -> Result<Arc<ServerConfig>> {
     let certs = load_certs(cert_path)?;
@@ -61,19 +61,126 @@ fn load_private_key(path: &Path) -> Result<PrivateKeyDer<'static>> {
         ChatmailError::config(format!("open TLS private key {}: {e}", path.display()))
     })?;
     let mut reader = BufReader::new(file);
-    if let Some(key) = pkcs8_private_keys(&mut reader)
-        .filter_map(|r| r.ok())
-        .next()
-    {
-        return Ok(PrivateKeyDer::Pkcs8(key));
+    private_key(&mut reader)
+        .map_err(|e| {
+            ChatmailError::config(format!("parse TLS private key {}: {e}", path.display()))
+        })?
+        .ok_or_else(|| {
+            ChatmailError::config(format!(
+                "no private key in {} (expected PKCS#8, PKCS#1 RSA, or SEC1 EC PEM)",
+                path.display()
+            ))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// OpenSSL `ecparam` / `-newkey ec` traditional form (`BEGIN EC PRIVATE KEY`).
+    const EC_SEC1_KEY: &str = "-----BEGIN EC PRIVATE KEY-----\n\
+MHcCAQEEIGL6GcbyVjjvOuVBu47P1AQ34r7B/rGjVn+I4cBTkyv2oAoGCCqGSM49\n\
+AwEHoUQDQgAE0ek+2wDB9xWTkAhZBcScLJivmBPt5NzmfT8q775JxbWzNhSz5nfq\n\
+CE5nnild39Ce+2fo1w76XqJz47/qojqh7A==\n\
+-----END EC PRIVATE KEY-----\n";
+
+    const EC_CERT: &str = "-----BEGIN CERTIFICATE-----\n\
+MIIBeDCCAR+gAwIBAgIUYQJVIT1R/TuS7Ev8bSZMa5OgAfEwCgYIKoZIzj0EAwIw\n\
+EjEQMA4GA1UEAwwHZWMudGVzdDAeFw0yNjA4MjUxNjE1MzlaFw0zNjA4MjIxNjE1\n\
+MzlaMBIxEDAOBgNVBAMMB2VjLnRlc3QwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNC\n\
+AATR6T7bAMH3FZOQCFkFxJwsmK+YE+3k3OZ9PyrvvknFtbM2FLPmd+oITmeeKV3f\n\
+0J77Z+jXDvpeonPjv+qiOqHso1MwUTAdBgNVHQ4EFgQUitXADSHqDFYPKxy16aeP\n\
+yoNLuVMwHwYDVR0jBBgwFoAUitXADSHqDFYPKxy16aePyoNLuVMwDwYDVR0TAQH/\n\
+BAUwAwEB/zAKBggqhkjOPQQDAgNHADBEAiAI5nAYmVQFXh4SZnqDbP2nltjmWqsl\n\
+HPpOM0tP7Tv6BAIgFdCfiDj71XV2B2zi5Nfsikrksge3sbQ8UN51AAvzesA=\n\
+-----END CERTIFICATE-----\n";
+
+    const RSA_PKCS1_KEY: &str = "-----BEGIN RSA PRIVATE KEY-----\n\
+MIIEowIBAAKCAQEAkYVfxYC7zI4B3N9pjGr85MdIqP81viKx871zG8WJA70vtUJj\n\
+7UTJsvg/xVUVXFH7Yl2/6/5Auo17EbHRkmjfiT3OpnGt0adAm1reP2+7xxBp9oXX\n\
+fY5qHevahclSSXIjcFBdzJGnBYVO7/LZf6M9enJCg7JMdO990TDi7n77pEMxBO3X\n\
++8HfnP1fnW+5O1mfQTxIrbY2mnYA9LhGCkc7uVRvLyBR1bx8A0FyKKN8v3Iyupav\n\
+o+hYFYRcNFsZ9OI3sYrgHB3wN3JhwO+0eA7V7Vlid1rcLF3+3jyPp8o2UFbkCuES\n\
+uEe2kYdBJ+NVWanYgSU/BKk+EkzVapevDnhXAwIDAQABAoIBADQErEaKjRdDEBFn\n\
+X3CNchdJ0YRvrkNoXZpWd4ZO53qJrzspH1VaiItMSGd+0aLtv2HbR1bRzUuidYLO\n\
+wK6IhJenm25OJqdSFTszkUy14Tb4fBheobhFJ1PI0pWOcLbGcTqdz9nnmv/TNnN5\n\
+qRwCO2DA5Vv0aXZHgf88bXJ5u/RscmHhUnA4v4i94eE8t78DN7Yurt1/VUe0O0Mv\n\
+OPtcpNAAIxLge1JQNmM/KMzoGX0on830k1NS2xPDrZdMkQhjcMo6j41S7HYG2lZc\n\
+wrEjf8bMklWBwrzK7I8wlkvTAeTQSBHrFrGpZA2P/rPa210ve+vjiabBkcAnVsqo\n\
+/dvLi+kCgYEAw4FolziPZ3lu+qU15naPS8eQM2kg7n1/0eJUFe1MgtehCXCwH+2v\n\
+9xHJDJDn+LIUZv2YIFsZZMRiIaiNcAPq2pAcCL4G/wD0BHjesX3iW12bOBjEEmME\n\
+gbJvi9S/t7vtMMYGDae6ex136lPAxogXY7+rKpziyEDX1lROLYLp8JcCgYEAvoyJ\n\
++yt6EcDSNwovK0u8Ne8Hp9DCfc+OX1WXL1/qL9fNCypJh/PKSmY24rZrDUcYcGNw\n\
+WGhEUatuSqSFEYNhJs1oOLjydRvs3u9HaI+bJ26pSts0te+fIF98kmRMOhDdb3NI\n\
+91pxZFV5IEIPZkQYOB1ZzgG9/yt0l7vzi05H7nUCgYB5smVDtJ53n7x4YzzRD74V\n\
+Qs09Y1RvgEl/ga4r1AILdGQ2tyG7Tj55wmVu4Ai140wV7Ae1JGADPMeFAiHAt3+K\n\
+u6fnvTonpBVBb2fX/m9XxkXnvmrWszJL9aG/3hfVLDLyaGG+QEkxd998StQ2AOLm\n\
+YZoPtYbpdoukS+g6JkKvUwKBgGYV1yqYXVq7iiPwsdqpRZlDiT9wCXLryuPqcAfy\n\
+g/3DyNdtfV13z+3SGx+VCX9gkohLzfmfStLSXFFjGOOMFnV6YJbbBxKUtm+tk/1B\n\
+yqbyk4JGNFQwn3jxj0TCtU/6jxfRlMroSo2teSo+Gg/49VzC5MUIi+j0OA++ozkD\n\
+5GetAoGBALtPP2HiQRQWQBb07UUuDrQ2+iGMm9yryuKJ6Aopm+B2MWkKlKyzs9CX\n\
+p7A91wW33eB953C7FwpsYQY/AQ6JdcExw+XqCV1GZkI0akl1vK14xCFarF9UH5+O\n\
+T3gLGQ9RX6lgTT8YrxnfRMkV2Lol26Wuce/puVDMhiIXKLYqnZ/c\n\
+-----END RSA PRIVATE KEY-----\n";
+
+    const RSA_CERT: &str = "-----BEGIN CERTIFICATE-----\n\
+MIIDBzCCAe+gAwIBAgIUEobW2dCEL5ISxgaLvFZgg1RyK3IwDQYJKoZIhvcNAQEL\n\
+BQAwEzERMA8GA1UEAwwIcnNhLnRlc3QwHhcNMjYwODI1MTYxNTQwWhcNMzYwODIy\n\
+MTYxNTQwWjATMREwDwYDVQQDDAhyc2EudGVzdDCCASIwDQYJKoZIhvcNAQEBBQAD\n\
+ggEPADCCAQoCggEBAJGFX8WAu8yOAdzfaYxq/OTHSKj/Nb4isfO9cxvFiQO9L7VC\n\
+Y+1EybL4P8VVFVxR+2Jdv+v+QLqNexGx0ZJo34k9zqZxrdGnQJta3j9vu8cQafaF\n\
+132Oah3r2oXJUklyI3BQXcyRpwWFTu/y2X+jPXpyQoOyTHTvfdEw4u5++6RDMQTt\n\
+1/vB35z9X51vuTtZn0E8SK22Npp2APS4RgpHO7lUby8gUdW8fANBciijfL9yMrqW\n\
+r6PoWBWEXDRbGfTiN7GK4Bwd8DdyYcDvtHgO1e1ZYnda3Cxd/t48j6fKNlBW5Arh\n\
+ErhHtpGHQSfjVVmp2IElPwSpPhJM1WqXrw54VwMCAwEAAaNTMFEwHQYDVR0OBBYE\n\
+FIUhRvPq09F5RZGfJQvO0+3XdyHdMB8GA1UdIwQYMBaAFIUhRvPq09F5RZGfJQvO\n\
+0+3XdyHdMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAIvhr2z+\n\
+OsedAQpyni3uKthldo48A1quZJFZaOw9zdWcyPfX/6vbq08VXGhmCAYxsQLMcUdT\n\
+PruNxnDGw3vhWXHY1333vZ97wJO4BAYqwS9iuCjRfLfpeskJPYcQEl/6pvjciwhl\n\
+MKiIE5xU8T7AujUegw8KphoV3Xc/+2raeRxjJT0n4ipS0WniTcvvEcUwqTqtGzYV\n\
+VYqtDttoAtOQMGDfCo6yuGQ5SY11xVaC0pc9vlZdtWOoYdbtRNzvb6HinvhUSFjf\n\
+uYqvPfQ1h65fbVyoAel0qh88mghAcKN9QwKpO2Cg2IvNrRApO5nuOPaabUgmg86d\n\
+BCsnj4xR6GA3R0A=\n\
+-----END CERTIFICATE-----\n";
+
+    fn write_pair(
+        cert_pem: &str,
+        key_pem: &str,
+    ) -> (tempfile::NamedTempFile, tempfile::NamedTempFile) {
+        let mut cert = tempfile::NamedTempFile::new().unwrap();
+        let mut key = tempfile::NamedTempFile::new().unwrap();
+        cert.write_all(cert_pem.as_bytes()).unwrap();
+        key.write_all(key_pem.as_bytes()).unwrap();
+        cert.flush().unwrap();
+        key.flush().unwrap();
+        (cert, key)
     }
-    let file = File::open(path).map_err(|e| {
-        ChatmailError::config(format!("open TLS private key {}: {e}", path.display()))
-    })?;
-    let mut reader = BufReader::new(file);
-    let key = rsa_private_keys(&mut reader)
-        .filter_map(|r| r.ok())
-        .next()
-        .ok_or_else(|| ChatmailError::config(format!("no private key in {}", path.display())))?;
-    Ok(PrivateKeyDer::Pkcs1(key))
+
+    fn init_crypto() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    }
+
+    #[test]
+    fn loads_sec1_ecdsa_p256() {
+        init_crypto();
+        let (cert, key) = write_pair(EC_CERT, EC_SEC1_KEY);
+        load_server_config(cert.path(), key.path()).expect("SEC1 EC key must load");
+    }
+
+    #[test]
+    fn loads_rsa_pkcs1() {
+        init_crypto();
+        let (cert, key) = write_pair(RSA_CERT, RSA_PKCS1_KEY);
+        load_server_config(cert.path(), key.path()).expect("PKCS#1 RSA key must load");
+    }
+
+    #[test]
+    fn rejects_empty_key_file() {
+        let (cert, key) = write_pair(EC_CERT, "");
+        let err = load_server_config(cert.path(), key.path()).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("no private key"), "{msg}");
+        assert!(msg.contains("SEC1"), "{msg}");
+    }
 }

--- a/crates/chatmail/src/ctl/certificate.rs
+++ b/crates/chatmail/src/ctl/certificate.rs
@@ -299,6 +299,7 @@ async fn certificate_status(args: &Args) -> Result<()> {
             "not_before": info.not_before,
             "not_after": info.not_after,
             "days_remaining": info.days_remaining,
+            "key_algorithm": info.key_algorithm,
             "status": status,
         }));
     }
@@ -322,6 +323,7 @@ async fn certificate_status(args: &Args) -> Result<()> {
     out.line(format!("Certificate:     {}", cert_path.display()));
     out.line(format!("Private key:     {}", key_path.display()));
     out.line(format!("\nCertificate type: {cert_kind}"));
+    out.line(format!("Key algorithm:   {}", info.key_algorithm));
     out.line(format!("Issuer:          {}", info.issuer));
     if !info.subject.is_empty() {
         out.line(format!("Subject:         {}", info.subject));

--- a/docs/TDD/19-certificates.md
+++ b/docs/TDD/19-certificates.md
@@ -17,14 +17,16 @@ tls file /var/lib/madmail/certs/fullchain.pem /var/lib/madmail/certs/privkey.pem
 
 Let's Encrypt is obtained **out-of-band** via CLI (`madmail certificate get`) or during `madmail install --tls-mode autocert`. The server only loads PEM files.
 
+**Key algorithms:** install / self-signed / ACME `finalize` emit **ECDSA P-256** (PKCS#8 PEM). `tls file` / `--tls-mode file` also loads operator PEMs: PKCS#8 (RSA or EC), traditional PKCS#1 RSA (`BEGIN RSA PRIVATE KEY`), and SEC1 EC (`BEGIN EC PRIVATE KEY`). rustls-ring cannot generate RSA, so RSA remains bring-your-own. DKIM stays RSA-2048 (`k=rsa`) for cmdeploy `filtermail`.
+
 ## TLS modes (`install` / auto-detect)
 
 | Mode | CLI | Behaviour |
 |------|-----|-----------|
 | `autocert` | `--tls-mode autocert --acme-email admin@domain` | HTTP-01 via instant-acme (DNS name) → writes `certs/*.pem`, account in `autocert/le-account.json` |
 | `autocert` (IP) | `--simple --ip PUBLIC_IP --auto-ip-cert --acme-email user@domain` | HTTP-01 via instant-acme, Let's Encrypt **shortlived** profile (~6-day IP cert) — see [`../install-simple-ip-acme.md`](../install-simple-ip-acme.md) |
-| `file` | `--tls-mode file --cert-path … --key-path …` | Use existing PEMs (certbot, Caddy, etc.) |
-| `self_signed` | `--tls-mode self_signed` or `--simple --ip` (without `--auto-ip-cert`) | rcgen self-signed in `certs/` (IP SANs via DNS names for bracket domains) |
+| `file` | `--tls-mode file --cert-path … --key-path …` | Use existing PEMs (RSA or EC; PKCS#8 / PKCS#1 / SEC1) |
+| `self_signed` | `--tls-mode self_signed` or `--simple --ip` (without `--auto-ip-cert`) | rcgen self-signed **ECDSA P-256** in `certs/` (IP SANs via DNS names for bracket domains) |
 
 Auto-detect (no `--tls-mode`):
 

--- a/docs/guide/cli/certificate-status.md
+++ b/docs/guide/cli/certificate-status.md
@@ -2,7 +2,7 @@
 
 Parent: [`certificate`](certificate.md)
 
-Show certificate management mode and validity
+Show certificate management mode, validity, and key algorithm (`ecdsa-p256`, `rsa-2048`, …).
 
 ## Synopsis
 

--- a/docs/guide/cli/certificate.md
+++ b/docs/guide/cli/certificate.md
@@ -2,6 +2,8 @@
 
 TLS certificate management: Let's Encrypt HTTP-01 issuance, status, and in-process autocert renewal.
 
+Self-signed and Let's Encrypt keys are **ECDSA P-256**. Operator-supplied PEMs (`tls-mode file`) may be RSA or EC (PKCS#8, PKCS#1 RSA, or SEC1 `BEGIN EC PRIVATE KEY`). `madmail certificate status` prints `key_algorithm` (`ecdsa-p256`, `rsa-2048`, …).
+
 
 ## Synopsis
 

--- a/docs/guide/cli/install.md
+++ b/docs/guide/cli/install.md
@@ -59,7 +59,7 @@ On **Windows**, default install paths are `%ProgramData%\Madmail\config` and `%P
 | `--install-service` | Register Windows service after install (no-op notice on Unix) |
 | `--start-service` | Start Windows service after install |
 | `--firewall` | Open Windows Firewall rules for mail/HTTP ports |
-| `--tls-mode` | `autocert`, `file`, or `self_signed` |
+| `--tls-mode` | `autocert`, `file`, or `self_signed` (self-signed and ACME keys are **ECDSA P-256**; `--tls-mode file` accepts RSA or EC PEMs, including `BEGIN EC PRIVATE KEY`) |
 | `--acme-email`, `--auto-ip-cert`, `--obtain-certificate`, `--no-obtain-certificate`, `--cert-only`, `--http-listen` | TLS issuance |
 | `--lang` | UI language: `en`, `fa`, `ru`, `es` |
 | `--skip-systemd`, `--skip-user` | Container / CI installs |

--- a/docs/guide/cli/json-output.md
+++ b/docs/guide/cli/json-output.md
@@ -236,10 +236,18 @@ Dry-run / completed uninstall returns paths and flags in `data`. When nothing to
   "ok": true,
   "command": "certificate status",
   "data": {
-    "tls_mode": "autocert",
+    "tls_management": "autocert (Let's Encrypt, auto-managed)",
     "domain": "mail.example.org",
-    "valid": true,
-    "expires_at": "2026-09-01T12:00:00Z"
+    "cert_path": "/var/lib/madmail/certs/fullchain.pem",
+    "cert_type": "Let's Encrypt (auto-managed)",
+    "issuer": "C=US, O=Let's Encrypt, CN=R11",
+    "subject": "CN=mail.example.org",
+    "sans": ["mail.example.org"],
+    "not_before": "Aug  1 00:00:00 2026 GMT",
+    "not_after": "Oct 30 00:00:00 2026 GMT",
+    "days_remaining": 66,
+    "key_algorithm": "ecdsa-p256",
+    "status": "valid"
   }
 }
 ```

--- a/docs/project/user-guide/11-deployment-ip-domain-certs.md
+++ b/docs/project/user-guide/11-deployment-ip-domain-certs.md
@@ -52,7 +52,7 @@ Just omit the `--auto-ip-cert` flag:
 madmail install --simple --ip 203.0.113.50
 ```
 
-The installer will generate a self-signed certificate for the IP address.
+The installer will generate a self-signed **ECDSA P-256** certificate for the IP address. You can also point `--tls-mode file` at an existing RSA or EC PEM pair (including OpenSSL `BEGIN EC PRIVATE KEY`).
 
 ### After install
 


### PR DESCRIPTION
Fixes #134.

## Summary

Install and Let's Encrypt already issued **ECDSA P-256** keys (rcgen / ACME `finalize`). What failed was **loading** operator EC PEMs in OpenSSL traditional form (`BEGIN EC PRIVATE KEY`) — `tls-mode file` / certbot-style keys. The loader now uses `rustls_pemfile::private_key()` (PKCS#8, PKCS#1 RSA, and SEC1 EC).

- Self-signed generation is explicitly ECDSA P-256 PKCS#8.
- `madmail certificate status` prints `key_algorithm` (`ecdsa-p256`, `rsa-2048`, …), including `--json`.
- `make dev-certs` uses P-256 instead of `rsa:2048`.
- RSA PEMs still work. DKIM stays RSA-2048 (`k=rsa`) for cmdeploy filtermail. rustls-ring cannot generate RSA, so RSA remains bring-your-own.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Area

- [x] SMTP
- [x] IMAP
- [x] Configuration / CLI
- [x] Docs (`docs/project/`, `docs/TDD`, user guide)
- [x] Other: TLS PEM loader / self-signed install

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (via `make lint` before the last nits)
- [x] `cargo test --workspace` (955 passed, 0 failed, 3 ignored live TURN/docker)
- [x] Targeted after nits: `chatmail-acme`, `chatmail-tls`, `chatmail` `tls_boot`
- [x] Manual / E2E verification (describe below)

**Manual verification (if any):**

```text
Self-signed install: PKCS#8 P-256, TLS 1.3 on :443
Convert privkey to SEC1 (BEGIN EC PRIVATE KEY), restart: status ecdsa-p256, HTTPS + IMAPS TLS 1.3
Replace with RSA PKCS#1 2048: status rsa-2048, HTTPS + IMAPS still TLS 1.3
Windows-related crate tests (tls_boot, service_cmd, firewall_cmd, tray) passed locally; no mingw on this host for .exe cross-compile
```

## Documentation

- [x] Updated operator/user docs (`docs/project/user-guide/`, install guides)
- [x] Updated developer docs (`docs/TDD/19-certificates.md`)
- [x] CLI: certificate / install / json-output / certificate-status

## Security & privacy

- [x] Security-sensitive — added/updated tests for the security property (SEC1 + PKCS#1 load; empty-key error)
- [x] Reviewed error messages for information leakage (lists expected PEM types, not key material)

## Commits

- `feat:` new feature

## Checklist

- [x] PR is focused and reviewable (small vertical slices preferred)
- [x] No secrets, `data/`, `target/`, or `node_modules/` committed
- [x] Submodule pointers updated if `external/madmail-admin-web` changed (N/A)
- [x] Behavior parity with Madmail v1 considered (or intentional difference documented)