### PR TITLE
feat(cli): add `madmail monitor` for live connection and throughput stats

### DIFF
--- a/crates/chatmail-config/src/cli.rs
+++ b/crates/chatmail-config/src/cli.rs
@@ -192,6 +192,21 @@ pub enum Command {
     /// Migrate submission PGP policy in config.
     #[command(name = "migrate-pgp-config")]
     MigratePgpConfig,
+    /// Live server metrics (connections and message throughput).
+    ///
+    /// Polls the `openmetrics` endpoint, so that endpoint has to be enabled in
+    /// the config (`openmetrics tcp://127.0.0.1:9749 { }`).
+    Monitor {
+        /// Seconds between samples.
+        #[arg(long, short = 'n', default_value_t = 2)]
+        interval: u64,
+        /// Stop after this many samples (default: run until interrupted).
+        #[arg(long, short = 'c')]
+        count: Option<u64>,
+        /// Override the scrape address (default: `openmetrics` from the config).
+        #[arg(long, value_name = "HOST:PORT")]
+        addr: Option<String>,
+    },
     /// Show server status (connections, users, uptime).
     Status {
         /// Per-port breakdown.

--- a/crates/chatmail-metrics/src/lib.rs
+++ b/crates/chatmail-metrics/src/lib.rs
@@ -22,7 +22,7 @@ mod server;
 
 pub use metrics::{
     conn_guard, exposition_text, init_metrics, record_smtp_aborted, record_smtp_completed,
-    record_smtp_failed_command, record_smtp_failed_login, record_smtp_started, set_queue_length,
-    ConnGuard,
+    record_smtp_failed_command, record_smtp_failed_login, record_smtp_started, sample_value,
+    samples, set_queue_length, ConnGuard,
 };
 pub use server::run_openmetrics_listener;

--- a/crates/chatmail-metrics/src/metrics.rs
+++ b/crates/chatmail-metrics/src/metrics.rs
@@ -191,22 +191,48 @@ pub(crate) fn gather_bytes() -> Result<Vec<u8>, prometheus::Error> {
 }
 
 /// Parse a counter/gauge sample from Prometheus text exposition.
-#[cfg(test)]
-pub fn sample_value(body: &str, metric_name: &str, label_selector: &str) -> Option<f64> {
+/// Every sample of `metric_name` in a Prometheus text exposition, as
+/// `(label set, value)` - the label set is the raw text between the braces, or
+/// empty for an unlabelled metric.
+///
+/// The name must match exactly: asking for `maddy_smtp_started` does not return
+/// samples of `maddy_smtp_started_transactions`.
+pub fn samples(body: &str, metric_name: &str) -> Vec<(String, f64)> {
+    let mut out = Vec::new();
     for line in body.lines() {
-        if line.starts_with('#') || line.is_empty() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
             continue;
         }
-        if !line.starts_with(metric_name) {
+        let Some(rest) = line.strip_prefix(metric_name) else {
             continue;
+        };
+        let (labels, rest) = match rest.strip_prefix('{') {
+            Some(after) => match after.split_once('}') {
+                Some((labels, rest)) => (labels.to_string(), rest),
+                None => continue,
+            },
+            // Without braces the name must end here, otherwise this is a
+            // different metric that merely starts with the same characters.
+            None if rest.starts_with(char::is_whitespace) => (String::new(), rest),
+            None => continue,
+        };
+        // The exposition format is `name{labels} value [timestamp]`; this
+        // encoder never emits timestamps.
+        if let Some(value) = rest.split_whitespace().next().and_then(|v| v.parse().ok()) {
+            out.push((labels, value));
         }
-        if !label_selector.is_empty() && !line.contains(label_selector) {
-            continue;
-        }
-        let value = line.split_whitespace().last()?;
-        return value.parse().ok();
     }
-    None
+    out
+}
+
+/// First sample of `metric_name` whose label set contains `label_selector`
+/// (empty selector matches the first sample of any label set).
+pub fn sample_value(body: &str, metric_name: &str, label_selector: &str) -> Option<f64> {
+    samples(body, metric_name)
+        .into_iter()
+        .find(|(labels, _)| label_selector.is_empty() || labels.contains(label_selector))
+        .map(|(_, value)| value)
 }
 
 #[cfg(test)]
@@ -214,6 +240,39 @@ mod tests {
     use super::*;
 
     const MODULE: &str = "metrics_unit_test";
+
+    #[test]
+    fn samples_matches_the_exact_metric_name() {
+        let body = "\
+# HELP maddy_smtp_started_transactions Amount of SMTP transactions started
+# TYPE maddy_smtp_started_transactions counter
+maddy_smtp_started_transactions{module=\"smtp\"} 7
+maddy_smtp_started_transactions{module=\"submission\"} 3
+maddy_queue_length{module=\"remote_queue\",location=\"/tmp/q\"} 2
+bare_metric 5
+";
+
+        let started = samples(body, "maddy_smtp_started_transactions");
+        assert_eq!(started.len(), 2);
+        assert_eq!(started[0].1, 7.0);
+        assert_eq!(started[1].1, 3.0);
+        assert!(started[0].0.contains(r#"module="smtp""#));
+
+        // A shorter name that is a prefix of a real one must not match it.
+        assert!(samples(body, "maddy_smtp_started").is_empty());
+
+        assert_eq!(samples(body, "bare_metric"), vec![(String::new(), 5.0)]);
+
+        assert_eq!(
+            sample_value(
+                body,
+                "maddy_smtp_started_transactions",
+                r#"module="submission""#
+            ),
+            Some(3.0)
+        );
+        assert_eq!(sample_value(body, "maddy_no_such_metric", ""), None);
+    }
 
     #[test]
     fn conn_guard_counts_while_alive() {

--- a/crates/chatmail/src/ctl/dispatch.rs
+++ b/crates/chatmail/src/ctl/dispatch.rs
@@ -144,7 +144,7 @@ fn not_implemented(cmd: &Command) -> Result<()> {
          Implemented: run, upgrade, update, version, admin-token, admin-web, install, certificate, \
          accounts, ban-list, blocklist, create-user, delete, registration, openrelay, language, \
          html-export, html-serve, html-migrate, webimap, websmtp, webmail-cors, push, federation, registration-tokens, sharing, \
-         status, uninstall, service, firewall, endpoint-cache, port, proxy, iroh, dkim, db, reload, message-size, tasks, queue, versions, completion"
+         monitor, status, uninstall, service, firewall, endpoint-cache, port, proxy, iroh, dkim, db, reload, message-size, tasks, queue, versions, completion"
     )))
 }
 

--- a/crates/chatmail/src/ctl/dispatch.rs
+++ b/crates/chatmail/src/ctl/dispatch.rs
@@ -22,7 +22,7 @@ use chatmail_db::settings_keys;
 
 use super::{
     accounts, admin_token, admin_web, blocklist_cmd, certificate, db, delete_cmd, dkim, docs,
-    endpoint_cache, federation, firewall_cmd, html, install, iroh, language, message_size,
+    endpoint_cache, federation, firewall_cmd, html, install, iroh, language, message_size, monitor,
     openrelay, port, proxy, push, queue_cmd, registration, registration_tokens, reload,
     service_cmd, service_toggle, sharing, status_cmd, tasks, uninstall, version, versions_cmd,
     webmail_cors,
@@ -112,6 +112,11 @@ pub async fn dispatch(cli: &Cli) -> Result<()> {
         }
         Some(Command::Sharing(cmd)) => sharing::sharing(&cli.args, cmd).await,
         Some(Command::Db(cmd)) => db::db(&cli.args, cmd).await,
+        Some(Command::Monitor {
+            interval,
+            count,
+            addr,
+        }) => monitor::monitor(&cli.args, *interval, *count, addr.as_deref()).await,
         Some(Command::Status { details }) => status_cmd::status(&cli.args, *details).await,
         Some(Command::Uninstall(flags)) => uninstall::uninstall(&cli.args, flags).await,
         Some(Command::Service(cmd)) => service_cmd::service(&cli.args, cmd).await,
@@ -174,6 +179,7 @@ fn command_name(cmd: &Command) -> &'static str {
         Command::Registration { .. } => "registration",
         Command::Openrelay { .. } => "openrelay",
         Command::MigratePgpConfig => "migrate-pgp-config",
+        Command::Monitor { .. } => "monitor",
         Command::Status { .. } => "status",
         Command::Port(_) => "port",
         Command::Queue { .. } => "queue",

--- a/crates/chatmail/src/ctl/install/config.rs
+++ b/crates/chatmail/src/ctl/install/config.rs
@@ -356,10 +356,11 @@ imap tls://0.0.0.0:993 tcp://0.0.0.0:143 {{
 {turn_block}
 {chatmail_http}
 
-# Prometheus / OpenMetrics (scrape http://127.0.0.1:9100/metrics)
-# openmetrics tcp://127.0.0.1:9100 {{
-#     debug no
-# }}
+# Prometheus / OpenMetrics (scrape http://127.0.0.1:9749/metrics; read by `madmail monitor`).
+# Loopback only: the endpoint has no authentication. 9749 rather than 9100 so it does not
+# collide with node_exporter - a port already in use here fails the boot preflight.
+openmetrics tcp://127.0.0.1:9749 {{
+}}
 "##,
         generated = c.generated,
         hostname = c.hostname,

--- a/crates/chatmail/src/ctl/install/mod.rs
+++ b/crates/chatmail/src/ctl/install/mod.rs
@@ -1236,6 +1236,10 @@ mod tests {
             conf.contains(&format!("relay_ip {IPV6}")),
             "TURN relay_ip should use explicit IPv6: {conf}"
         );
+        // `madmail monitor` reads this endpoint, so the generated config has to
+        // enable it - and parse back to the loopback listener, not just contain it.
+        let parsed = chatmail_config::parse_maddy_config(&conf).expect("generated config parses");
+        assert_eq!(parsed.openmetrics_listen.as_deref(), Some("127.0.0.1:9749"));
     }
 
     #[test]

--- a/crates/chatmail/src/ctl/mod.rs
+++ b/crates/chatmail/src/ctl/mod.rs
@@ -39,6 +39,7 @@ mod install;
 mod iroh;
 mod language;
 mod message_size;
+mod monitor;
 mod openrelay;
 mod output;
 mod port;

--- a/crates/chatmail/src/ctl/monitor.rs
+++ b/crates/chatmail/src/ctl/monitor.rs
@@ -1,0 +1,295 @@
+// Copyright (C) 2026 themadorg
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! `madmail monitor` — live connection and throughput metrics.
+//!
+//! Reads the `openmetrics` endpoint the server already exposes rather than
+//! introducing a control socket, so the same numbers back the CLI, a Prometheus
+//! scrape, and any future dashboard.
+
+use std::time::{Duration, Instant};
+
+use chatmail_config::{load_config, AppConfig, Args};
+use chatmail_metrics::samples;
+use chatmail_types::{ChatmailError, Result};
+
+use super::output::CtlOut;
+
+const CONNS_ACTIVE: &str = "maddy_conns_active";
+const COMPLETED: &str = "maddy_smtp_smtp_completed_transactions";
+const ABORTED: &str = "maddy_smtp_aborted_transactions";
+const QUEUE_LENGTH: &str = "maddy_queue_length";
+
+/// One scrape, reduced to the numbers the display needs.
+#[derive(Debug, Default, PartialEq)]
+struct Sample {
+    imap: f64,
+    smtp: f64,
+    submission: f64,
+    conns_total: f64,
+    completed: f64,
+    aborted: f64,
+    queue: f64,
+}
+
+impl Sample {
+    fn parse(body: &str) -> Self {
+        let conns = samples(body, CONNS_ACTIVE);
+        Self {
+            imap: label_value(&conns, "imap"),
+            smtp: label_value(&conns, "smtp"),
+            submission: label_value(&conns, "submission"),
+            conns_total: conns.iter().map(|(_, v)| v).sum(),
+            completed: sum(body, COMPLETED),
+            aborted: sum(body, ABORTED),
+            queue: sum(body, QUEUE_LENGTH),
+        }
+    }
+}
+
+fn sum(body: &str, metric: &str) -> f64 {
+    samples(body, metric).iter().map(|(_, v)| v).sum()
+}
+
+fn label_value(samples: &[(String, f64)], module: &str) -> f64 {
+    let selector = format!(r#"module="{module}""#);
+    samples
+        .iter()
+        .find(|(labels, _)| labels.contains(&selector))
+        .map(|(_, v)| *v)
+        .unwrap_or(0.0)
+}
+
+/// Per-second rate between two counter readings.
+///
+/// A server restart resets the counter, which would otherwise show up as a
+/// large negative rate; Prometheus treats a counter going backwards as a reset
+/// and reports 0 for that interval, and so do we.
+fn rate(prev: f64, cur: f64, dt: Duration) -> f64 {
+    let secs = dt.as_secs_f64();
+    if secs <= 0.0 || cur < prev {
+        return 0.0;
+    }
+    (cur - prev) / secs
+}
+
+/// `host:port` to scrape: `--addr`, else the configured `openmetrics` listener.
+fn scrape_addr(config: &AppConfig, addr: Option<&str>) -> Result<String> {
+    if let Some(addr) = addr {
+        return Ok(dialable(addr));
+    }
+    match config.openmetrics_listen.as_deref() {
+        Some(listen) => Ok(dialable(listen)),
+        None => Err(ChatmailError::config(
+            "openmetrics endpoint is not enabled; add `openmetrics tcp://127.0.0.1:9749 { }` \
+             to the config (bind it to loopback - it has no authentication), \
+             or pass --addr",
+        )),
+    }
+}
+
+/// A wildcard bind address is not a dial address - rewrite it to loopback.
+fn dialable(listen: &str) -> String {
+    match listen.rsplit_once(':') {
+        Some(("0.0.0.0", port)) | Some(("", port)) => format!("127.0.0.1:{port}"),
+        Some(("[::]", port)) | Some(("::", port)) => format!("[::1]:{port}"),
+        _ => listen.to_string(),
+    }
+}
+
+pub async fn monitor(
+    args: &Args,
+    interval: u64,
+    count: Option<u64>,
+    addr: Option<&str>,
+) -> Result<()> {
+    let out = CtlOut::from_args(args, "monitor");
+    let config = if args.config.is_file() {
+        load_config(&args.config)?
+    } else {
+        AppConfig::default()
+    };
+    let url = format!("http://{}/metrics", scrape_addr(&config, addr)?);
+    let interval = Duration::from_secs(interval.max(1));
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .map_err(|e| ChatmailError::config(format!("monitor: HTTP client: {e}")))?;
+
+    out.line(format!("Scraping {url} every {}s", interval.as_secs()));
+
+    let mut previous: Option<(Sample, Instant)> = None;
+    let mut printed = 0u64;
+    loop {
+        // The first row is printed immediately with no rate, so that
+        // `--count 1` returns the current counts right away instead of
+        // sleeping through an interval first.
+        if previous.is_some() {
+            tokio::time::sleep(interval).await;
+        }
+
+        let body = scrape(&client, &url).await?;
+        let now = Instant::now();
+        let sample = Sample::parse(&body);
+
+        // Header only once the first scrape has actually worked, so a failure
+        // to reach the endpoint is not preceded by an empty table.
+        if previous.is_none() {
+            out.line(format!(
+                "{:>6} {:>6} {:>10} {:>7} {:>9} {:>9} {:>7}",
+                "imap", "smtp", "submission", "total", "msg/s", "aborted/s", "queue"
+            ));
+        }
+
+        let rates = previous.as_ref().map(|(prev, at)| {
+            let dt = now.duration_since(*at);
+            (
+                rate(prev.completed, sample.completed, dt),
+                rate(prev.aborted, sample.aborted, dt),
+            )
+        });
+
+        report(&out, &sample, rates)?;
+        previous = Some((sample, now));
+
+        printed += 1;
+        if count.is_some_and(|n| printed >= n) {
+            return Ok(());
+        }
+    }
+}
+
+async fn scrape(client: &reqwest::Client, url: &str) -> Result<String> {
+    let resp = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| ChatmailError::config(format!("monitor: GET {url}: {e}")))?;
+    if !resp.status().is_success() {
+        return Err(ChatmailError::config(format!(
+            "monitor: GET {url}: HTTP {}",
+            resp.status()
+        )));
+    }
+    resp.text()
+        .await
+        .map_err(|e| ChatmailError::config(format!("monitor: reading {url}: {e}")))
+}
+
+fn report(out: &CtlOut, s: &Sample, rates: Option<(f64, f64)>) -> Result<()> {
+    if out.is_json() {
+        // One envelope per sample, so `--json` streams as NDJSON.
+        return out.emit(serde_json::json!({
+            "conns": {
+                "imap": s.imap,
+                "smtp": s.smtp,
+                "submission": s.submission,
+                "total": s.conns_total,
+            },
+            "messages_per_second": rates.map(|(msg, _)| msg),
+            "aborted_per_second": rates.map(|(_, aborted)| aborted),
+            "completed_total": s.completed,
+            "aborted_total": s.aborted,
+            "queue_length": s.queue,
+        }));
+    }
+
+    let (msg, aborted) = match rates {
+        Some((msg, aborted)) => (format!("{msg:.2}"), format!("{aborted:.2}")),
+        // No previous sample yet, so there is no interval to average over.
+        None => ("-".to_string(), "-".to_string()),
+    };
+    out.line(format!(
+        "{:>6} {:>6} {:>10} {:>7} {:>9} {:>9} {:>7}",
+        s.imap as i64,
+        s.smtp as i64,
+        s.submission as i64,
+        s.conns_total as i64,
+        msg,
+        aborted,
+        s.queue as i64,
+    ));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BODY: &str = "\
+# TYPE maddy_conns_active gauge
+maddy_conns_active{module=\"imap\"} 4
+maddy_conns_active{module=\"smtp\"} 2
+maddy_conns_active{module=\"submission\"} 1
+maddy_smtp_smtp_completed_transactions{module=\"smtp\"} 10
+maddy_smtp_smtp_completed_transactions{module=\"submission\"} 5
+maddy_smtp_aborted_transactions{module=\"smtp\"} 3
+maddy_queue_length{module=\"remote_queue\",location=\"/tmp/q\"} 7
+";
+
+    #[test]
+    fn parses_a_scrape_into_totals() {
+        let s = Sample::parse(BODY);
+        assert_eq!(s.imap, 4.0);
+        assert_eq!(s.smtp, 2.0);
+        assert_eq!(s.submission, 1.0);
+        assert_eq!(s.conns_total, 7.0);
+        // Summed across module labels.
+        assert_eq!(s.completed, 15.0);
+        assert_eq!(s.aborted, 3.0);
+        assert_eq!(s.queue, 7.0);
+    }
+
+    #[test]
+    fn missing_metrics_read_as_zero() {
+        assert_eq!(Sample::parse(""), Sample::default());
+    }
+
+    #[test]
+    fn rate_is_per_second_and_survives_a_counter_reset() {
+        assert_eq!(rate(10.0, 20.0, Duration::from_secs(2)), 5.0);
+        // Server restarted between scrapes: report 0, not a huge negative.
+        assert_eq!(rate(100.0, 1.0, Duration::from_secs(2)), 0.0);
+        // Two scrapes in the same instant would divide by zero.
+        assert_eq!(rate(1.0, 9.0, Duration::ZERO), 0.0);
+    }
+
+    #[test]
+    fn wildcard_bind_addresses_are_dialled_on_loopback() {
+        assert_eq!(dialable("0.0.0.0:9749"), "127.0.0.1:9749");
+        assert_eq!(dialable("[::]:9749"), "[::1]:9749");
+        assert_eq!(dialable("127.0.0.1:9749"), "127.0.0.1:9749");
+        assert_eq!(dialable("metrics.internal:9749"), "metrics.internal:9749");
+    }
+
+    #[test]
+    fn scrape_addr_prefers_the_flag_then_the_config() {
+        let mut config = AppConfig::default();
+        assert_eq!(
+            scrape_addr(&config, Some("10.0.0.1:1234")).unwrap(),
+            "10.0.0.1:1234"
+        );
+
+        // Neither set: the error has to say how to turn the endpoint on.
+        let err = scrape_addr(&config, None).unwrap_err().to_string();
+        assert!(err.contains("openmetrics"), "unhelpful error: {err}");
+
+        config.openmetrics_listen = Some("0.0.0.0:9749".to_string());
+        assert_eq!(scrape_addr(&config, None).unwrap(), "127.0.0.1:9749");
+    }
+}

--- a/crates/chatmail/tests/monitor_test.rs
+++ b/crates/chatmail/tests/monitor_test.rs
@@ -1,0 +1,85 @@
+//! End-to-end: the real `madmail monitor` binary scraping a live openmetrics listener.
+
+use std::process::Command;
+use std::time::Duration;
+
+use assert_cmd::cargo::cargo_bin;
+use chatmail_metrics::run_openmetrics_listener;
+use tempfile::TempDir;
+use tokio_util::sync::CancellationToken;
+
+fn reserve_addr() -> String {
+    let s = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    s.local_addr().expect("addr").to_string()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn monitor_reads_a_live_openmetrics_listener() {
+    let addr = reserve_addr();
+    let cancel = CancellationToken::new();
+    let listen = addr.clone();
+    let cancel_bg = cancel.clone();
+    let server = tokio::spawn(async move {
+        run_openmetrics_listener(&listen, cancel_bg)
+            .await
+            .expect("openmetrics")
+    });
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    // An open connection in this process must show up in the separate
+    // `madmail` process's scrape: gauge -> exporter -> HTTP -> CLI parser.
+    let guard = chatmail_metrics::conn_guard("imap");
+
+    // Point --config at a file that does not exist so the repo's
+    // `./data/chatmail.toml` is not picked up (see boot_test.rs).
+    let dir = TempDir::new().expect("tempdir");
+    let config = dir.path().join("none.toml");
+    let (config, state) = (
+        config.to_string_lossy().into_owned(),
+        dir.path().to_string_lossy().into_owned(),
+    );
+    let output = tokio::task::spawn_blocking(move || {
+        Command::new(cargo_bin("madmail"))
+            .args([
+                "--json",
+                "--config",
+                &config,
+                "--state-dir",
+                &state,
+                "monitor",
+                "--addr",
+                &addr,
+                "--count",
+                "1",
+            ])
+            .output()
+            .expect("run madmail monitor")
+    })
+    .await
+    .expect("join");
+    drop(guard);
+
+    assert!(
+        output.status.success(),
+        "exit {:?}\nstdout: {}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("utf8");
+    let line = stdout.lines().next().expect("one JSON line");
+    let v: serde_json::Value = serde_json::from_str(line).expect("json envelope");
+
+    assert_eq!(v["ok"], true, "{v}");
+    assert_eq!(v["command"], "monitor", "{v}");
+    assert_eq!(v["data"]["conns"]["imap"], 1.0, "{v}");
+    // Pre-created by init_metrics, so present and zero rather than absent.
+    assert_eq!(v["data"]["conns"]["smtp"], 0.0, "{v}");
+    assert_eq!(v["data"]["conns"]["submission"], 0.0, "{v}");
+    // The first sample has nothing to measure a rate against.
+    assert!(v["data"]["messages_per_second"].is_null(), "{v}");
+
+    cancel.cancel();
+    server.await.expect("server task");
+}

--- a/docs/TDD/14-cli-tools.md
+++ b/docs/TDD/14-cli-tools.md
@@ -59,6 +59,7 @@ Status: **done** · **planned** (parsed, `not_implemented`) · **defer**
 | `version` | [version.md](../guide/cli/version.md) | `version.rs` | **done** |
 | `reload` | [reload.md](../guide/cli/reload.md) | `reload.rs` | **done** |
 | `status` | [status.md](../guide/cli/status.md) | `status_cmd.rs` | **done** |
+| `monitor` | [monitor.md](../guide/cli/monitor.md) | `monitor.rs` | **done** |
 | `completion` | [completion.md](../guide/cli/completion.md) | `docs.rs` | **done** |
 | `admin-token` | [admin-token.md](../guide/cli/admin-token.md) | `admin_token.rs` | **done** |
 | `admin-web` | [admin-web.md](../guide/cli/admin-web.md) | `admin_web.rs` | **done** |
@@ -114,6 +115,7 @@ Status: **done** · **planned** (parsed, `not_implemented`) · **defer**
 | `version` | [version.md](../guide/cli/version.md) | `maddy.go` | **done** |
 | `reload` | [reload.md](../guide/cli/reload.md) | `ctl/reload_config.go` | **done** |
 | `status` | [status.md](../guide/cli/status.md) | `ctl/online.go` | **done** (`--details`) |
+| `monitor` | [monitor.md](../guide/cli/monitor.md) | — (v2; #19) | **done** (`--interval`, `--count`, `--addr`) |
 | `certificate` | [certificate.md](../guide/cli/certificate.md) | — (instant-acme) | **done** — `get`, `regenerate`, `status`, [`autocert`](../guide/cli/certificate-autocert.md) |
 | `db` | [db.md](../guide/cli/db.md) | — | **done** — `sqlite-to-postgres` |
 

--- a/docs/guide/cli/README.md
+++ b/docs/guide/cli/README.md
@@ -62,6 +62,9 @@ Port service aliases: `submission_tls` → `submission-tls`, `imap_tls` → `ima
 ### [`status`](status.md)
 
 
+### [`monitor`](monitor.md)
+
+
 ### [`db`](db.md)
 
 - [`sqlite-to-postgres`](db-sqlite-to-postgres.md)

--- a/docs/guide/cli/json-output.md
+++ b/docs/guide/cli/json-output.md
@@ -135,6 +135,27 @@ Not applicable — server mode does not use ctl JSON output.
 
 `ports` and `server_tracker` are omitted when unavailable. Use `--details` to include `ports`.
 
+### `monitor`
+
+One envelope per sample (newline-delimited when `--count` is not 1):
+
+```json
+{
+  "ok": true,
+  "command": "monitor",
+  "data": {
+    "conns": { "imap": 4.0, "smtp": 2.0, "submission": 0.0, "total": 6.0 },
+    "messages_per_second": 19.88,
+    "aborted_per_second": 0.0,
+    "completed_total": 180.0,
+    "aborted_total": 5.0,
+    "queue_length": 3.0
+  }
+}
+```
+
+`messages_per_second` and `aborted_per_second` are `null` on the first sample, which has no previous sample to measure against. Metrics missing from the scrape read as `0`.
+
 ### `reload`
 
 ```json

--- a/docs/guide/cli/monitor.md
+++ b/docs/guide/cli/monitor.md
@@ -1,0 +1,74 @@
+# `monitor`
+
+Live connection and message-throughput metrics from a running server, one row per sample.
+
+
+## Synopsis
+
+```bash
+madmail monitor [-n|--interval <SECS>] [-c|--count <N>] [--addr <HOST:PORT>]
+```
+
+## Global flags
+
+| Flag | Alias | Environment | Default | Description |
+|------|-------|-------------|---------|-------------|
+| `--config` | — | `CHATMAIL_CONFIG` | `/etc/madmail/madmail.conf` (or `./data/chatmail.toml` when present) | Path to the server config file |
+| `--state-dir` | `--libexec` | `CHATMAIL_STATE_DIR` | `/var/lib/madmail` (or `./data` when it contains state) | Persistent state directory (`credentials.db`, maildirs, `admin_token`, …) |
+
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `-n`, `--interval <SECS>` | Seconds between samples (default `2`) |
+| `-c`, `--count <N>` | Stop after `N` samples (default: run until interrupted) |
+| `--addr <HOST:PORT>` | Scrape this address instead of the config's `openmetrics` listener |
+
+## Example
+
+```bash
+madmail monitor
+madmail monitor --interval 1 --count 10
+madmail monitor --count 1 --json
+```
+
+```
+Scraping http://127.0.0.1:9749/metrics every 2s
+  imap   smtp submission   total     msg/s aborted/s   queue
+     4      2          0       6         -         -       3
+     4      2          0       6     19.88      0.00       3
+```
+
+Reads the server's `openmetrics` endpoint (`/metrics`), so that endpoint must be enabled. `madmail install` writes it into the generated config:
+
+```
+openmetrics tcp://127.0.0.1:9749 {
+}
+```
+
+Keep it on loopback — the endpoint has no authentication. A wildcard bind address (`0.0.0.0`, `[::]`) is scraped over loopback.
+
+- **Connections** are `maddy_conns_active` per module; `total` sums every module.
+- **msg/s** is the change in `maddy_smtp_smtp_completed_transactions` (summed across modules) divided by the wall-clock time between two scrapes. The first row has no previous sample, so it shows `-`.
+- A counter that goes backwards means the server restarted; that interval reports `0`.
+
+## JSON output (`--json`)
+
+```bash
+madmail monitor --count 1 --json
+```
+
+One success envelope per sample, so without `--count` the output is newline-delimited JSON:
+
+```json
+{"ok": true, "command": "monitor", "data": { ... }}
+```
+
+Schema: [json-output.md](json-output.md#monitor).
+
+
+---
+[← CLI index](README.md) · [Global flags](global-flags.md)
+
+[Source: `crates/chatmail/src/ctl/monitor.rs`](https://github.com/themadorg/madmail/blob/main/crates/chatmail/src/ctl/monitor.rs)


### PR DESCRIPTION
Step 4 of #19: the CLI. Top of a two-PR stack, rebased onto 2.27.0:

| | | |
|---|---|---|
| themadorg/madmail#164 | `maddy_conns_active` gauge (step 1) | base `main` |
| **this PR** | `madmail monitor` (step 4) | base `feat/19-conn-metrics` |

This is based on `feat/19-conn-metrics`, not `main`, so the diff here is only this PR's own four commits. **Merge order:** #164 first, then retarget this PR to `main` — GitHub will not do that automatically, because #164's head is a fork branch rather than the base branch this PR points at.

How to retarget depends on how #164 lands. If it is **merge-committed**, its commit is in `main`'s history and a plain `gh pr edit 165 --base main` is enough. If it is **squash-merged**, `60aed77` never reaches `main`, and retargeting alone would show the gauge changes twice — this branch has to be replayed onto the squash first:

```bash
git fetch upstream
git rebase --onto upstream/main 60aed77 feat/19-monitor-cli
git push -f origin feat/19-monitor-cli
gh pr edit 165 --repo themadorg/madmail --base main
```

```
$ madmail monitor --interval 1
Scraping http://127.0.0.1:9749/metrics every 1s
  imap   smtp submission   total     msg/s aborted/s   queue
     4      2          0       6         -         -       3
     4      2          0       6     19.88      0.00       3
     4      2          0       6     19.91      0.00       3
```

## Commits

1. `feat(cli): add madmail monitor …` — the command, plus an exact-name metrics parser.
2. `fix(cli): enable the openmetrics endpoint in the installer` — see below.
3. `test(cli): run monitor against a live openmetrics listener`
4. `docs(cli): document madmail monitor` — guide page, JSON schema, index and status rows.

## Why scrape `/metrics` instead of adding a control socket

The existing `ctl` commands are offline — they read the config and open the DB in-process — so none of them can see a running server's state. Rather than introduce a control socket for this one command, `monitor` reads the `openmetrics` endpoint the server already serves. The CLI, a Prometheus scrape and any future dashboard then read the same numbers, and there is no second code path to keep in sync. That is also the issue's "Data Export Readiness" item, satisfied by construction.

## The installer now enables the endpoint — on 9749, not 9100

The installer used to write the `openmetrics` block commented out, so on a default install `monitor` could only report that the endpoint was off. It now writes:

```
openmetrics tcp://127.0.0.1:9749 {
}
```

The old commented example used 9100. That is node_exporter's default port, and the supervisor runs `preflight_listen_addrs` on the openmetrics address at boot and propagates the failure — so enabling it on 9100 would make a fresh install fail to start on any host already running node_exporter. 9749 avoids that and matches what the error message and docs already say. It stays on loopback because the endpoint has no authentication. This only affects newly generated configs; existing ones are untouched.

If you would rather keep it opt-in, it is a one-line revert of commit 2, and the error message already names the exact line to add:

```
Error: configuration error: openmetrics endpoint is not enabled; add `openmetrics tcp://127.0.0.1:9749 { }` to the config (bind it to loopback - it has no authentication), or pass --addr
```

## Decisions worth reviewing

- **Rates are client-side**, `Δcounter / Δt` across two scrapes — the sliding window the issue asks for, without a ring buffer on the server.
- **Wall-clock `Δt`**, not the nominal interval, so scrape latency does not skew readings.
- **A counter going backwards means the server restarted**, and reports `0` for that interval, as Prometheus does for a counter reset. Otherwise a restart would show as a large negative rate.
- **The first row prints immediately with `-` for rates**, so `monitor --count 1 --json` returns current counts straight away for scripting.
- **`--json` emits one envelope per sample** (NDJSON).
- **A wildcard `openmetrics_listen`** (`0.0.0.0`, `[::]`) is a bind address, not a dial address, and is rewritten to loopback.
- **5s HTTP timeout, async reqwest client** — `reqwest::blocking` builds its own runtime and panics under the one `dispatch` runs on (see the comment at `dispatch.rs:45`).

## Metrics parser

`sample_value` in `chatmail-metrics` matched on `line.starts_with(name)`, so `maddy_smtp_started` would have matched samples of `maddy_smtp_started_transactions`. It is now an exact name match (the name must be followed by `{` or whitespace), exposed as `samples()`, which returns every labelled sample so the CLI can sum across modules. `sample_value` wraps it and keeps its behaviour and callers.

## Verification

Run on macOS against this branch rebased onto 2.27.0 (which includes upstream's own `statvfs` fix, so the workspace builds there without #166, now closed):

- `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all --check`, `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` — all clean.
- `cargo test -p chatmail -p chatmail-metrics -p chatmail-config -p chatmail-smtp` — all pass, 0 failures.
- **End-to-end** (`crates/chatmail/tests/monitor_test.rs`): starts a real openmetrics listener, holds a connection guard in the test process, and runs the actual `madmail monitor --json --count 1` binary against it. It must report `imap: 1` from that live gauge — covering the gauge, the exporter, HTTP and the parser together — plus `smtp`/`submission` present as `0` and no rate on the first sample.
- **Installer round-trip**: the generated config is parsed back with `parse_maddy_config` and must yield `openmetrics_listen == 127.0.0.1:9749`, so a malformed block fails the test rather than just a missing string.
- Unit tests in `monitor.rs` cover scrape parsing, missing metrics reading as 0, rate including counter reset and zero `Δt`, wildcard address rewriting, and `--addr`/config/error precedence; one in `metrics.rs` covers exact name matching.

What is still not exercised is a full `madmail run` boot followed by `monitor`; the e2e test runs the real exporter and the real CLI binary, but not the supervisor that wires them together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
