### PR TITLE
docs(landing): sync GitHub Pages with Windows operator docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,6 +262,7 @@ jobs:
         working-directory: landing
         run: |
           bun install --frozen-lockfile
+          bun run test
           bun run build
 
       - name: Upload GitHub Pages artifact

--- a/docs/project/user-guide/02-quick-start.md
+++ b/docs/project/user-guide/02-quick-start.md
@@ -168,7 +168,7 @@ This path installs a full production setup (systemd service, user, directories, 
 
 See the dedicated short guide:
 
-**[Install on a Public IP with Let’s Encrypt](../install-simple-ip-acme.md)**
+**[Install on a Public IP with Let’s Encrypt](../../install-simple-ip-acme.md)**
 
 It boils down to (run as root):
 

--- a/landing/package.json
+++ b/landing/package.json
@@ -6,6 +6,7 @@
 	"scripts": {
 		"docs:tree": "node scripts/generate-documentation-tree.mjs",
 		"fonts:sync": "node scripts/sync-fonts.mjs",
+		"test": "node --test src/lib/docLinks.test.js src/lib/mdsvexHighlight.test.js",
 		"dev": "node scripts/generate-documentation-tree.mjs && vite dev",
 		"build": "node scripts/generate-documentation-tree.mjs && vite build",
 		"preview": "vite preview",

--- a/landing/src/lib/components/Install.svelte
+++ b/landing/src/lib/components/Install.svelte
@@ -1,6 +1,7 @@
 <script>
 	import CodeBlock from '$lib/components/CodeBlock.svelte';
 	import arrowRight from '$lib/icons/arrow-right.svg?raw';
+	import { repo } from '$lib/nav.js';
 
 	const installCode = `ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 
@@ -23,6 +24,17 @@ sudo systemctl enable --now madmail`;
 		Also works with a public IP and no domain.
 		<a href="/docs/deployment" class="hint-link">
 			See deployment options
+			<span class="icon" aria-hidden="true">{@html arrowRight}</span>
+		</a>
+	</p>
+	<p class="hint">
+		On Windows, use
+		<code>madmail-windows-amd64-setup.exe</code>
+		from
+		<a href="{repo}/releases">Releases</a>,
+		or the CLI in
+		<a href="/docs/project/user-guide/02-quick-start#windows" class="hint-link">
+			Quick Start — Windows
 			<span class="icon" aria-hidden="true">{@html arrowRight}</span>
 		</a>
 	</p>
@@ -76,6 +88,11 @@ sudo systemctl enable --now madmail`;
 
 	.hint-link:hover {
 		text-decoration: underline;
+	}
+
+	.hint code {
+		font-family: var(--font-mono);
+		font-size: 0.85em;
 	}
 
 	.icon :global(svg) {

--- a/landing/src/lib/docLinks.js
+++ b/landing/src/lib/docLinks.js
@@ -1,19 +1,82 @@
 import { hrefFromRoute } from './docs.js';
 
 const REPO_BLOB = 'https://github.com/themadorg/madmail/blob/main';
-const REPO_ROOT_PREFIXES = new Set(['context', 'crates', 'tests', 'scripts']);
+const REPO_ROOT_PREFIXES = new Set([
+	'assets',
+	'context',
+	'crates',
+	'external',
+	'packaging',
+	'scripts',
+	'tests'
+]);
+
+const DOCS_SUBTREES = [
+	'TDD',
+	'guide',
+	'project',
+	'plans',
+	'problems',
+	'madmail-admin-web',
+	'man',
+	'prompts'
+];
+
+const ROOT_DOC_SLUGS = new Set([
+	'ai-assisted-development',
+	'context-references',
+	'how-we-built-it',
+	'install-simple-ip-acme',
+	'local-dev',
+	'what-is-missing'
+]);
+
+/** @param {unknown} file */
+export function sourcePathFromFile(file) {
+	if (!file || typeof file !== 'object') return '';
+	const record = /** @type {{ path?: string, filename?: string, history?: string[] }} */ (file);
+	return record.path || record.filename || record.history?.[0] || '';
+}
+
+/** @param {string} href */
+export function splitHash(href) {
+	const index = href.indexOf('#');
+	if (index === -1) return { path: href, hash: '' };
+	return { path: href.slice(0, index), hash: href.slice(index) };
+}
+
+/** @param {string | null} resolved @param {string} hash */
+function withHash(resolved, hash) {
+	if (!resolved) return null;
+	return `${resolved}${hash}`;
+}
+
+/** @param {string} path */
+function isDocFile(path) {
+	return /\.(md|txt)$/i.test(path);
+}
+
+/** @param {string} path */
+function stripDocExt(path) {
+	return path.replace(/\.(md|txt)$/i, '');
+}
 
 /** @param {string} sourcePath */
 function docsRootFromSource(sourcePath) {
 	const match = sourcePath.replace(/\\/g, '/').match(/(.*\/docs)\//);
-	return match?.[1] ?? null;
+	if (match) return match[1];
+	const normalized = sourcePath.replace(/\\/g, '/');
+	if (normalized === 'docs' || normalized.endsWith('/docs')) return normalized;
+	return null;
 }
 
 /** @param {string} sourcePath */
 function sourceDocDir(sourcePath) {
 	const normalized = sourcePath.replace(/\\/g, '/');
-	const match = normalized.match(/docs\/(.+)\/[^/]+$/);
-	return match?.[1] ?? '';
+	const nested = normalized.match(/docs\/(.+)\/[^/]+$/);
+	if (nested) return nested[1];
+	if (/docs\/[^/]+$/.test(normalized)) return '';
+	return '';
 }
 
 /** @param {string[]} baseParts @param {string} linkPath */
@@ -42,12 +105,12 @@ function resolveRelative(baseDir, linkPath) {
 function routeFromDocsPath(docsRoot, targetPath) {
 	const prefix = `${docsRoot}/`;
 	if (!targetPath.startsWith(prefix)) return null;
-	return targetPath.slice(prefix.length).replace(/\.(md|txt)$/i, '');
+	return stripDocExt(targetPath.slice(prefix.length));
 }
 
 /** @param {string} linkUrl @param {string} sourcePath */
 export function resolveDocLink(linkUrl, sourcePath) {
-	if (!linkUrl.endsWith('.md') && !linkUrl.endsWith('.txt')) return null;
+	if (!isDocFile(linkUrl)) return null;
 
 	const docsRoot = docsRootFromSource(sourcePath);
 	if (!docsRoot) return null;
@@ -57,6 +120,9 @@ export function resolveDocLink(linkUrl, sourcePath) {
 	const route = routeFromDocsPath(docsRoot, targetPath);
 
 	if (!route) return null;
+	if (route === 'project/install-simple-ip-acme' || route.endsWith('/install-simple-ip-acme')) {
+		return '/docs/install-simple-ip-acme';
+	}
 	return hrefFromRoute(route);
 }
 
@@ -65,10 +131,24 @@ function normalizeMarkdownHref(href) {
 	return href.replace(/^\.\//, '').replace(/^\//, '').replace(/\.(md|txt)$/i, '');
 }
 
+/** @param {string} href */
+function repoPathFromHref(href) {
+	const cleaned = href.replace(/\\/g, '/');
+	const match = cleaned.match(
+		/(?:^|\/)((?:assets|context|crates|external|packaging|scripts|tests)\/\S+)$/
+	);
+	return match?.[1] ?? null;
+}
+
 /** @param {string} href @param {string} sourcePath */
 export function resolveRepoBlobHref(href, sourcePath) {
 	if (!href || href.startsWith('http') || href.startsWith('mailto:') || href.startsWith('#')) {
 		return null;
+	}
+
+	const fromHref = repoPathFromHref(href);
+	if (fromHref && REPO_ROOT_PREFIXES.has(fromHref.split('/')[0])) {
+		return `${REPO_BLOB}/${fromHref}`;
 	}
 
 	if (!docsRootFromSource(sourcePath)) return null;
@@ -86,28 +166,64 @@ export function resolveRepoBlobHref(href, sourcePath) {
 	return `${REPO_BLOB}/${repoPath}`;
 }
 
-/** @param {string} href @param {string} sourcePath */
-export function resolveHref(href, sourcePath) {
-	if (href.startsWith('/docs/')) {
-		return href.replace(/\.(md|txt)$/i, '');
+/** @param {string} path */
+function resolveDocsSubtreeHref(path) {
+	const cleaned = path.replace(/\\/g, '/');
+	for (const tree of DOCS_SUBTREES) {
+		const match = cleaned.match(new RegExp(`(?:^|/)(${tree}/\\S+\\.(?:md|txt))$`, 'i'));
+		if (match) return hrefFromRoute(stripDocExt(match[1]));
+	}
+	return null;
+}
+
+/** @param {string} path @param {string} sourcePath */
+function resolveHeuristicHref(path, sourcePath) {
+	const fromSubtree = resolveDocsSubtreeHref(path);
+	if (fromSubtree) return fromSubtree;
+
+	const base = stripDocExt(path.split('/').pop() ?? path);
+	if (ROOT_DOC_SLUGS.has(base)) {
+		return `/docs/${base}`;
 	}
 
-	if (/^\/\d{2}-.+\.md$/i.test(href)) {
-		return `/docs/project/user-guide/${href.slice(1).replace(/\.md$/i, '')}`;
+	const parentProject = path.match(/^\.\.\/(\d{2}-[^/]+\.(?:md|txt))$/i);
+	if (parentProject && (!sourcePath || sourcePath.includes('user-guide'))) {
+		return `/docs/project/${stripDocExt(parentProject[1])}`;
 	}
 
-	const fromSource = resolveDocLink(href, sourcePath);
-	if (fromSource) return fromSource;
-
-	const normalized = normalizeMarkdownHref(href);
-
-	if (/^\d{2}-/i.test(normalized)) {
+	const normalized = normalizeMarkdownHref(path);
+	if (/^\d{2}-/i.test(normalized) && !normalized.includes('/')) {
 		return `/docs/project/user-guide/${normalized}`;
 	}
 
-	if (normalized === 'install-simple-ip-acme' || href.includes('install-simple-ip-acme')) {
-		return '/docs/install-simple-ip-acme';
+	return null;
+}
+
+/** @param {string} href @param {string} [sourcePath] */
+export function resolveHref(href, sourcePath = '') {
+	if (!href || href.startsWith('http') || href.startsWith('mailto:') || href.startsWith('#')) {
+		return null;
 	}
 
-	return resolveRepoBlobHref(href, sourcePath);
+	const { path, hash } = splitHash(href);
+
+	if (path.startsWith('/docs/')) {
+		return withHash(stripDocExt(path), hash);
+	}
+
+	if (/^\/\d{2}-.+\.(md|txt)$/i.test(path)) {
+		return withHash(`/docs/project/user-guide/${path.slice(1).replace(/\.(md|txt)$/i, '')}`, hash);
+	}
+
+	if (path.includes('install-simple-ip-acme')) {
+		return withHash('/docs/install-simple-ip-acme', hash);
+	}
+
+	const fromSource = resolveDocLink(path, sourcePath);
+	if (fromSource) return withHash(fromSource, hash);
+
+	const heuristic = resolveHeuristicHref(path, sourcePath);
+	if (heuristic) return withHash(heuristic, hash);
+
+	return withHash(resolveRepoBlobHref(path, sourcePath), hash);
 }

--- a/landing/src/lib/docLinks.test.js
+++ b/landing/src/lib/docLinks.test.js
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { resolveHref, sourcePathFromFile, splitHash } from './docLinks.js';
+
+const USER_GUIDE = 'content/docs/project/user-guide/02-quick-start.md';
+const IP_ACME = 'content/docs/install-simple-ip-acme.md';
+
+test('splitHash keeps fragment separate from the path', () => {
+	assert.deepEqual(splitHash('./17-customizing-html-pages.md#windows'), {
+		path: './17-customizing-html-pages.md',
+		hash: '#windows'
+	});
+});
+
+test('sourcePathFromFile reads mdsvex filename fallbacks', () => {
+	assert.equal(sourcePathFromFile({ filename: USER_GUIDE }), USER_GUIDE);
+	assert.equal(sourcePathFromFile({ history: [USER_GUIDE] }), USER_GUIDE);
+	assert.equal(sourcePathFromFile({}), '');
+});
+
+test('Windows packaging links become GitHub blob URLs', () => {
+	const blob =
+		'https://github.com/themadorg/madmail/blob/main/packaging/windows/README.md';
+
+	assert.equal(resolveHref('../../../packaging/windows/README.md', USER_GUIDE), blob);
+	assert.equal(
+		resolveHref(
+			'../../../packaging/windows/README.md#windows-defender-smartscreen-and-uac',
+			USER_GUIDE
+		),
+		`${blob}#windows-defender-smartscreen-and-uac`
+	);
+	assert.equal(resolveHref('../packaging/windows/README.md', IP_ACME), blob);
+	assert.equal(resolveHref('../../../packaging/windows/README.md', ''), blob);
+});
+
+test('user-guide links keep hashes and drop the .md suffix', () => {
+	assert.equal(
+		resolveHref('./17-customizing-html-pages.md#windows', USER_GUIDE),
+		'/docs/project/user-guide/17-customizing-html-pages#windows'
+	);
+	assert.equal(
+		resolveHref('./12-advanced-deployment.md', USER_GUIDE),
+		'/docs/project/user-guide/12-advanced-deployment'
+	);
+});
+
+test('relative docs outside user-guide resolve on the landing site', () => {
+	assert.equal(resolveHref('../../local-dev.md', USER_GUIDE), '/docs/local-dev');
+	assert.equal(
+		resolveHref('../15-development-workflow.md', USER_GUIDE),
+		'/docs/project/15-development-workflow'
+	);
+	assert.equal(resolveHref('../../TDD/07-federation.md', USER_GUIDE), '/docs/TDD/07-federation');
+	assert.equal(
+		resolveHref('../../guide/docker.md#turn-calls', USER_GUIDE),
+		'/docs/guide/docker#turn-calls'
+	);
+	assert.equal(
+		resolveHref('../../install-simple-ip-acme.md', USER_GUIDE),
+		'/docs/install-simple-ip-acme'
+	);
+	assert.equal(
+		resolveHref('../install-simple-ip-acme.md', USER_GUIDE),
+		'/docs/install-simple-ip-acme'
+	);
+});
+
+test('heuristics still work when mdsvex omits file.path', () => {
+	assert.equal(resolveHref('../../local-dev.md', ''), '/docs/local-dev');
+	assert.equal(
+		resolveHref('../15-development-workflow.md', ''),
+		'/docs/project/15-development-workflow'
+	);
+	assert.equal(resolveHref('../../TDD/07-federation.md', ''), '/docs/TDD/07-federation');
+	assert.equal(
+		resolveHref('./12-dns-mail-auth.md', ''),
+		'/docs/project/user-guide/12-dns-mail-auth'
+	);
+});

