### PR TITLE
fix(admin): widen statvfs fields before multiplying

### DIFF
--- a/crates/chatmail-admin/src/resources/status_storage.rs
+++ b/crates/chatmail-admin/src/resources/status_storage.rs
@@ -532,6 +532,10 @@ pub async fn storage(st: &AdminState, method: &str) -> AdminResult {
 }
 
 #[cfg(unix)]
+// The statvfs widening below is a no-op on whichever platform already has the
+// wider field, so one of the conversions is always "useless" - but which one
+// depends on the target, so it cannot be written to satisfy the lint everywhere.
+#[allow(clippy::useless_conversion)]
 fn disk_usage(path: &Path) -> Option<serde_json::Value> {
     use std::ffi::CString;
     use std::mem::MaybeUninit;
@@ -543,9 +547,11 @@ fn disk_usage(path: &Path) -> Option<serde_json::Value> {
         return None;
     }
     let stat = unsafe { stat.assume_init() };
-    let bsize = stat.f_frsize;
-    let total_bytes = stat.f_blocks * bsize;
-    let avail_bytes = stat.f_bavail * bsize;
+    // statvfs field widths are platform-dependent: f_blocks/f_bavail are 32-bit
+    // on macOS and 64-bit on Linux, so widen before multiplying.
+    let bsize = u64::from(stat.f_frsize);
+    let total_bytes = u64::from(stat.f_blocks) * bsize;
+    let avail_bytes = u64::from(stat.f_bavail) * bsize;
     let used_bytes = total_bytes.saturating_sub(avail_bytes);
     let percent_used = if total_bytes > 0 {
         used_bytes as f64 / total_bytes as f64 * 100.0


### PR DESCRIPTION
> **Stack:** themadorg/madmail#166 (macOS build fix) · themadorg/madmail#164 (step 1, the gauge) · themadorg/madmail#165 (step 4, `madmail monitor`). #166 and #164 are independent and can merge in any order. #165 is based on the `feat/19-conn-metrics` branch, so once this PR merges it needs retargeting to `main`.

`crates/chatmail-admin/src/resources/status_storage.rs` does not compile on macOS:

```
error[E0277]: cannot multiply `u32` by `u64`
   --> crates/chatmail-admin/src/resources/status_storage.rs:548:37
    |
548 |     let avail_bytes = stat.f_bavail * bsize;
    |                                     ^ no implementation for `u32 * u64`
```

`statvfs` field widths are platform-dependent. `f_blocks` and `f_bavail` are `fsblkcnt_t`, which is 32-bit on macOS and 64-bit on Linux, while `f_frsize` is 64-bit on both. Multiplying them directly only type-checks on Linux, so the whole `chatmail-admin` crate — and everything that depends on it, which includes the `chatmail` binary — fails to build on a macOS host.

Widening all three to `u64` before multiplying fixes it and is a no-op on Linux.

The `#[allow(clippy::useless_conversion)]` is unfortunately necessary: whichever field is already 64-bit on a given target makes its own conversion redundant, and which one that is differs per platform, so there is no spelling that satisfies the lint on both. Writing `as u64` instead just swaps this lint for `clippy::unnecessary_cast` with the same platform split.

## Verification

- macOS: `RUSTFLAGS="-D warnings" cargo check -p chatmail-admin` and `cargo clippy -p chatmail-admin --all-targets -- -D warnings` both clean, where before the change `cargo check` failed with four errors.
- The arithmetic is unchanged on Linux — same values, same types after widening.

Found while working on #19; unrelated to that issue, so it is on its own.

