### PR TITLE
feat(metrics): track concurrent IMAP and SMTP connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,6 +877,7 @@ dependencies = [
  "chatmail-config",
  "chatmail-db",
  "chatmail-iroh",
+ "chatmail-metrics",
  "chatmail-pgp",
  "chatmail-push",
  "chatmail-state",

--- a/crates/chatmail-imap/Cargo.toml
+++ b/crates/chatmail-imap/Cargo.toml
@@ -10,6 +10,7 @@ chatmail-config = { workspace = true }
 chatmail-db = { workspace = true }
 chatmail-turn = { workspace = true }
 chatmail-iroh = { workspace = true }
+chatmail-metrics = { workspace = true }
 chatmail-push = { workspace = true }
 chatmail-pgp = { workspace = true }
 chatmail-state = { workspace = true }

--- a/crates/chatmail-imap/src/server.rs
+++ b/crates/chatmail-imap/src/server.rs
@@ -66,6 +66,7 @@ pub async fn run_imap_listener(
                 let cfg = cfg.clone();
                 let acceptor = tls_acceptor.clone();
                 tokio::spawn(async move {
+                    let _conn_guard = chatmail_metrics::conn_guard("imap");
                     connection_stats::on_open(&peer_ip);
                     let mut session = ImapSession::new(ctx, pool, cfg);
                     let result = if let Some(acceptor) = acceptor {

--- a/crates/chatmail-metrics/src/lib.rs
+++ b/crates/chatmail-metrics/src/lib.rs
@@ -21,7 +21,8 @@ mod metrics;
 mod server;
 
 pub use metrics::{
-    exposition_text, init_metrics, record_smtp_aborted, record_smtp_completed,
+    conn_guard, exposition_text, init_metrics, record_smtp_aborted, record_smtp_completed,
     record_smtp_failed_command, record_smtp_failed_login, record_smtp_started, set_queue_length,
+    ConnGuard,
 };
 pub use server::run_openmetrics_listener;

--- a/crates/chatmail-metrics/src/metrics.rs
+++ b/crates/chatmail-metrics/src/metrics.rs
@@ -16,7 +16,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use once_cell::sync::Lazy;
-use prometheus::{register_counter_vec, register_gauge_vec, Encoder, TextEncoder};
+use prometheus::{
+    register_counter_vec, register_gauge_vec, register_int_gauge_vec, Encoder, TextEncoder,
+};
 
 static STARTED: Lazy<prometheus::CounterVec> = Lazy::new(|| {
     register_counter_vec!(
@@ -73,6 +75,15 @@ static FAILED_COMMANDS: Lazy<prometheus::CounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
+static CONNS_ACTIVE: Lazy<prometheus::IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "maddy_conns_active",
+        "Amount of client connections currently open",
+        &["module"]
+    )
+    .unwrap()
+});
+
 static QUEUE_LENGTH: Lazy<prometheus::GaugeVec> = Lazy::new(|| {
     register_gauge_vec!(
         "maddy_queue_length",
@@ -109,6 +120,30 @@ pub fn record_smtp_ratelimit_deferred(module: &str) {
     RATELIMIT_DEFERRED.with_label_values(&[module]).inc();
 }
 
+/// Count one open connection for `module` until the returned guard is dropped.
+///
+/// The count is released on drop rather than by an explicit close call so that
+/// it survives every way a connection task can end - a failed TLS handshake, an
+/// early return, a panic, or the runtime dropping the task at shutdown. Bind it
+/// (`let _guard = ...`), never `let _ = ...`, which drops it immediately.
+#[must_use = "the connection is counted only while the guard is alive"]
+pub fn conn_guard(module: &str) -> ConnGuard {
+    let gauge = CONNS_ACTIVE.with_label_values(&[module]);
+    gauge.inc();
+    ConnGuard { gauge }
+}
+
+/// Decrements `maddy_conns_active` for its module when dropped.
+pub struct ConnGuard {
+    gauge: prometheus::IntGauge,
+}
+
+impl Drop for ConnGuard {
+    fn drop(&mut self) {
+        self.gauge.dec();
+    }
+}
+
 pub fn set_queue_length(module: &str, location: &str, depth: f64) {
     QUEUE_LENGTH
         .with_label_values(&[module, location])
@@ -124,6 +159,7 @@ pub fn init_metrics() {
     let _ = &*FAILED_LOGINS;
     let _ = &*FAILED_COMMANDS;
     let _ = &*QUEUE_LENGTH;
+    let _ = &*CONNS_ACTIVE;
     // Create label children so `/metrics` is non-empty before the first SMTP event.
     let _ = STARTED.with_label_values(&["smtp"]);
     let _ = STARTED.with_label_values(&["submission"]);
@@ -133,6 +169,9 @@ pub fn init_metrics() {
     let _ = ABORTED.with_label_values(&["submission"]);
     let _ = FAILED_LOGINS.with_label_values(&["smtp"]);
     let _ = FAILED_LOGINS.with_label_values(&["submission"]);
+    let _ = CONNS_ACTIVE.with_label_values(&["smtp"]);
+    let _ = CONNS_ACTIVE.with_label_values(&["submission"]);
+    let _ = CONNS_ACTIVE.with_label_values(&["imap"]);
 }
 
 /// Full Prometheus text exposition (for tests and debugging).
@@ -175,6 +214,35 @@ mod tests {
     use super::*;
 
     const MODULE: &str = "metrics_unit_test";
+
+    #[test]
+    fn conn_guard_counts_while_alive() {
+        // Unique label: the gauge is a global static and tests share the process.
+        let module = "conn_guard_alive_test";
+        let gauge = CONNS_ACTIVE.with_label_values(&[module]);
+
+        let guards: Vec<_> = (0..3).map(|_| conn_guard(module)).collect();
+        assert_eq!(gauge.get(), 3);
+
+        drop(guards);
+        assert_eq!(gauge.get(), 0);
+    }
+
+    #[test]
+    fn conn_guard_releases_on_panic() {
+        let module = "conn_guard_panic_test";
+        let gauge = CONNS_ACTIVE.with_label_values(&[module]);
+
+        let result = std::panic::catch_unwind(|| {
+            let _guard = conn_guard(module);
+            panic!("session died mid-connection");
+        });
+        assert!(result.is_err());
+
+        // A connection task that panics must not leak a count, otherwise the
+        // gauge only ever climbs and the whole metric becomes useless.
+        assert_eq!(gauge.get(), 0);
+    }
 
     #[test]
     fn gather_after_init_is_non_empty() {

--- a/crates/chatmail-smtp/src/server.rs
+++ b/crates/chatmail-smtp/src/server.rs
@@ -67,6 +67,7 @@ pub async fn run_smtp_listener(
                 let cfg = cfg.clone();
                 let acceptor = tls_acceptor.clone();
                 tokio::spawn(async move {
+                    let _conn_guard = chatmail_metrics::conn_guard(cfg.module);
                     let mut session = SmtpSession::new(ctx, pool, cfg);
                     let result = if let Some(acceptor) = acceptor {
                         match acceptor.accept(stream).await {


### PR DESCRIPTION
> **Stack:** themadorg/madmail#164 (step 1, the gauge) → themadorg/madmail#165 (step 4, `madmail monitor`). #165 is based on the `feat/19-conn-metrics` branch, so once this PR merges it needs retargeting to `main`. Rebased onto 2.27.0; no code changes in the rebase.

Step 1 of #19: the "online users" metric. Replaces #163, which was written against the pre-Rust tree.

## What

`maddy_conns_active{module}` — an `IntGaugeVec` in `chatmail-metrics`, held up for the lifetime of every accepted IMAP and SMTP connection. Exported through the existing `openmetrics` listener, so nothing new is needed to read it.

Three lines of wiring; the rest is the guard and its tests.

## Why an RAII guard and not open/close calls

The count is released on `Drop`, not by an explicit close call. A connection task can end in more ways than the happy path — a failed TLS handshake returns early, a session can panic, and the runtime drops in-flight tasks at shutdown. A gauge that misses any of those only ever climbs, which makes it worse than useless for the monitoring this exists for.

`conn_guard` is `#[must_use]`: `let _ = conn_guard(..)` drops the guard on the same line and would silently count nothing. The binding has to be `let _guard = ...`.

The guard is created as the first statement inside `tokio::spawn`, so the TLS-handshake-failure branch is covered too.

## Notes

- Label children for `imap`, `smtp` and `submission` are pre-created in `init_metrics()`, matching what the SMTP counters already do there, so the series is present and reads `0` before the first connection instead of being absent. That matters for the CLI in step 4 — it should still handle a missing series as 0, but it will not normally hit that.
- `chatmail-imap`'s existing `connection_stats` module is untouched. It also tracks per-peer IPs for a different consumer and is not interchangeable with a gauge; duplicating the count is cheaper than entangling the two.
- SMTP labels itself from `cfg.module`, so `smtp` and `submission` separate on their own, consistent with the existing SMTP counters.
- `chatmail-imap` gains a dependency on `chatmail-metrics` (a leaf crate — no cycle). `chatmail-smtp` already had it.

## Scope

Concurrent connections, which is the working definition of "session" for IMAP and SMTP and what an admin needs for capacity planning. Not distinct authenticated identities — if we want that later it is additive, and `connection_stats` already has the per-IP half of it.

Throughput and the `monitor` CLI are separate; see the plan comments on #19, which I will re-scope against the Rust crates now that this one is done.

## Verification

- `cargo build -p chatmail-metrics -p chatmail-smtp -p chatmail-imap` — clean.
- `cargo clippy --all-targets -- -D warnings` on the three crates — clean. `cargo fmt --all --check` — clean. `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` — clean.
- `cargo test -p chatmail-metrics` — 7 passed, including two new ones: N guards read N and drop to 0, and a guard inside `catch_unwind` that panics still leaves the gauge at 0. The panic case is the one that proves the RAII choice earned its lines. Both use unique label values, since the statics are global and tests share a process.
- `cargo test -p chatmail-imap -p chatmail-smtp`: `p6_imap_idle_unsolicited_exists` fails, but it fails identically on a clean checkout of this branch point (verified by stashing) — pre-existing, unrelated.


