### PR TITLE
feat(metrics): track concurrent IMAP and SMTP connections

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -203,6 +203,7 @@ require (
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
 	github.com/kulti/thelper v0.6.3 // indirect
 	github.com/kunwardeep/paralleltest v1.0.10 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lasiar/canonicalheader v1.1.2 // indirect
 	github.com/ldez/exptostd v0.4.2 // indirect
 	github.com/ldez/gomoddirectives v0.6.1 // indirect

--- a/internal/connmetrics/listener.go
+++ b/internal/connmetrics/listener.go
@@ -1,0 +1,87 @@
+/*
+Maddy Mail Server - Composable all-in-one email server.
+Copyright © 2019-2020 Max Mazurov <fox.cpp@disroot.org>, Maddy Mail Server contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+// Package connmetrics provides a net.Listener wrapper that reports the number
+// of currently open client connections as a Prometheus gauge.
+package connmetrics
+
+import (
+	"net"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var activeConns = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Namespace: "maddy",
+		Name:      "conns_active",
+		Help:      "Amount of client connections currently open",
+	},
+	[]string{"module"},
+)
+
+func init() {
+	prometheus.MustRegister(activeConns)
+}
+
+// NewListener wraps inner so that every accepted connection increments the
+// maddy_conns_active gauge for module and decrements it when closed.
+//
+// It must be applied to the raw listener, before tls.NewListener: the
+// connections it returns are not *tls.Conn, and go-imap type-asserts for that
+// to pick up the TLS state of an implicit-TLS connection.
+func NewListener(inner net.Listener, module string) net.Listener {
+	return &listener{Listener: inner, gauge: activeConns.WithLabelValues(module)}
+}
+
+// WrapConn accounts for a single connection that was not obtained from a
+// listener wrapped by NewListener. The same "wrap it before TLS" rule applies.
+func WrapConn(c net.Conn, module string) net.Conn {
+	g := activeConns.WithLabelValues(module)
+	g.Inc()
+	return &conn{Conn: c, gauge: g}
+}
+
+type listener struct {
+	net.Listener
+	gauge prometheus.Gauge
+}
+
+func (l *listener) Accept() (net.Conn, error) {
+	c, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	l.gauge.Inc()
+	return &conn{Conn: c, gauge: l.gauge}, nil
+}
+
+type conn struct {
+	net.Conn
+	gauge prometheus.Gauge
+	once  sync.Once
+}
+
+// Close decrements the gauge exactly once, no matter how many times it is
+// called - both go-imap and go-smtp close a connection more than once on some
+// paths.
+func (c *conn) Close() error {
+	c.once.Do(c.gauge.Dec)
+	return c.Conn.Close()
+}

--- a/internal/connmetrics/listener_test.go
+++ b/internal/connmetrics/listener_test.go
@@ -1,0 +1,69 @@
+package connmetrics
+
+import (
+	"net"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestListenerCountsOpenConns(t *testing.T) {
+	inner, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer inner.Close()
+
+	l := NewListener(inner, "test")
+
+	const count = 3
+	accepted := make(chan net.Conn, count)
+	go func() {
+		for i := 0; i < count; i++ {
+			c, err := l.Accept()
+			if err != nil {
+				close(accepted)
+				return
+			}
+			accepted <- c
+		}
+	}()
+
+	clients := make([]net.Conn, 0, count)
+	for i := 0; i < count; i++ {
+		c, err := net.Dial("tcp", l.Addr().String())
+		if err != nil {
+			t.Fatal(err)
+		}
+		clients = append(clients, c)
+	}
+	defer func() {
+		for _, c := range clients {
+			_ = c.Close()
+		}
+	}()
+
+	server := make([]net.Conn, 0, count)
+	for i := 0; i < count; i++ {
+		c, ok := <-accepted
+		if !ok {
+			t.Fatal("Accept failed")
+		}
+		server = append(server, c)
+	}
+
+	if got := testutil.ToFloat64(activeConns.WithLabelValues("test")); got != count {
+		t.Errorf("gauge after %d accepts = %v, want %d", count, got, count)
+	}
+
+	for _, c := range server {
+		_ = c.Close()
+		// Both go-imap and go-smtp close a connection twice on some paths;
+		// the second Close must not decrement again.
+		_ = c.Close()
+	}
+
+	if got := testutil.ToFloat64(activeConns.WithLabelValues("test")); got != 0 {
+		t.Errorf("gauge after closing every conn = %v, want 0", got)
+	}
+}

--- a/internal/endpoint/chatmail/chatmail.go
+++ b/internal/endpoint/chatmail/chatmail.go
@@ -47,6 +47,7 @@ import (
 	"github.com/themadorg/madmail/framework/log"
 	"github.com/themadorg/madmail/framework/module"
 	"github.com/themadorg/madmail/internal/auth/pass_table"
+	"github.com/themadorg/madmail/internal/connmetrics"
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/shadowsocks/go-shadowsocks2/core"
@@ -885,13 +886,13 @@ func (e *Endpoint) handleALPNConn(conn net.Conn, httpConns, smtpConns, imapConns
 		case "smtp":
 			if e.smtpModule != nil {
 				e.logger.Msg("ALPN proxy: routing to internal smtp", "remote", conn.RemoteAddr())
-				smtpConns <- tls.Server(bConn, e.tlsConfig)
+				smtpConns <- tls.Server(connmetrics.WrapConn(bConn, e.smtpModule.InstanceName()), e.tlsConfig)
 				return
 			}
 		case "imap":
 			if e.imapModule != nil {
 				e.logger.Msg("ALPN proxy: routing to internal imap", "remote", conn.RemoteAddr())
-				imapConns <- tls.Server(bConn, e.tlsConfig)
+				imapConns <- tls.Server(connmetrics.WrapConn(bConn, e.imapModule.InstanceName()), e.tlsConfig)
 				return
 			}
 		}

--- a/internal/endpoint/imap/imap.go
+++ b/internal/endpoint/imap/imap.go
@@ -51,6 +51,7 @@ import (
 	"github.com/themadorg/madmail/framework/module"
 	"github.com/themadorg/madmail/internal/auth"
 	"github.com/themadorg/madmail/internal/authz"
+	"github.com/themadorg/madmail/internal/connmetrics"
 	"github.com/themadorg/madmail/internal/pgp_verify"
 	"github.com/themadorg/madmail/internal/proxy_protocol"
 	"github.com/themadorg/madmail/internal/updatepipe"
@@ -182,6 +183,7 @@ func (endp *Endpoint) setupListeners(addresses []config.Endpoint) error {
 		if err != nil {
 			return fmt.Errorf("imap: %v", err)
 		}
+		l = connmetrics.NewListener(l, "imap")
 		endp.Log.Printf("listening on %v", addr)
 
 		if addr.IsTLS() {

--- a/internal/endpoint/smtp/smtp.go
+++ b/internal/endpoint/smtp/smtp.go
@@ -43,6 +43,7 @@ import (
 	"github.com/themadorg/madmail/framework/module"
 	"github.com/themadorg/madmail/internal/auth"
 	"github.com/themadorg/madmail/internal/authz"
+	"github.com/themadorg/madmail/internal/connmetrics"
 	"github.com/themadorg/madmail/internal/limits"
 	"github.com/themadorg/madmail/internal/msgpipeline"
 	"github.com/themadorg/madmail/internal/proxy_protocol"
@@ -326,6 +327,7 @@ func (endp *Endpoint) setupListeners(addresses []config.Endpoint) error {
 		if err != nil {
 			return fmt.Errorf("%s: %w", endp.name, err)
 		}
+		l = connmetrics.NewListener(l, endp.name)
 		endp.Log.Printf("listening on %v", addr)
 
 		if addr.IsTLS() {


### PR DESCRIPTION
Step 1 of #19: the "online users" metric.

## What

New `internal/connmetrics` package: a `net.Listener` wrapper that reports currently open client connections as a Prometheus gauge, `maddy_conns_active{module}`, labelled with the endpoint instance name. Wired into the IMAP and SMTP endpoints, plus the chatmail ALPN path.

It is exported through the existing `openmetrics` endpoint, so nothing new is needed to read it. Seven lines of wiring; the rest is the package and its test.

## Placement, and why it is not where the issue plan said

The plan comment on #19 proposed wrapping inside `Endpoint.Serve(l net.Listener)`. That turned out to be wrong twice:

- `setupListeners` calls `endp.serv.Serve(l)` directly, never `endp.Serve(l)`, so the production listeners would not have been counted at all.
- It puts the wrapper *above* TLS. go-imap reads the TLS state of an implicit-TLS connection with a bare `tlsConn, _ := c.(*tls.Conn)` (`server/conn.go:88`). A wrapper there makes that assertion fail, `TLSState()` returns nil, and an IMAPS connection looks like plaintext to the auth checks — silently, with no error anywhere.

So the wrap goes innermost, right after `net.Listen` and below `tls.NewListener`.

`internal/endpoint/chatmail` is a third surface the plan missed: it serves IMAP and SMTP over an ALPN-multiplexed TLS port and hands the endpoints conns that are already `*tls.Conn`. Same rule, so it accounts for those with `connmetrics.WrapConn` on the raw buffered conn *before* `tls.Server`.

`Close` is guarded with a `sync.Once` — both go-imap and go-smtp close a connection more than once on some paths, and an unguarded `Dec` would drift the gauge negative.

## Scope

This counts concurrent connections, which is the working definition of "session" for IMAP and SMTP and what an admin needs for capacity planning. It does not track distinct authenticated identities; if we want that later, it is an additive `map[string]int` hooked into the login paths, no rework here.

Throughput (step 2), the `openmetrics` config default (step 3) and `maddy monitor` (step 4) are separate PRs.

## Verification

- `go build ./internal/...` and `go vet ./internal/...` clean.
- New test in `internal/connmetrics`: accepts N connections, asserts the gauge reads N, closes each one twice, asserts it returns to 0.
- `go test ./internal/endpoint/...` fails on the same 12 tests before and after this change (pre-existing, `PGP verification failed: mime: no media type`), confirmed against a stashed baseline.
- Grepped go-smtp, go-imap and `internal/` for `*net.TCPConn` / `SetKeepAlive` / `SetNoDelay` — no hits, so nothing else loses a capability by sitting above the wrapper.
- `go.mod` gains one indirect dependency (`kylelemons/godebug`, pulled in by `prometheus/testutil`); `go.sum` is unchanged.

Note for step 4: a series does not exist until that endpoint accepts its first connection, so the CLI must render a missing series as 0 rather than erroring.

I could not run `golangci-lint` locally — the installed binary is v2 and `.golangci.yml` is v1 format (`can't load config: unsupported version of the configuration`). errcheck was satisfied by hand instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