--- a/landing/src/lib/mdsvexHighlight.js
+++ b/landing/src/lib/mdsvexHighlight.js
@@ -1,0 +1,21 @@
+import { escapeSvelte } from 'mdsvex';
+
+/** @param {string} code */
+function escapeCode(code) {
+	return escapeSvelte(
+		code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+	);
+}
+
+/**
+ * Fenced code for mdsvex/Svelte. Prism's powershell/bash lexers and the
+ * generated html`...` template both eat `\\`, which broke Windows paths.
+ *
+ * @param {string} code
+ * @param {string} [lang]
+ */
+export function highlightMdsvex(code, lang) {
+	const language = (lang || 'text').toLowerCase().replace(/[^a-z0-9+-]/g, '') || 'text';
+	const cls = `language-${language}`;
+	return `<pre class="${cls}"><code class="${cls}">${escapeCode(code)}</code></pre>`;
+}

--- a/landing/src/lib/mdsvexHighlight.test.js
+++ b/landing/src/lib/mdsvexHighlight.test.js
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { highlightMdsvex } from './mdsvexHighlight.js';
+
+test('powershell current-directory prefix keeps its backslash', () => {
+	const html = highlightMdsvex('.\\madmail.exe install', 'powershell');
+	assert.match(html, /class="language-powershell"/);
+	assert.equal(html.includes('.\\madmail.exe install'), true);
+});
+
+test('Windows Program Files paths keep backslashes', () => {
+	const html = highlightMdsvex('C:\\Program Files\\Madmail\\madmail.exe', 'powershell');
+	assert.equal(html.includes('C:\\Program Files\\Madmail\\madmail.exe'), true);
+});

