### PR TITLE
docs: PostgreSQL as an empty-database backend (not a SQLite conversion)

### DIFF
--- a/docs/TDD/13-configuration.md
+++ b/docs/TDD/13-configuration.md
@@ -42,14 +42,14 @@ Environment substitution `{env:VAR}` in values is expanded when the variable is 
 |-----------|-------------------|
 | `auto_create yes` | `auth_auto_create` |
 | `jit_domain` | `jit_domain` (defaults to `primary_domain`) |
-| `table sql_table { driver; dsn }` | `credentials_driver`, `credentials_dsn` |
+| `table sql_table { driver; dsn }` | `credentials_driver`, `credentials_dsn` — **this is the application database v2 opens** (`sqlite3` file or `postgres` DSN) |
 | `dsn credentials.db` | `credentials_dsn` (legacy / flat form, relative to `state_dir` for SQLite) |
 
 ### `storage.imapsql`
 
 | Directive | `AppConfig` field |
 |-----------|-------------------|
-| `driver` / `dsn` | `imapsql_driver`, `imapsql_dsn` — `sqlite3` (default) or `postgres` (libpq DSN; Madmail schema import supported) |
+| `driver` / `dsn` | `imapsql_driver`, `imapsql_dsn` — `sqlite3` (default) or `postgres` (libpq or `postgres://` DSN). Set the **same** DSN as `auth.pass_table` so the file is not misleading; v2 does not open a second SQL database. Operator guide: [18-postgres.md](../project/user-guide/18-postgres.md) (empty database only — not a SQLite file conversion). |
 | `default_quota` | `default_quota` (e.g. `1G`) |
 | `retention` | `retention` (e.g. `24h`) — hourly maildir purge when server runs; see [`21-scheduled-maintenance.md`](21-scheduled-maintenance.md) |
 | `unused_account_retention` | `unused_account_retention` (e.g. `720h`) — delete never-logged-in accounts |

--- a/docs/TDD/17-data-models.md
+++ b/docs/TDD/17-data-models.md
@@ -2,7 +2,7 @@
 
 madmail-v2 uses **one consolidated database** (`state_dir/chatmail.db` for SQLite, or Postgres DSN from `maddy.conf`) containing the Madmail **imapsql** extension tables. Madmail splits `credentials.db` (auth KV) and `imapsql.db` (everything else); madmail-v2 can still read Madmail `passwords` tables that use `key`/`value` columns.
 
-**Backends:** SQLite (default) and **Postgres** (`DbPool::Postgres`, `migrations/postgres/`). Postgres supports Madmail schema import plus extension migrations.
+**Backends:** SQLite (default) and **Postgres** (`DbPool::Postgres`, `migrations/postgres/`). Postgres supports Madmail schema import plus extension migrations. Switching `driver` to `postgres` does **not** copy an existing SQLite file; operator how-to (empty DB): [user-guide/18-postgres.md](../project/user-guide/18-postgres.md).
 
 Schema source of truth in code: `crates/chatmail-db/migrations/` (SQLite + Postgres variants).
 

--- a/docs/guide/docker.md
+++ b/docs/guide/docker.md
@@ -612,7 +612,7 @@ After `madmail install`, hostname and domain are written into `/etc/madmail/madm
 
 ## Custom configuration
 
-To use your own config (domain, autocert, Postgres, Shadowsocks, etc.), place `madmail.conf` under `/etc/madmail` on the host and bind-mount the three paths. The default image entrypoint already points at `/etc/madmail/madmail.conf` and `/var/lib/madmail`:
+To use your own config (domain, autocert, Postgres, Shadowsocks, etc.), place `madmail.conf` under `/etc/madmail` on the host and bind-mount the three paths. The default image entrypoint already points at `/etc/madmail/madmail.conf` and `/var/lib/madmail`. Postgres is a **driver/DSN in that file**, not a Compose environment variable; use it for an empty database, not to convert SQLite — [PostgreSQL operator guide](../project/user-guide/18-postgres.md).
 
 ```bash
 cp assets/madmail.conf.docker /etc/madmail/madmail.conf
