### PR TITLE
fix(federation): drop the unreachable SMTP-over-443 delivery retry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,6 +877,7 @@ dependencies = [
  "chatmail-config",
  "chatmail-db",
  "chatmail-iroh",
+ "chatmail-metrics",
  "chatmail-pgp",
  "chatmail-push",
  "chatmail-state",

--- a/crates/chatmail-config/src/cli.rs
+++ b/crates/chatmail-config/src/cli.rs
@@ -192,6 +192,21 @@ pub enum Command {
     /// Migrate submission PGP policy in config.
     #[command(name = "migrate-pgp-config")]
     MigratePgpConfig,
+    /// Live server metrics (connections and message throughput).
+    ///
+    /// Polls the `openmetrics` endpoint, so that endpoint has to be enabled in
+    /// the config (`openmetrics tcp://127.0.0.1:9749 { }`).
+    Monitor {
+        /// Seconds between samples.
+        #[arg(long, short = 'n', default_value_t = 2)]
+        interval: u64,
+        /// Stop after this many samples (default: run until interrupted).
+        #[arg(long, short = 'c')]
+        count: Option<u64>,
+        /// Override the scrape address (default: `openmetrics` from the config).
+        #[arg(long, value_name = "HOST:PORT")]
+        addr: Option<String>,
+    },
     /// Show server status (connections, users, uptime).
     Status {
         /// Per-port breakdown.

--- a/crates/chatmail-delivery/src/federation_smtp.rs
+++ b/crates/chatmail-delivery/src/federation_smtp.rs
@@ -110,10 +110,11 @@ impl SmtpTransport {
     }
 }
 
-/// Deliver one message over SMTP.
+/// Deliver one message over SMTP on port 25, upgrading with STARTTLS when offered.
 ///
-/// Tries port 25 (optional STARTTLS) first, then port 443 implicit TLS — required for
-/// classic Chatmail relays (`nine.testrun.org`, etc.) that expose SMTP only on :443.
+/// Port 25 is the only SMTP port tried. MX records name a host, not a port, so
+/// inbound mail cannot be anywhere else; the relay-to-relay alternative is the
+/// HTTPS `/mxdeliv` route in [`crate::transport`], which runs first.
 ///
 /// `helo_name` is this server's identity for EHLO (primary_domain / public IP), not the remote host.
 pub async fn deliver(host: &str, job: &OutboundJob, helo_name: &str) -> Result<(), String> {
@@ -133,22 +134,18 @@ pub async fn deliver(host: &str, job: &OutboundJob, helo_name: &str) -> Result<(
     match deliver_plain_starttls(&endpoint25, connect_host, rcpt_domain, helo, job).await {
         Ok(()) => {
             info!(endpoint = %endpoint25, rcpt = %job.rcpt_to, "federation: SMTP delivery ok (port 25)");
-            return Ok(());
+            Ok(())
         }
         Err(e25) => {
             warn!(
                 endpoint = %endpoint25,
                 rcpt = %job.rcpt_to,
                 error = %e25,
-                "federation: SMTP :25 failed, trying implicit TLS :443"
+                "federation: SMTP :25 failed"
             );
+            Err(e25)
         }
     }
-
-    let endpoint443 = format!("{connect_host}:443");
-    deliver_implicit_tls(&endpoint443, connect_host, rcpt_domain, helo, job)
-        .await
-        .map_err(|e443| format!("smtp :25 failed; smtp :443 tls: {e443}"))
 }
 
 /// Plain SMTP on :25 with optional STARTTLS (RFC 3207).
@@ -195,40 +192,6 @@ async fn deliver_plain_starttls(
     }
 
     run_smtp_transaction(&mut transport, job).await
-}
-
-/// Implicit TLS on :443 (Chatmail / Delta Chat relay SMTP submission style).
-async fn deliver_implicit_tls(
-    endpoint: &str,
-    connect_host: &str,
-    rcpt_domain: &str,
-    helo_name: &str,
-    job: &OutboundJob,
-) -> Result<(), String> {
-    info!(endpoint, rcpt = %job.rcpt_to, "federation: SMTP implicit TLS connect");
-
-    let stream = tokio::time::timeout(Duration::from_secs(30), TcpStream::connect(endpoint))
-        .await
-        .map_err(|_| "smtp tls connect timeout".to_string())?
-        .map_err(|e| format!("smtp tls connect: {e}"))?;
-
-    let server_name = smtp_tls_server_name(connect_host, rcpt_domain)?;
-    let tls_stream = tokio::time::timeout(
-        Duration::from_secs(30),
-        federation_smtp_tls_connector().connect(server_name, stream),
-    )
-    .await
-    .map_err(|_| "smtp tls handshake timeout".to_string())?
-    .map_err(|e| format!("smtp tls handshake: {e}"))?;
-
-    let mut transport = SmtpTransport::Tls(Box::new(tls_stream));
-    read_smtp_reply(&mut transport, 220).await?;
-    transport.write_all(format!("EHLO {helo_name}\r\n")).await?;
-    read_smtp_reply(&mut transport, 250).await?;
-
-    run_smtp_transaction(&mut transport, job).await?;
-    info!(endpoint, rcpt = %job.rcpt_to, "federation: SMTP delivery ok (port 443 TLS)");
-    Ok(())
 }
 
 async fn run_smtp_transaction(
@@ -438,5 +401,31 @@ mod tests {
         deliver_to_endpoint(&addr.to_string(), "mx.test", "test", &job)
             .await
             .expect("STARTTLS SMTP federation delivery");
+    }
+
+    /// P7-UT07: a peer with no reachable SMTP on :25 fails there and nowhere else.
+    ///
+    /// There used to be an implicit-TLS retry on :443. It could never deliver mail:
+    /// relays demux :443 to a submission service that requires SASL auth, and a
+    /// peer running plain HTTPS there never sends the server-first banner this
+    /// client waits for — so the retry blocked for the full 30s connect timeout on
+    /// every federation failure. Relay-to-relay delivery goes over HTTPS /mxdeliv
+    /// or port 25, never :443.
+    ///
+    /// `.invalid` is reserved by RFC 2606 and never resolves, so this exercises the
+    /// failure path without touching the network.
+    #[tokio::test]
+    async fn p7_ut07_no_implicit_tls_retry_on_443() {
+        let job = OutboundJob {
+            mail_from: "sender@test".into(),
+            rcpt_to: "rcpt@peer.invalid".into(),
+            data: b"test".to_vec(),
+        };
+
+        let err = deliver("peer.invalid", &job, "mx.test")
+            .await
+            .expect_err("unresolvable peer must fail");
+
+        assert!(!err.contains("443"), "must not retry on :443, got: {err}");
     }
 }

--- a/crates/chatmail-delivery/src/transport.rs
+++ b/crates/chatmail-delivery/src/transport.rs
@@ -84,10 +84,9 @@ pub async fn deliver_remote(ctx: &DeliveryContext, job: &OutboundJob) -> Deliver
                     return DeliveryOutcome::Success;
                 }
                 Err(e) => {
-                    // Always fall through to SMTP after HTTP failure.
-                    // Peers like nine.testrun.org often only accept real SMTP on :443;
-                    // treating 4xx from missing /mxdeliv as permanent skipped SMTP entirely
-                    // and broke WebSMTP/SMTP federation equally once HTTP returned 404.
+                    // Always fall through to SMTP after HTTP failure: treating 4xx from
+                    // a missing /mxdeliv as permanent skipped SMTP entirely, which broke
+                    // federation with any peer that only speaks SMTP once HTTP 404'd.
                     warn!(
                         %url,
                         rcpt = %job.rcpt_to,

--- a/crates/chatmail-imap/Cargo.toml
+++ b/crates/chatmail-imap/Cargo.toml
@@ -10,6 +10,7 @@ chatmail-config = { workspace = true }
 chatmail-db = { workspace = true }
 chatmail-turn = { workspace = true }
 chatmail-iroh = { workspace = true }
+chatmail-metrics = { workspace = true }
 chatmail-push = { workspace = true }
 chatmail-pgp = { workspace = true }
 chatmail-state = { workspace = true }

--- a/crates/chatmail-imap/src/server.rs
+++ b/crates/chatmail-imap/src/server.rs
@@ -66,6 +66,7 @@ pub async fn run_imap_listener(
                 let cfg = cfg.clone();
                 let acceptor = tls_acceptor.clone();
                 tokio::spawn(async move {
+                    let _conn_guard = chatmail_metrics::conn_guard("imap");
                     connection_stats::on_open(&peer_ip);
                     let mut session = ImapSession::new(ctx, pool, cfg);
                     let result = if let Some(acceptor) = acceptor {

--- a/crates/chatmail-metrics/src/lib.rs
+++ b/crates/chatmail-metrics/src/lib.rs
@@ -21,7 +21,8 @@ mod metrics;
 mod server;
 
 pub use metrics::{
-    exposition_text, init_metrics, record_smtp_aborted, record_smtp_completed,
+    conn_guard, exposition_text, init_metrics, record_smtp_aborted, record_smtp_completed,
     record_smtp_failed_command, record_smtp_failed_login, record_smtp_started, set_queue_length,
+    ConnGuard,
 };
 pub use server::run_openmetrics_listener;

--- a/crates/chatmail-metrics/src/lib.rs
+++ b/crates/chatmail-metrics/src/lib.rs
@@ -22,7 +22,7 @@ mod server;
 
 pub use metrics::{
     conn_guard, exposition_text, init_metrics, record_smtp_aborted, record_smtp_completed,
-    record_smtp_failed_command, record_smtp_failed_login, record_smtp_started, set_queue_length,
-    ConnGuard,
+    record_smtp_failed_command, record_smtp_failed_login, record_smtp_started, sample_value,
+    samples, set_queue_length, ConnGuard,
 };
 pub use server::run_openmetrics_listener;

--- a/crates/chatmail-metrics/src/metrics.rs
+++ b/crates/chatmail-metrics/src/metrics.rs
@@ -191,22 +191,48 @@ pub(crate) fn gather_bytes() -> Result<Vec<u8>, prometheus::Error> {
 }
 
 /// Parse a counter/gauge sample from Prometheus text exposition.
-#[cfg(test)]
-pub fn sample_value(body: &str, metric_name: &str, label_selector: &str) -> Option<f64> {
+/// Every sample of `metric_name` in a Prometheus text exposition, as
+/// `(label set, value)` - the label set is the raw text between the braces, or
+/// empty for an unlabelled metric.
+///
+/// The name must match exactly: asking for `maddy_smtp_started` does not return
+/// samples of `maddy_smtp_started_transactions`.
+pub fn samples(body: &str, metric_name: &str) -> Vec<(String, f64)> {
+    let mut out = Vec::new();
     for line in body.lines() {
-        if line.starts_with('#') || line.is_empty() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
             continue;
         }
-        if !line.starts_with(metric_name) {
+        let Some(rest) = line.strip_prefix(metric_name) else {
             continue;
+        };
+        let (labels, rest) = match rest.strip_prefix('{') {
+            Some(after) => match after.split_once('}') {
+                Some((labels, rest)) => (labels.to_string(), rest),
+                None => continue,
+            },
+            // Without braces the name must end here, otherwise this is a
+            // different metric that merely starts with the same characters.
+            None if rest.starts_with(char::is_whitespace) => (String::new(), rest),
+            None => continue,
+        };
+        // The exposition format is `name{labels} value [timestamp]`; this
+        // encoder never emits timestamps.
+        if let Some(value) = rest.split_whitespace().next().and_then(|v| v.parse().ok()) {
+            out.push((labels, value));
         }
-        if !label_selector.is_empty() && !line.contains(label_selector) {
-            continue;
-        }
-        let value = line.split_whitespace().last()?;
-        return value.parse().ok();
     }
-    None
+    out
+}
+
+/// First sample of `metric_name` whose label set contains `label_selector`
+/// (empty selector matches the first sample of any label set).
+pub fn sample_value(body: &str, metric_name: &str, label_selector: &str) -> Option<f64> {
+    samples(body, metric_name)
+        .into_iter()
+        .find(|(labels, _)| label_selector.is_empty() || labels.contains(label_selector))
+        .map(|(_, value)| value)
 }
 
 #[cfg(test)]
@@ -214,6 +240,39 @@ mod tests {
     use super::*;
 
     const MODULE: &str = "metrics_unit_test";
+
+    #[test]
+    fn samples_matches_the_exact_metric_name() {
+        let body = "\
+# HELP maddy_smtp_started_transactions Amount of SMTP transactions started
+# TYPE maddy_smtp_started_transactions counter
+maddy_smtp_started_transactions{module=\"smtp\"} 7
+maddy_smtp_started_transactions{module=\"submission\"} 3
+maddy_queue_length{module=\"remote_queue\",location=\"/tmp/q\"} 2
+bare_metric 5
+";
+
+        let started = samples(body, "maddy_smtp_started_transactions");
+        assert_eq!(started.len(), 2);
+        assert_eq!(started[0].1, 7.0);
+        assert_eq!(started[1].1, 3.0);
+        assert!(started[0].0.contains(r#"module="smtp""#));
+
+        // A shorter name that is a prefix of a real one must not match it.
+        assert!(samples(body, "maddy_smtp_started").is_empty());
+
+        assert_eq!(samples(body, "bare_metric"), vec![(String::new(), 5.0)]);
+
+        assert_eq!(
+            sample_value(
+                body,
+                "maddy_smtp_started_transactions",
+                r#"module="submission""#
+            ),
+            Some(3.0)
+        );
+        assert_eq!(sample_value(body, "maddy_no_such_metric", ""), None);
+    }
 
     #[test]
     fn conn_guard_counts_while_alive() {

--- a/crates/chatmail-metrics/src/metrics.rs
+++ b/crates/chatmail-metrics/src/metrics.rs
@@ -16,7 +16,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use once_cell::sync::Lazy;
-use prometheus::{register_counter_vec, register_gauge_vec, Encoder, TextEncoder};
+use prometheus::{
+    register_counter_vec, register_gauge_vec, register_int_gauge_vec, Encoder, TextEncoder,
+};
 
 static STARTED: Lazy<prometheus::CounterVec> = Lazy::new(|| {
     register_counter_vec!(
@@ -73,6 +75,15 @@ static FAILED_COMMANDS: Lazy<prometheus::CounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
+static CONNS_ACTIVE: Lazy<prometheus::IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "maddy_conns_active",
+        "Amount of client connections currently open",
+        &["module"]
+    )
+    .unwrap()
+});
+
 static QUEUE_LENGTH: Lazy<prometheus::GaugeVec> = Lazy::new(|| {
     register_gauge_vec!(
         "maddy_queue_length",
@@ -109,6 +120,30 @@ pub fn record_smtp_ratelimit_deferred(module: &str) {
     RATELIMIT_DEFERRED.with_label_values(&[module]).inc();
 }
 
+/// Count one open connection for `module` until the returned guard is dropped.
+///
+/// The count is released on drop rather than by an explicit close call so that
+/// it survives every way a connection task can end - a failed TLS handshake, an
+/// early return, a panic, or the runtime dropping the task at shutdown. Bind it
+/// (`let _guard = ...`), never `let _ = ...`, which drops it immediately.
+#[must_use = "the connection is counted only while the guard is alive"]
+pub fn conn_guard(module: &str) -> ConnGuard {
+    let gauge = CONNS_ACTIVE.with_label_values(&[module]);
+    gauge.inc();
+    ConnGuard { gauge }
+}
+
+/// Decrements `maddy_conns_active` for its module when dropped.
+pub struct ConnGuard {
+    gauge: prometheus::IntGauge,
+}
+
+impl Drop for ConnGuard {
+    fn drop(&mut self) {
+        self.gauge.dec();
+    }
+}
+
 pub fn set_queue_length(module: &str, location: &str, depth: f64) {
     QUEUE_LENGTH
         .with_label_values(&[module, location])
@@ -124,6 +159,7 @@ pub fn init_metrics() {
     let _ = &*FAILED_LOGINS;
     let _ = &*FAILED_COMMANDS;
     let _ = &*QUEUE_LENGTH;
+    let _ = &*CONNS_ACTIVE;
     // Create label children so `/metrics` is non-empty before the first SMTP event.
     let _ = STARTED.with_label_values(&["smtp"]);
     let _ = STARTED.with_label_values(&["submission"]);
@@ -133,6 +169,9 @@ pub fn init_metrics() {
     let _ = ABORTED.with_label_values(&["submission"]);
     let _ = FAILED_LOGINS.with_label_values(&["smtp"]);
     let _ = FAILED_LOGINS.with_label_values(&["submission"]);
+    let _ = CONNS_ACTIVE.with_label_values(&["smtp"]);
+    let _ = CONNS_ACTIVE.with_label_values(&["submission"]);
+    let _ = CONNS_ACTIVE.with_label_values(&["imap"]);
 }
 
 /// Full Prometheus text exposition (for tests and debugging).
@@ -175,6 +214,35 @@ mod tests {
     use super::*;
 
     const MODULE: &str = "metrics_unit_test";
+
+    #[test]
+    fn conn_guard_counts_while_alive() {
+        // Unique label: the gauge is a global static and tests share the process.
+        let module = "conn_guard_alive_test";
+        let gauge = CONNS_ACTIVE.with_label_values(&[module]);
+
+        let guards: Vec<_> = (0..3).map(|_| conn_guard(module)).collect();
+        assert_eq!(gauge.get(), 3);
+
+        drop(guards);
+        assert_eq!(gauge.get(), 0);
+    }
+
+    #[test]
+    fn conn_guard_releases_on_panic() {
+        let module = "conn_guard_panic_test";
+        let gauge = CONNS_ACTIVE.with_label_values(&[module]);
+
+        let result = std::panic::catch_unwind(|| {
+            let _guard = conn_guard(module);
+            panic!("session died mid-connection");
+        });
+        assert!(result.is_err());
+
+        // A connection task that panics must not leak a count, otherwise the
+        // gauge only ever climbs and the whole metric becomes useless.
+        assert_eq!(gauge.get(), 0);
+    }
 
     #[test]
     fn gather_after_init_is_non_empty() {

--- a/crates/chatmail-smtp/src/server.rs
+++ b/crates/chatmail-smtp/src/server.rs
@@ -67,6 +67,7 @@ pub async fn run_smtp_listener(
                 let cfg = cfg.clone();
                 let acceptor = tls_acceptor.clone();
                 tokio::spawn(async move {
+                    let _conn_guard = chatmail_metrics::conn_guard(cfg.module);
                     let mut session = SmtpSession::new(ctx, pool, cfg);
                     let result = if let Some(acceptor) = acceptor {
                         match acceptor.accept(stream).await {

--- a/crates/chatmail/src/ctl/dispatch.rs
+++ b/crates/chatmail/src/ctl/dispatch.rs
@@ -22,7 +22,7 @@ use chatmail_db::settings_keys;
 
 use super::{
     accounts, admin_token, admin_web, blocklist_cmd, certificate, delete_cmd, dkim, docs,
-    endpoint_cache, federation, firewall_cmd, html, install, iroh, language, message_size,
+    endpoint_cache, federation, firewall_cmd, html, install, iroh, language, message_size, monitor,
     openrelay, port, proxy, push, queue_cmd, registration, registration_tokens, reload,
     service_cmd, service_toggle, sharing, status_cmd, tasks, uninstall, version, versions_cmd,
     webmail_cors,
@@ -111,6 +111,11 @@ pub async fn dispatch(cli: &Cli) -> Result<()> {
             registration_tokens::registration_tokens(&cli.args, cmd).await
         }
         Some(Command::Sharing(cmd)) => sharing::sharing(&cli.args, cmd).await,
+        Some(Command::Monitor {
+            interval,
+            count,
+            addr,
+        }) => monitor::monitor(&cli.args, *interval, *count, addr.as_deref()).await,
         Some(Command::Status { details }) => status_cmd::status(&cli.args, *details).await,
         Some(Command::Uninstall(flags)) => uninstall::uninstall(&cli.args, flags).await,
         Some(Command::Service(cmd)) => service_cmd::service(&cli.args, cmd).await,
@@ -173,6 +178,7 @@ fn command_name(cmd: &Command) -> &'static str {
         Command::Registration { .. } => "registration",
         Command::Openrelay { .. } => "openrelay",
         Command::MigratePgpConfig => "migrate-pgp-config",
+        Command::Monitor { .. } => "monitor",
         Command::Status { .. } => "status",
         Command::Port(_) => "port",
         Command::Queue { .. } => "queue",

--- a/crates/chatmail/src/ctl/mod.rs
+++ b/crates/chatmail/src/ctl/mod.rs
@@ -38,6 +38,7 @@ mod install;
 mod iroh;
 mod language;
 mod message_size;
+mod monitor;
 mod openrelay;
 mod output;
 mod port;

--- a/crates/chatmail/src/ctl/monitor.rs
+++ b/crates/chatmail/src/ctl/monitor.rs
@@ -1,0 +1,295 @@
+// Copyright (C) 2026 themadorg
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! `madmail monitor` — live connection and throughput metrics.
+//!
+//! Reads the `openmetrics` endpoint the server already exposes rather than
+//! introducing a control socket, so the same numbers back the CLI, a Prometheus
+//! scrape, and any future dashboard.
+
+use std::time::{Duration, Instant};
+
+use chatmail_config::{load_config, AppConfig, Args};
+use chatmail_metrics::samples;
+use chatmail_types::{ChatmailError, Result};
+
+use super::output::CtlOut;
+
+const CONNS_ACTIVE: &str = "maddy_conns_active";
+const COMPLETED: &str = "maddy_smtp_smtp_completed_transactions";
+const ABORTED: &str = "maddy_smtp_aborted_transactions";
+const QUEUE_LENGTH: &str = "maddy_queue_length";
+
+/// One scrape, reduced to the numbers the display needs.
+#[derive(Debug, Default, PartialEq)]
+struct Sample {
+    imap: f64,
+    smtp: f64,
+    submission: f64,
+    conns_total: f64,
+    completed: f64,
+    aborted: f64,
+    queue: f64,
+}
+
+impl Sample {
+    fn parse(body: &str) -> Self {
+        let conns = samples(body, CONNS_ACTIVE);
+        Self {
+            imap: label_value(&conns, "imap"),
+            smtp: label_value(&conns, "smtp"),
+            submission: label_value(&conns, "submission"),
+            conns_total: conns.iter().map(|(_, v)| v).sum(),
+            completed: sum(body, COMPLETED),
+            aborted: sum(body, ABORTED),
+            queue: sum(body, QUEUE_LENGTH),
+        }
+    }
+}
+
+fn sum(body: &str, metric: &str) -> f64 {
+    samples(body, metric).iter().map(|(_, v)| v).sum()
+}
+
+fn label_value(samples: &[(String, f64)], module: &str) -> f64 {
+    let selector = format!(r#"module="{module}""#);
+    samples
+        .iter()
+        .find(|(labels, _)| labels.contains(&selector))
+        .map(|(_, v)| *v)
+        .unwrap_or(0.0)
+}
+
+/// Per-second rate between two counter readings.
+///
+/// A server restart resets the counter, which would otherwise show up as a
+/// large negative rate; Prometheus treats a counter going backwards as a reset
+/// and reports 0 for that interval, and so do we.
+fn rate(prev: f64, cur: f64, dt: Duration) -> f64 {
+    let secs = dt.as_secs_f64();
+    if secs <= 0.0 || cur < prev {
+        return 0.0;
+    }
+    (cur - prev) / secs
+}
+
+/// `host:port` to scrape: `--addr`, else the configured `openmetrics` listener.
+fn scrape_addr(config: &AppConfig, addr: Option<&str>) -> Result<String> {
+    if let Some(addr) = addr {
+        return Ok(dialable(addr));
+    }
+    match config.openmetrics_listen.as_deref() {
+        Some(listen) => Ok(dialable(listen)),
+        None => Err(ChatmailError::config(
+            "openmetrics endpoint is not enabled; add `openmetrics tcp://127.0.0.1:9749 { }` \
+             to the config (bind it to loopback - it has no authentication), \
+             or pass --addr",
+        )),
+    }
+}
+
+/// A wildcard bind address is not a dial address - rewrite it to loopback.
+fn dialable(listen: &str) -> String {
+    match listen.rsplit_once(':') {
+        Some(("0.0.0.0", port)) | Some(("", port)) => format!("127.0.0.1:{port}"),
+        Some(("[::]", port)) | Some(("::", port)) => format!("[::1]:{port}"),
+        _ => listen.to_string(),
+    }
+}
+
+pub async fn monitor(
+    args: &Args,
+    interval: u64,
+    count: Option<u64>,
+    addr: Option<&str>,
+) -> Result<()> {
+    let out = CtlOut::from_args(args, "monitor");
+    let config = if args.config.is_file() {
+        load_config(&args.config)?
+    } else {
+        AppConfig::default()
+    };
+    let url = format!("http://{}/metrics", scrape_addr(&config, addr)?);
+    let interval = Duration::from_secs(interval.max(1));
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .map_err(|e| ChatmailError::config(format!("monitor: HTTP client: {e}")))?;
+
+    out.line(format!("Scraping {url} every {}s", interval.as_secs()));
+
+    let mut previous: Option<(Sample, Instant)> = None;
+    let mut printed = 0u64;
+    loop {
+        // The first row is printed immediately with no rate, so that
+        // `--count 1` returns the current counts right away instead of
+        // sleeping through an interval first.
+        if previous.is_some() {
+            tokio::time::sleep(interval).await;
+        }
+
+        let body = scrape(&client, &url).await?;
+        let now = Instant::now();
+        let sample = Sample::parse(&body);
+
+        // Header only once the first scrape has actually worked, so a failure
+        // to reach the endpoint is not preceded by an empty table.
+        if previous.is_none() {
+            out.line(format!(
+                "{:>6} {:>6} {:>10} {:>7} {:>9} {:>9} {:>7}",
+                "imap", "smtp", "submission", "total", "msg/s", "aborted/s", "queue"
+            ));
+        }
+
+        let rates = previous.as_ref().map(|(prev, at)| {
+            let dt = now.duration_since(*at);
+            (
+                rate(prev.completed, sample.completed, dt),
+                rate(prev.aborted, sample.aborted, dt),
+            )
+        });
+
+        report(&out, &sample, rates)?;
+        previous = Some((sample, now));
+
+        printed += 1;
+        if count.is_some_and(|n| printed >= n) {
+            return Ok(());
+        }
+    }
+}
+
+async fn scrape(client: &reqwest::Client, url: &str) -> Result<String> {
+    let resp = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| ChatmailError::config(format!("monitor: GET {url}: {e}")))?;
+    if !resp.status().is_success() {
+        return Err(ChatmailError::config(format!(
+            "monitor: GET {url}: HTTP {}",
+            resp.status()
+        )));
+    }
+    resp.text()
+        .await
+        .map_err(|e| ChatmailError::config(format!("monitor: reading {url}: {e}")))
+}
+
+fn report(out: &CtlOut, s: &Sample, rates: Option<(f64, f64)>) -> Result<()> {
+    if out.is_json() {
+        // One envelope per sample, so `--json` streams as NDJSON.
+        return out.emit(serde_json::json!({
+            "conns": {
+                "imap": s.imap,
+                "smtp": s.smtp,
+                "submission": s.submission,
+                "total": s.conns_total,
+            },
+            "messages_per_second": rates.map(|(msg, _)| msg),
+            "aborted_per_second": rates.map(|(_, aborted)| aborted),
+            "completed_total": s.completed,
+            "aborted_total": s.aborted,
+            "queue_length": s.queue,
+        }));
+    }
+
+    let (msg, aborted) = match rates {
+        Some((msg, aborted)) => (format!("{msg:.2}"), format!("{aborted:.2}")),
+        // No previous sample yet, so there is no interval to average over.
+        None => ("-".to_string(), "-".to_string()),
+    };
+    out.line(format!(
+        "{:>6} {:>6} {:>10} {:>7} {:>9} {:>9} {:>7}",
+        s.imap as i64,
+        s.smtp as i64,
+        s.submission as i64,
+        s.conns_total as i64,
+        msg,
+        aborted,
+        s.queue as i64,
+    ));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BODY: &str = "\
+# TYPE maddy_conns_active gauge
+maddy_conns_active{module=\"imap\"} 4
+maddy_conns_active{module=\"smtp\"} 2
+maddy_conns_active{module=\"submission\"} 1
+maddy_smtp_smtp_completed_transactions{module=\"smtp\"} 10
+maddy_smtp_smtp_completed_transactions{module=\"submission\"} 5
+maddy_smtp_aborted_transactions{module=\"smtp\"} 3
+maddy_queue_length{module=\"remote_queue\",location=\"/tmp/q\"} 7
+";
+
+    #[test]
+    fn parses_a_scrape_into_totals() {
+        let s = Sample::parse(BODY);
+        assert_eq!(s.imap, 4.0);
+        assert_eq!(s.smtp, 2.0);
+        assert_eq!(s.submission, 1.0);
+        assert_eq!(s.conns_total, 7.0);
+        // Summed across module labels.
+        assert_eq!(s.completed, 15.0);
+        assert_eq!(s.aborted, 3.0);
+        assert_eq!(s.queue, 7.0);
+    }
+
+    #[test]
+    fn missing_metrics_read_as_zero() {
+        assert_eq!(Sample::parse(""), Sample::default());
+    }
+
+    #[test]
+    fn rate_is_per_second_and_survives_a_counter_reset() {
+        assert_eq!(rate(10.0, 20.0, Duration::from_secs(2)), 5.0);
+        // Server restarted between scrapes: report 0, not a huge negative.
+        assert_eq!(rate(100.0, 1.0, Duration::from_secs(2)), 0.0);
+        // Two scrapes in the same instant would divide by zero.
+        assert_eq!(rate(1.0, 9.0, Duration::ZERO), 0.0);
+    }
+
+    #[test]
+    fn wildcard_bind_addresses_are_dialled_on_loopback() {
+        assert_eq!(dialable("0.0.0.0:9749"), "127.0.0.1:9749");
+        assert_eq!(dialable("[::]:9749"), "[::1]:9749");
+        assert_eq!(dialable("127.0.0.1:9749"), "127.0.0.1:9749");
+        assert_eq!(dialable("metrics.internal:9749"), "metrics.internal:9749");
+    }
+
+    #[test]
+    fn scrape_addr_prefers_the_flag_then_the_config() {
+        let mut config = AppConfig::default();
+        assert_eq!(
+            scrape_addr(&config, Some("10.0.0.1:1234")).unwrap(),
+            "10.0.0.1:1234"
+        );
+
+        // Neither set: the error has to say how to turn the endpoint on.
+        let err = scrape_addr(&config, None).unwrap_err().to_string();
+        assert!(err.contains("openmetrics"), "unhelpful error: {err}");
+
+        config.openmetrics_listen = Some("0.0.0.0:9749".to_string());
+        assert_eq!(scrape_addr(&config, None).unwrap(), "127.0.0.1:9749");
+    }
+}

--- a/docs/TDD/07-federation.md
+++ b/docs/TDD/07-federation.md
@@ -68,6 +68,13 @@ Each queued message: `{id}.meta` (JSON, includes `queued_at_unix`) + `{id}.body`
 2. **HTTP**  `POST http://domain/mxdeliv` (fallback)
 3. **SMTP**  Direct delivery to recipient host port 25 (last resort after HTTP failures)
 
+Port 25 is the only SMTP port tried. MX records name a host, not a port, so inbound
+mail cannot live anywhere else, and the relay-to-relay alternative is `/mxdeliv`
+above. An implicit-TLS retry on `:443` existed until it was removed: relays demux
+`:443` to a submission service requiring SASL auth, so it could never deliver, and
+against a peer serving plain HTTPS there it blocked for the full 30s connect timeout
+on every federation failure (`p7_ut07_no_implicit_tls_retry_on_443`).
+
 ## Endpoint Override System
 Database table `dns_overrides` + in-memory cache.
 


### PR DESCRIPTION
## Summary

Removes the implicit-TLS retry on a peer's port 443 from outbound SMTP federation. It could never deliver a message, and it made every federation failure take 30 seconds longer than it needed to.

`deliver()` tried `host:25` and, on any failure, retried `host:443` with implicit TLS. Two independent reasons that retry is dead code:

1. **It reaches the wrong service and then blocks.** The federation SMTP client never sets `alpn_protocols`, so against a relay that demultiplexes 443 by ALPN the connection lands in the `default` branch — the internal HTTPS server. `deliver_implicit_tls` writes nothing and immediately waits for a server-first `220` banner. An HTTP server never speaks first, so the connection blocks until the 30s timeout and only then fails. It did not fail fast.

2. **Even with the right ALPN token it would be rejected.** Relays route the `smtp` token to their submission service, which is configured `smtpd_sasl_auth_enable=yes` with `smtpd_relay_restrictions=permit_sasl_authenticated,reject`. Port 443 is a *client submission* path there, never an MX path.

Relays do listen on 25 for inbound MX mail, and the documented relay-to-relay alternative is an HTTPS `POST /mxdeliv` — which this repo already implements and already tries first (`transport.rs` runs HTTPS, then HTTP, then SMTP). So the retry never contributed a delivery, only latency on the failure path.

Port 25 is now the only SMTP port tried, and its error is returned directly rather than wrapped in a second failure that hides it.

Also corrects two doc comments that asserted the opposite and would invite someone to add this back:

- `federation_smtp.rs` — "required for classic Chatmail relays (`nine.testrun.org`, etc.) that expose SMTP only on :443". They run Postfix on 25 for MX.
- `transport.rs` — "Peers like nine.testrun.org often only accept real SMTP on :443". The surrounding comment's actual point (don't treat a 4xx from a missing `/mxdeliv` as permanent) is kept.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Area

- [x] SMTP
- [x] Federation / delivery queue
- [x] Docs (`docs/project/`, `docs/TDD/`, user guide)

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`

Test written first, and it failed for the right reason before the change:

```text
must not retry on :443, got: smtp :25 failed; smtp :443 tls: smtp tls connect:
failed to lookup address information: nodename nor servname provided, or not known
```

`p7_ut07_no_implicit_tls_retry_on_443` drives `deliver()` at a `.invalid` host — reserved by RFC 2606, so it never resolves and the test needs no network — and asserts the resulting error never mentions 443. The assertion is on error content rather than elapsed time, so it is not timing-flaky.

**Manual verification:**

```text
cargo test -p chatmail-delivery
cargo test --workspace
cargo clippy --workspace --all-targets -- -D warnings
```

Two notes for reviewers:

- `p6_imap_idle_unsolicited_exists` in `chatmail-imap` is **pre-existing flaky** — roughly one pass in three on an unmodified tree, unrelated to this change.
- On macOS the workspace does not build without #166 (`statvfs` field widths); that is pre-existing on `main`. Local verification here was run with #166's change applied to the working tree and then reverted, so it is not part of this diff.

## Documentation

- [x] Updated or added TDD section (`docs/TDD/`) — required for significant design changes

`07-federation.md` already listed port 25 as the last-resort SMTP step and never documented the 443 retry — the code was the outlier. Added an explicit note on why 443 is not tried, so it does not get reintroduced.

## Security & privacy

- [x] Not security-sensitive

Removes an outbound code path; adds none. Worth noting it deletes the only caller of the federation TLS client that ran *without* STARTTLS negotiation, but the `SkipServerVerification` verifier is unchanged and still used by the STARTTLS path.

## Commits

- [x] `fix:` bug fix

## Checklist

- [x] PR is focused and reviewable (small vertical slices preferred)
- [x] No secrets, `data/`, `target/`, or `node_modules/` committed
- [x] Submodule pointers updated if `external/madmail-admin-web` changed — n/a
- [x] Behavior parity with Madmail v1 considered (or intentional difference documented)

Parity note: no delivery behaviour is lost. Any peer reachable before is still reachable via `/mxdeliv` or port 25; only a path that could not complete a transaction is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