--- a/landing/src/lib/publishedDocs.js
+++ b/landing/src/lib/publishedDocs.js
@@ -12,9 +12,11 @@ export const COMPILED_DOC_ROUTES = [
 	'project/user-guide/10-troubleshooting',
 	'project/user-guide/11-deployment-ip-domain-certs',
 	'project/user-guide/12-dns-mail-auth',
+	'project/user-guide/12-advanced-deployment',
 	'project/user-guide/15-endpoint-rewrite',
 	'project/user-guide/16-exchangers',
 	'project/user-guide/17-customizing-html-pages',
+	'project/user-guide/README',
 	'install-simple-ip-acme'
 ];
 

--- a/landing/src/lib/rehypeDocLinks.js
+++ b/landing/src/lib/rehypeDocLinks.js
@@ -1,10 +1,10 @@
 import { visit } from 'unist-util-visit';
-import { resolveHref } from './docLinks.js';
+import { resolveHref, sourcePathFromFile } from './docLinks.js';
 
 /** @returns {import('unified').Plugin} */
 export function rehypeDocLinks() {
 	return (tree, file) => {
-		const sourcePath = file?.path ?? file?.history?.[0] ?? '';
+		const sourcePath = sourcePathFromFile(file);
 
 		visit(tree, 'element', (node) => {
 			if (node.tagName !== 'a' || !node.properties?.href) return;

--- a/landing/src/lib/remarkLandingLinks.js
+++ b/landing/src/lib/remarkLandingLinks.js
@@ -1,10 +1,24 @@
 import { visit } from 'unist-util-visit';
-import { resolveHref } from './docLinks.js';
+import { resolveHref, sourcePathFromFile } from './docLinks.js';
+
+/** Prism's powershell lexer treats `\` as an escape, which deletes Windows paths. */
+const PLAIN_CODE_LANGS = new Set(['powershell', 'ps1', 'pwsh', 'cmd']);
+
+/** @returns {import('unified').Plugin} */
+export function remarkPlainPowershell() {
+	return (tree) => {
+		visit(tree, 'code', (node) => {
+			const lang = node.lang?.toLowerCase();
+			if (!lang || !PLAIN_CODE_LANGS.has(lang)) return;
+			node.lang = 'text';
+		});
+	};
+}
 
 /** @returns {import('unified').Plugin} */
 export function remarkLandingLinks() {
 	return (tree, file) => {
-		const sourcePath = file?.path ?? file?.history?.[0] ?? '';
+		const sourcePath = sourcePathFromFile(file);
 
 		visit(tree, 'link', (node) => {
 			let url = node.url;

--- a/landing/vite.config.js
+++ b/landing/vite.config.js
@@ -5,7 +5,8 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { rehypeDocLinks } from './src/lib/rehypeDocLinks.js';
 import { rehypeDocToc } from './src/lib/rehypeDocToc.js';
 import { rehypeHeadingIds } from './src/lib/rehypeHeadingIds.js';
-import { remarkLandingLinks } from './src/lib/remarkLandingLinks.js';
+import { highlightMdsvex } from './src/lib/mdsvexHighlight.js';
+import { remarkLandingLinks, remarkPlainPowershell } from './src/lib/remarkLandingLinks.js';
 import { defineConfig } from 'vite';
 
 function generateDocumentationTree() {
@@ -52,7 +53,8 @@ export default defineConfig({
 			preprocess: [
 				mdsvex({
 					extensions: ['.svx', '.md'],
-					remarkPlugins: [remarkLandingLinks],
+					highlight: { highlighter: highlightMdsvex },
+					remarkPlugins: [remarkPlainPowershell, remarkLandingLinks],
 					rehypePlugins: [rehypeHeadingIds, rehypeDocToc, rehypeDocLinks]
 				})
 			],


### PR DESCRIPTION
## Summary

Sync the GitHub Pages landing site with operator docs that are already on `main`, mainly Windows.

The docs tree is already published via the `docs/` symlink. What was missing was landing-specific wiring: homepage install stayed Linux-only, `12-advanced-deployment` was never added to the compiled-routes list, `packaging/windows` links 404'd, hashes kept a `.md` suffix, and Prism/mdsvex ate backslashes in PowerShell samples (`.\madmail.exe`, `C:\Program Files\Madmail\...`).

Also fixes the Quick Start link to the IP + ACME guide (`../../install-simple-ip-acme.md`).

Does not include open-PR docs (Postgres copy, Docker Iroh).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [x] Documentation only
- [x] Build / CI / tooling
- [ ] Refactor (no functional change)

## Area

- [ ] SMTP
- [ ] IMAP
- [ ] Federation / delivery queue
- [ ] Authentication / JIT
- [ ] Admin API / admin web UI (`external/madmail-admin-web`)
- [ ] TURN / Iroh / proxy services
- [ ] Storage / quota / DB migrations
- [ ] Configuration / CLI
- [x] Docs (`docs/project/`, `docs/TDD/`, user guide)
- [x] Other: GitHub Pages landing (`landing/`)

## Testing

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace` (or targeted crate/tests: <!-- list if subset -->)
- [x] Manual / E2E verification (describe below)

**Manual verification (if any):**

```text
cd landing
bun install --frozen-lockfile
bun run test
bun run build
bun run preview -- --host 0.0.0.0 --port 4173

Checked:
- homepage Quick Setup mentions Windows setup wizard
- /docs/project/user-guide/02-quick-start#windows keeps .\madmail.exe
- packaging/windows links go to GitHub blob URLs
- /docs/install-simple-ip-acme keeps C:\Program Files\Madmail\madmail.exe
- /docs/project/user-guide/12-advanced-deployment Windows row
```

Landing CI now runs `bun run test` before build.

## Documentation

- [ ] No doc updates needed
- [x] Updated operator/user docs (`docs/project/user-guide/`, install guides)
- [ ] Updated developer docs (`docs/project/`)
- [ ] Updated or added TDD section (`docs/TDD/`) — required for significant design changes

## Security & privacy

- [x] Not security-sensitive
- [ ] Security-sensitive — added/updated tests for the security property
- [ ] Reviewed error messages for information leakage

## Commits

- `docs:` documentation

## Checklist

- [x] PR is focused and reviewable (small vertical slices preferred)
- [x] No secrets, `data/`, `target/`, or `node_modules/` committed
- [ ] Submodule pointers updated if `external/madmail-admin-web` changed
- [ ] Behavior parity with Madmail v1 considered (or intentional difference documented)