@@ -731,3 +731,4 @@ The Dockerfile uses three stages: admin-web (Bun), Rust compile (Alpine), and Al
 - [Install: public IP + Let's Encrypt](../install-simple-ip-acme.md)
 - [Configuration](../project/06-configuration-system.md)
 - [Admin UI and CLI](../project/user-guide/07-admin-and-cli.md)
+- [PostgreSQL](postgres.md) — optional application database (empty DB, not a SQLite conversion)

--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -1,6 +1,6 @@
 # Native install guide (`madmail install`)
 
-`madmail install` bootstraps a mail server: writes `madmail.conf`, TLS material, SQLite state, optional systemd unit, and (on system installs) a service user and binary under `/usr/local/bin/`.
+`madmail install` bootstraps a mail server: writes `madmail.conf`, TLS material, SQLite state, optional systemd unit, and (on system installs) a service user and binary under `/usr/local/bin/`. PostgreSQL is an optional application-database backend for a **new empty** database after install — [operator guide](../project/user-guide/18-postgres.md). Changing `driver` does not copy an existing SQLite file.
 
 The command is **Madmail-compatible**. The binary name (`madmail`, `chatmail`, …) is taken from `argv[0]` and drives config filenames, systemd unit name, and service user name.
 
@@ -408,3 +408,4 @@ For IP/self-signed relays, Delta Chat clients may need to accept self-signed cer
 - [CLI JSON output](cli/json-output.md) — `--json` schemas for scripting
 - [CLI tools (TDD)](../TDD/14-cli-tools.md) — global flags and ctl overview
 - [Configuration (TDD)](../TDD/13-configuration.md) — runtime config after install
+- [PostgreSQL](postgres.md) — optional application database (empty DB, not a SQLite conversion)

--- a/docs/guide/postgres.md
+++ b/docs/guide/postgres.md
@@ -1,0 +1,7 @@
+# PostgreSQL
+
+Madmail v2 can use **PostgreSQL** instead of SQLite for the application database (accounts, settings, quotas, tokens, federation). Mail stays in Maildir.
+
+This is a **backend for an empty database**, not a copy of an existing SQLite file. `madmail install` still writes SQLite; you edit `driver` / `dsn` and restart. A SQLite → Postgres migration guide (and copy tool) is **in the works**.
+
+Operator guide: [PostgreSQL as the application database](../project/user-guide/18-postgres.md).

--- a/docs/project/04-crate-by-crate-tour.md
+++ b/docs/project/04-crate-by-crate-tour.md
@@ -61,7 +61,7 @@ Modules:
 
 **Critical tables** (from migrations): `settings`, `passwords`, `quotas`, `blocked_users`, `registration_tokens`, `federation_stats`, `dns_overrides`.
 
-Also has Postgres migrations (for future or alternate deploys).
+Also has Postgres migrations (alternate application-database backend; operator guide: [user-guide/18-postgres.md](./user-guide/18-postgres.md)).
 
 ### `chatmail-state`
 

--- a/docs/project/12-storage-and-persistence.md
+++ b/docs/project/12-storage-and-persistence.md
@@ -4,9 +4,9 @@ This document explains where mail lives, how quota is enforced, and how the fast
 
 ## The Two Kinds of Data
 
-### 1. Structured / Small / Hot Data → SQLite
+### 1. Structured / Small / Hot Data → SQLite or PostgreSQL
 
-`chatmail.db` (or `credentials.db` in some paths) via `chatmail-db`.
+`chatmail.db` / `credentials.db` (SQLite) or a Postgres DSN via `chatmail-db`. Operator guide for a **new empty** Postgres database: [user-guide/18-postgres.md](./user-guide/18-postgres.md). That is not a conversion of an existing SQLite file.
 
 Tables for:
 - Settings (dynamic config)

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -65,7 +65,7 @@ This `docs/project/` area now contains both the deep code-understanding series a
 - **PGP-only by design** for Delta Chat users (enforced in SMTP DATA, APPEND, /mxdeliv).
 - **Just-In-Time (JIT) registration** — accounts created on first login or `/new`.
 - **Hybrid federation** — preferred HTTP POST /mxdeliv, fallback to SMTP.
-- **Hot in-memory state** (`AppState`) + write-through to SQLite + Maildir.
+- **Hot in-memory state** (`AppState`) + write-through to SQLite or PostgreSQL + Maildir. Postgres is an optional empty-database backend, not a SQLite conversion ([user-guide/18-postgres.md](./user-guide/18-postgres.md)).
 - **Dynamic config** via DB `settings` table (most things reloadable without restart).
 - **Self-contained deploys** — admin web SPA can be compiled into the binary.
 - **Privacy / No-Log** and strong defaults.

--- a/docs/project/user-guide/01-what-is-chatmail.md
+++ b/docs/project/user-guide/01-what-is-chatmail.md
@@ -20,7 +20,7 @@ Delta Chat uses this protocol. Instead of building yet another closed messenger,
 | **Shadowsocks**         | Stealth deployment in restricted networks                       |
 | **ACME / TLS**          | Automatic certificate management                                |
 | **Quota & blocklist**   | Per-account limits and federation policy (ACCEPT/REJECT)        |
-| **SQLite + PostgreSQL** | Both backends supported; live config reload without restart     |
+| **SQLite + PostgreSQL** | Both backends supported; live config reload without restart. Postgres is a **new empty database**, not a SQLite conversion — [operator guide](./18-postgres.md). |
 
 
 

--- a/docs/project/user-guide/02-quick-start.md
+++ b/docs/project/user-guide/02-quick-start.md
@@ -234,8 +234,8 @@ You can override this with `--state-dir` on the command line or the `state_dir` 
 ```
 state_dir/
 ├── admin_token                  # 64-character admin API token (file permissions 0600)
-├── chatmail.db                  # Main SQLite database (settings, accounts, quotas, federation stats, blocklist, etc.)
-├── credentials.db               # Legacy authentication database (used by some older paths)
+├── chatmail.db                  # Main SQLite database when using the default driver (settings, accounts, quotas, …)
+├── credentials.db               # Legacy / install default SQLite file (`auth.pass_table` `dsn`)
 ├── mail/                        # All user mailboxes in Maildir format
 │   ├── alice@example.com/
 │   │   └── Maildir/
@@ -268,7 +268,7 @@ state_dir/
 
 ### Backups
 
-The simplest reliable backup is a snapshot or copy of the entire `state_dir` (ideally while the service is stopped, or using proper tools that handle SQLite WAL files correctly).
+The simplest reliable backup is a snapshot or copy of the entire `state_dir` (ideally while the service is stopped, or using proper tools that handle SQLite WAL files correctly). If the application database is **PostgreSQL**, back that up separately — see [PostgreSQL as the application database](./18-postgres.md). `madmail install` always writes SQLite; Postgres is an optional backend for an **empty** database, not a conversion of an existing SQLite file. A SQLite → Postgres copy tool is in the works.
 
 ## Self-Serving Binary and Documentation
 

--- a/docs/project/user-guide/07-admin-and-cli.md
+++ b/docs/project/user-guide/07-admin-and-cli.md
@@ -9,6 +9,8 @@ There are two main ways to manage a server:
 
 Both talk to the same underlying system.
 
+The application database defaults to SQLite (`credentials.db` / `chatmail.db`). PostgreSQL is optional for a **new empty** database — [PostgreSQL operator guide](./18-postgres.md). Changing `driver` does not copy existing SQLite data.
+
 One particularly useful CLI command for production servers is `madmail upgrade` (see the Quick Start guide for how signed binary upgrades work).
 
 ## The Web Admin Dashboard

--- a/docs/project/user-guide/10-troubleshooting.md
+++ b/docs/project/user-guide/10-troubleshooting.md
@@ -137,8 +137,10 @@ When something is really not working, these commands are your friends:
 ```bash
 madmail status                 # basic health
 madmail logs                   # if your system uses journalctl or similar
-sqlite3 /var/lib/madmail/chatmail.db "SELECT * FROM settings;"   # Linux default path
+sqlite3 /var/lib/madmail/chatmail.db "SELECT * FROM settings;"   # Linux default path (SQLite backend)
 ```
+
+On PostgreSQL, inspect `settings` with `psql` against the DSN in `auth.pass_table`. See [PostgreSQL as the application database](./18-postgres.md) (empty database, not a SQLite copy).
 
 Windows:
 

--- a/docs/project/user-guide/18-postgres.md
+++ b/docs/project/user-guide/18-postgres.md
@@ -1,0 +1,93 @@
+# PostgreSQL as the application database
+
+Madmail v2 can store accounts, settings, quotas, tokens, and federation state in **PostgreSQL** instead of SQLite. Mail bodies stay on disk (Maildir). Contact-sharing pages stay in a separate SQLite file (`sharing.db`).
+
+**This is a backend choice for an empty database.** It is not a conversion of an existing SQLite install. Changing `driver` does not copy `credentials.db` / `chatmail.db` into Postgres. There is no `madmail` command that does that copy.
+
+`madmail install` always writes SQLite. Point the config at Postgres after install (or on a custom config), then **restart** the process so it opens the new driver. `madmail reload` does not re-read `driver` / `dsn`.
+
+## What lives where
+
+| Data | Where |
+|------|--------|
+| Password hashes, settings, quotas, blocklist, registration tokens, federation stats, port overrides, push tokens | The **application SQL database** (SQLite file *or* Postgres) |
+| Message files, IMAP flags, UID lists | `{state_dir}/mail/` (Maildir) |
+| Outbound retry jobs | `{state_dir}/remote_queue/` |
+| Admin API token | `{state_dir}/admin_token` (file, not SQL) |
+| `/share` contact pages | `{state_dir}/sharing.db` (always SQLite) |
+
+Back up Maildir and `state_dir` the same way on either backend. For Postgres, also back up that database with normal Postgres tools (`pg_dump`, snapshots). SQLite WAL copy tricks do not apply.
+
+## One database in v2
+
+Go Madmail often used two SQLite files (`credentials.db` and `imapsql.db`). v2 opens **one** application database: the `table sql_table` under `auth.pass_table`.
+
+Set **both** `auth.pass_table` and `storage.imapsql` to the same Postgres `driver` and `dsn` so the config file is not misleading. Only the auth `sql_table` DSN is what the process actually opens.
+
+## Fresh Postgres (recommended path)
+
+1. Create an empty database and a role that can create tables (sqlx migrations run on first start).
+
+   ```sql
+   CREATE USER madmail WITH PASSWORD 'choose-a-secret';
+   CREATE DATABASE madmail OWNER madmail;
+   ```
+
+2. Install Madmail as usual (`madmail install …`). That still writes SQLite in the generated config.
+
+3. Edit `/etc/madmail/madmail.conf` (or your `--config` file). Use the same DSN in both blocks:
+
+   ```
+   auth.pass_table local_authdb {
+       auto_create yes
+       jit_domain $(primary_domain)
+       table sql_table {
+           driver postgres
+           dsn host=127.0.0.1 port=5432 user=madmail password=choose-a-secret dbname=madmail sslmode=disable
+           table_name passwords
+       }
+   }
+
+   storage.imapsql local_mailboxes {
+       auto_create yes
+       driver postgres
+       dsn host=127.0.0.1 port=5432 user=madmail password=choose-a-secret dbname=madmail sslmode=disable
+       retention 24h
+       default_quota 1G
+       appendlimit 100M
+   }
+   ```
+
+   URL form is also accepted: `postgres://madmail:choose-a-secret@127.0.0.1:5432/madmail?sslmode=disable`.
+
+4. Stop SQLite-using processes if you already started the server once. Restart Madmail (`systemctl restart madmail`, or `docker restart madmail`). First boot against an empty Postgres database applies `crates/chatmail-db/migrations/postgres/`.
+
+5. Confirm with `madmail status` and a login or `madmail accounts list`. Leftover `credentials.db` / `chatmail.db` files in `state_dir` are unused after the switch; they are not deleted automatically.
+
+Use `sslmode=require` (or stricter) when Postgres is not on localhost. Do not commit DSNs with real passwords.
+
+## Docker
+
+The image default and `install` still use SQLite. After bootstrap, put Postgres `driver` / `dsn` in the bind-mounted `madmail.conf` (same two blocks as above) and restart the container. Run Postgres as a sibling container or an external host the Madmail container can reach.
+
+There is no Compose environment variable that selects Postgres. `MADDY_HOSTNAME` / `MADDY_DOMAIN` only fill hostname and mail domain in the bundled config.
+
+See [Docker deployment](../../guide/docker.md#custom-configuration).
+
+## What this does not do
+
+- Copy rows from an existing SQLite file into Postgres.
+- Move Maildir, the retry queue, TLS material, or `admin_token`.
+- Move `sharing.db`.
+- Upgrade a live server in place by flipping `driver` while it is running.
+
+If you already have users on SQLite and want them on Postgres, that is a **data copy**, not this backend switch. Keep using SQLite for now, or stand up a **new** Postgres server and recreate accounts. A SQLite → Postgres migration guide (and copy tool) is **in the works**.
+
+A server that was **already** on Postgres under Go Madmail is a different case: v2 can open that schema and fill missing tables. That is not an SQLite conversion.
+
+## Related
+
+- [Quick start — where data lives](./02-quick-start.md#where-the-server-stores-its-data-default-locations)
+- [Configuration (TDD)](../../TDD/13-configuration.md)
+- [Data models](../../TDD/17-data-models.md)
+- [Native install](../../guide/install.md)

--- a/docs/project/user-guide/README.md
+++ b/docs/project/user-guide/README.md
@@ -28,6 +28,7 @@ It is written in the same spirit as the original Madmail "chatmail" documentatio
 | DNS, SPF, DKIM, DMARC, federation reachability | [12-dns-mail-auth.md](./12-dns-mail-auth.md) | Operators (very common question) |
 | Advanced / stealth deployment options | [12-advanced-deployment.md](./12-advanced-deployment.md) | Experienced operators |
 | Customizing the HTML pages and web UI | [17-customizing-html-pages.md](./17-customizing-html-pages.md) | Operators who want to brand or modify the public site |
+| PostgreSQL instead of SQLite | [18-postgres.md](./18-postgres.md) | Operators (new empty database only — not a SQLite conversion) |
 | Endpoint Rewrite (push-push / domain redirection) | [15-endpoint-rewrite.md](./15-endpoint-rewrite.md) | Advanced operators |
 | Exchangers (push-pull, pull-pull intermediaries) | [16-exchangers.md](./16-exchangers.md) | Advanced operators |
 


### PR DESCRIPTION
## Summary

Operator docs for using **PostgreSQL** as the v2 application database.

v2 already opens Postgres (`driver postgres` + DSN). `madmail install` still writes SQLite. This PR says that out loud and shows how to point a **new empty** database at Postgres after install.

Changing `driver` does **not** copy an existing SQLite file. Mail stays in Maildir. `sharing.db` stays SQLite. A SQLite → Postgres migration guide (and copy tool) is **in the works**; it is not in this PR.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [x] Documentation only
- [ ] Build / CI / tooling
- [ ] Refactor (no functional change)

## Area

- [ ] SMTP
- [ ] IMAP
- [ ] Federation / delivery queue
- [ ] Authentication / JIT
- [ ] Admin API / admin web UI (`external/madmail-admin-web`)
- [ ] TURN / Iroh / proxy services
- [x] Storage / quota / DB migrations
- [x] Configuration / CLI
- [x] Docs (`docs/project/`, `docs/TDD/`, user guide)
- [ ] Other:

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace` (or targeted crate/tests: n/a — docs only)
- [ ] Manual / E2E verification (describe below)

**Manual verification (if any):**

```text
Docs-only. Cross-links from install, Docker, user-guide, TDD 13/17.
Canonical page: docs/project/user-guide/18-postgres.md
```

## Documentation

- [ ] No doc updates needed
- [x] Updated operator/user docs (`docs/project/user-guide/`, install guides)
- [x] Updated developer docs (`docs/project/`)
- [x] Updated or added TDD section (`docs/TDD/`) — required for significant design changes

## Security & privacy

- [x] Not security-sensitive
- [ ] Security-sensitive — added/updated tests for the security property
- [ ] Reviewed error messages for information leakage

## Commits

- `docs:` documentation

## Checklist

- [x] PR is focused and reviewable (small vertical slices preferred)
- [x] No secrets, `data/`, `target/`, or `node_modules/` committed
- [ ] Submodule pointers updated if `external/madmail-admin-web` changed
- [x] Behavior parity with Madmail v1 considered (or intentional difference documented)
